### PR TITLE
Components: Decouple and refactor how visual states are handled

### DIFF
--- a/src/components/Input/Backdrop.js
+++ b/src/components/Input/Backdrop.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from '../../utilities/classNames'
+
+const propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  state: PropTypes.string
+}
+
+const Backdrop = props => {
+  const {
+    disabled,
+    state
+  } = props
+
+  const className = classNames(
+    'c-InputBackdrop',
+    disabled && 'is-disabled',
+    state && `is-${state}`,
+    props.className
+  )
+
+  return (
+    <div className={className} role='presentation' />
+  )
+}
+
+Backdrop.propTypes = propTypes
+
+export default Backdrop

--- a/src/components/Input/HelpText.js
+++ b/src/components/Input/HelpText.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from '../../utilities/classNames'
+
+const propTypes = {
+  className: PropTypes.string,
+  state: PropTypes.string
+}
+
+const HelpText = props => {
+  const {
+    state
+  } = props
+
+  const className = classNames(
+    'c-InputHelpText',
+    state && `is-${state}`,
+    props.className
+  )
+
+  return (
+    <div className={className}>
+      {props.children}
+    </div>
+  )
+}
+
+HelpText.propTypes = propTypes
+
+export default HelpText

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -28,7 +28,7 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | autoFocus | boolean | Automatically focuses the input. |
 | className | string | Custom class names to be added to the component. |
 | disabled | boolean | Disable the input. |
-| error | boolean or string | Change input to error state. Displays text underneath input. |
+| helpText | string | Displays text underneath input. |
 | id | string | ID for the input. |
 | multiline | boolean or number | Transforms input into an auto-expanding textarea. |
 | name | string | Name for the input. |
@@ -38,8 +38,16 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
 | resizable | boolean | Enables resizing for the textarea (only enabled for `multiline`). |
 | seamless | boolean | Removes the border around the input. |
 | size | boolean | Determines the size of the input. |
+| state | string | Change input to state color. |
 | suffix | string | Text to appear after the input. |
-| success | boolean or string | Change input to success state. Displays text underneath input. |
 | type | string | Determines the input type. |
 | value | string | Initial value of the input. |
-| warning | boolean or string | Change input to warning state. Displays text underneath input. |
+
+
+### States
+
+| Prop | Description |
+| --- | --- |
+| `error` | Changes color to red. |
+| `success` | Changes color to green. |
+| `warning` | Changes color to yellow. |

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -2,6 +2,8 @@
 
 import React, { PureComponent as Component } from 'react'
 import PropTypes from 'prop-types'
+import Backdrop from './Backdrop'
+import HelpText from './HelpText'
 import Resizer from './Resizer'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/constants'
@@ -10,7 +12,7 @@ const propTypes = {
   autoFocus: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  helpText: PropTypes.string,
   id: PropTypes.string,
   multiline: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   name: PropTypes.string,
@@ -23,16 +25,14 @@ const propTypes = {
   resizable: PropTypes.bool,
   seamless: PropTypes.bool,
   size: PropTypes.string,
-  success: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  state: PropTypes.string,
   suffix: PropTypes.string,
   type: PropTypes.string,
-  value: PropTypes.string,
-  warning: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  value: PropTypes.string
 }
 const defaultProps = {
   autoFocus: false,
   disabled: false,
-  error: false,
   multiline: null,
   onBlur: noop,
   onChange: noop,
@@ -40,10 +40,8 @@ const defaultProps = {
   readOnly: false,
   resizable: false,
   seamless: false,
-  success: false,
   type: 'text',
-  value: '',
-  warning: false
+  value: ''
 }
 
 class Input extends Component {
@@ -69,7 +67,7 @@ class Input extends Component {
     const {
       autoFocus,
       disabled,
-      error,
+      helpText,
       id,
       inputRef,
       multiline,
@@ -82,10 +80,9 @@ class Input extends Component {
       resizable,
       seamless,
       size,
-      success,
+      state,
       suffix,
       type,
-      warning,
       ...rest
     } = this.props
 
@@ -97,14 +94,12 @@ class Input extends Component {
     const className = classNames(
       'c-Input',
       disabled && 'is-disabled',
-      error && 'is-error',
       multiline && 'is-multiline',
       readOnly && 'is-readonly',
       resizable && 'is-resizable',
       seamless && 'is-seamless',
-      success && 'is-success',
+      state && `is-${state}`,
       value && 'has-value',
-      warning && 'is-warning',
       this.props.className
     )
 
@@ -137,17 +132,11 @@ class Input extends Component {
       </div>
       : null
 
-    const statefulHelperTextMarkup = () => {
-      return [error, success, warning].map(state => {
-        if (state && typeof state === 'string' && state.length) {
-          return (
-            <div className='c-InputHelperLabel' key={state}>
-              {state}
-            </div>
-          )
-        }
-      })
-    }
+    const helpTextMarkup = helpText
+      ? <HelpText state={state}>
+        {helpText}
+      </HelpText>
+      : null
 
     const inputElement = React.createElement(multiline ? 'textarea' : 'input', {
       ...rest,
@@ -173,10 +162,10 @@ class Input extends Component {
           {prefixMarkup}
           {inputElement}
           {suffixMarkup}
-          <div className='c-InputBackdrop' />
+          <Backdrop disabled={disabled} state={state} />
           {resizer}
         </div>
-        {statefulHelperTextMarkup()}
+        {helpTextMarkup}
       </div>
     )
   }

--- a/src/components/Input/tests/Input.test.js
+++ b/src/components/Input/tests/Input.test.js
@@ -195,21 +195,21 @@ describe('States', () => {
   })
 
   test('Applies error styles if specified', () => {
-    const wrapper = shallow(<Input error />)
+    const wrapper = shallow(<Input state='error' />)
     const o = wrapper.find('.c-Input')
 
     expect(o.prop('className')).toContain('is-error')
   })
 
   test('Applies success styles if specified', () => {
-    const wrapper = shallow(<Input success />)
+    const wrapper = shallow(<Input state='success' />)
     const o = wrapper.find('.c-Input')
 
     expect(o.prop('className')).toContain('is-success')
   })
 
   test('Applies warning styles if specified', () => {
-    const wrapper = shallow(<Input warning />)
+    const wrapper = shallow(<Input state='warning' />)
     const o = wrapper.find('.c-Input')
 
     expect(o.prop('className')).toContain('is-warning')
@@ -218,8 +218,8 @@ describe('States', () => {
 
 describe('Stateful helper label', () => {
   test('Renders stateful helper label if error is a string', () => {
-    const wrapper = shallow(<Input error='Error' />)
-    const helperLabel = wrapper.find('.c-InputHelperLabel')
+    const wrapper = mount(<Input state='error' helpText='Error' />)
+    const helperLabel = wrapper.find('.c-InputHelpText')
 
     expect(helperLabel.exists()).toBeTruthy()
     expect(helperLabel.text()).toBe('Error')

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -34,7 +34,7 @@ An Select component is an enhanced version of the default HTML `<select>`.
 | autoFocus | boolean | Automatically focuses the select. |
 | className | string | Custom class names to be added to the component. |
 | disabled | boolean | Disable the select. |
-| error | boolean or string | Change select to error state. Displays text underneath select. |
+| helpText | string | Displays text underneath input. |
 | id | string | ID for the select. |
 | name | string | Name for the select. |
 | options | array or object or string | List of options to choose from. |
@@ -43,7 +43,15 @@ An Select component is an enhanced version of the default HTML `<select>`.
 | readOnly | boolean | Disable editing of the select. |
 | seamless | boolean | Removes the border around the select. |
 | size | boolean | Determines the size of the select. |
+| state | string | Change select to state color. |
 | suffix | string | Text to appear after the select. |
-| success | boolean or string | Change select to success state. Displays text underneath select. |
 | value | string | Initial value of the select. |
-| warning | boolean or string | Change select to warning state. Displays text underneath select. |
+
+
+### States
+
+| Prop | Description |
+| --- | --- |
+| `error` | Changes color to red. |
+| `success` | Changes color to green. |
+| `warning` | Changes color to yellow. |

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -1,5 +1,7 @@
 import React, { PureComponent as Component } from 'react'
 import PropTypes from 'prop-types'
+import Backdrop from '../Input/Backdrop'
+import HelpText from '../Input/HelpText'
 import classNames from '../../utilities/classNames'
 import { noop } from '../../utilities/constants'
 
@@ -23,7 +25,7 @@ const propTypes = {
   autoFocus: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  helpText: PropTypes.string,
   id: PropTypes.string,
   name: PropTypes.string,
   options: PropTypes.oneOfType([
@@ -39,21 +41,17 @@ const propTypes = {
   placeholder: PropTypes.string,
   prefix: PropTypes.string,
   size: PropTypes.string,
-  success: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  value: PropTypes.string,
-  warning: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  state: PropTypes.string,
+  value: PropTypes.string
 }
 const defaultProps = {
   autoFocus: false,
   disabled: false,
-  error: false,
   onBlur: noop,
   onChange: noop,
   onFocus: noop,
   options: [],
-  success: false,
-  value: '',
-  warning: false
+  value: ''
 }
 
 const PLACEHOLDER_VALUE = '__placeholder__'
@@ -85,15 +83,15 @@ class Select extends Component {
     const {
       className,
       disabled,
-      error,
+      helpText,
       onChange,
       options,
       placeholder,
       prefix,
       seamless,
       size,
+      state,
       success,
-      warning,
       value,
       ...rest
     } = this.props
@@ -103,11 +101,9 @@ class Select extends Component {
     const selectClassName = classNames(
       'c-Select',
       disabled && 'is-disabled',
-      error && 'is-error',
       hasPlaceholder && 'has-placeholder',
       seamless && 'is-seamless',
-      success && 'is-success',
-      warning && 'is-warning',
+      state && `is-${state}`,
       className
     )
 
@@ -164,19 +160,13 @@ class Select extends Component {
       </div>
       : null
 
-    const selectedValue = hasPlaceholder ? PLACEHOLDER_VALUE : this.state.value
+    const helpTextMarkup = helpText
+      ? <HelpText state={state}>
+        {helpText}
+      </HelpText>
+      : null
 
-    const statefulHelperTextMarkup = () => {
-      return [error, success, warning].map(state => {
-        if (state && typeof state === 'string' && state.length) {
-          return (
-            <div className='c-InputHelperLabel' key={state}>
-              {state}
-            </div>
-          )
-        }
-      })
-    }
+    const selectedValue = hasPlaceholder ? PLACEHOLDER_VALUE : this.state.value
 
     return (
       <div className='c-InputWrapper'>
@@ -193,9 +183,9 @@ class Select extends Component {
             {optionsMarkup}
           </select>
           <div className='c-SelectIcon' />
-          <div className='c-InputBackdrop' />
+          <Backdrop disabled={disabled} state={state} />
         </div>
-        {statefulHelperTextMarkup()}
+        {helpTextMarkup}
       </div>
     )
   }

--- a/src/components/Select/tests/Select.test.js
+++ b/src/components/Select/tests/Select.test.js
@@ -164,7 +164,7 @@ describe('States', () => {
 
   describe('Error', () => {
     test('Applies error styles if error prop is true', () => {
-      const wrapper = shallow(<Select error />)
+      const wrapper = shallow(<Select state='error' />)
       const o = wrapper.find('.c-Select')
 
       expect(o.prop('className')).toContain('is-error')
@@ -172,8 +172,8 @@ describe('States', () => {
 
     test('Adds error helper text if error prop is a string', () => {
       const message = 'Cannonballlll'
-      const wrapper = shallow(<Select error={message} />)
-      const o = wrapper.find('.c-InputHelperLabel')
+      const wrapper = mount(<Select state='error' helpText={message} />)
+      const o = wrapper.find('.c-InputHelpText')
 
       expect(o.text()).toContain(message)
     })
@@ -181,7 +181,7 @@ describe('States', () => {
 
   describe('Success', () => {
     test('Applies success styles if success prop is true', () => {
-      const wrapper = shallow(<Select success />)
+      const wrapper = shallow(<Select state='success' />)
       const o = wrapper.find('.c-Select')
 
       expect(o.prop('className')).toContain('is-success')
@@ -189,8 +189,8 @@ describe('States', () => {
 
     test('Adds success helper text if success prop is a string', () => {
       const message = 'Cannonballlll'
-      const wrapper = shallow(<Select success={message} />)
-      const o = wrapper.find('.c-InputHelperLabel')
+      const wrapper = mount(<Select state='success' helpText={message} />)
+      const o = wrapper.find('.c-InputHelpText')
 
       expect(o.text()).toContain(message)
     })
@@ -198,7 +198,7 @@ describe('States', () => {
 
   describe('Warning', () => {
     test('Applies warning styles if warning prop is true', () => {
-      const wrapper = shallow(<Select warning />)
+      const wrapper = shallow(<Select state='warning' />)
       const o = wrapper.find('.c-Select')
 
       expect(o.prop('className')).toContain('is-warning')
@@ -206,8 +206,8 @@ describe('States', () => {
 
     test('Adds warning helper text if warning prop is a string', () => {
       const message = 'Cannonballlll'
-      const wrapper = shallow(<Select warning={message} />)
-      const o = wrapper.find('.c-InputHelperLabel')
+      const wrapper = mount(<Select state='warning' helpText={message} />)
+      const o = wrapper.find('.c-InputHelpText')
 
       expect(o.text()).toContain(message)
     })

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -15,11 +15,18 @@ A Text component is a light-weight text wrapper enhanced with a collection of ae
 | --- | --- | --- |
 | className | string | Custom class names to be added to the component. |
 | disableSelect | boolean | Disables text selection. |
-| error | boolean | Changes text color to error state. |
 | faint | boolean | Changes text color to a very light grey. |
 | muted | boolean  | Changes text color to a light grey. |
 | size | number | Adjust text size. |
 | subtle | boolean | Changes text color to a lighter grey. |
-| success | boolean | Changes text color to success state. |
+| state | string | Changes the text color based on state. |
 | truncate | boolean | Enables CSS truncation for text. |
-| warning | boolean | Changes text color to a warning state. |
+
+
+### States
+
+| Prop | Description |
+| --- | --- |
+| `error` | Changes color to red. |
+| `success` | Changes color to green. |
+| `warning` | Changes color to yellow. |

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -5,14 +5,12 @@ import classNames from '../../utilities/classNames'
 const propTypes = {
   className: PropTypes.string,
   disableSelect: PropTypes.bool,
-  error: PropTypes.bool,
   faint: PropTypes.bool,
   muted: PropTypes.bool,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  state: PropTypes.string,
   subtle: PropTypes.bool,
-  success: PropTypes.bool,
-  truncate: PropTypes.bool,
-  warning: PropTypes.bool
+  truncate: PropTypes.bool
 }
 const defaultProps = {
   disableSelect: false,
@@ -22,27 +20,23 @@ const defaultProps = {
 const Text = props => {
   const {
     disableSelect,
-    error,
     faint,
     muted,
     size,
+    state,
     subtle,
-    success,
-    truncate,
-    warning
+    truncate
   } = props
 
   const className = classNames(
     'c-Text',
     disableSelect && 'is-disableSelect',
-    error && 'is-error',
     faint && 'is-faint',
     muted && 'is-muted',
     size && `is-${size}`,
+    state && `is-${state}`,
     subtle && 'is-subtle',
-    success && 'is-success',
     truncate && 'is-truncate',
-    warning && 'is-warning',
     props.className
   )
 

--- a/src/components/Text/tests/Text.test.js
+++ b/src/components/Text/tests/Text.test.js
@@ -67,19 +67,19 @@ describe('Styles', () => {
 
 describe('States', () => {
   test('Applies error styles if specified', () => {
-    const wrapper = shallow(<Text error />)
+    const wrapper = shallow(<Text state='error' />)
 
     expect(wrapper.prop('className')).toContain('is-error')
   })
 
   test('Applies success styles if specified', () => {
-    const wrapper = shallow(<Text success />)
+    const wrapper = shallow(<Text state='success' />)
 
     expect(wrapper.prop('className')).toContain('is-success')
   })
 
   test('Applies warning styles if specified', () => {
-    const wrapper = shallow(<Text warning />)
+    const wrapper = shallow(<Text state='warning' />)
 
     expect(wrapper.prop('className')).toContain('is-warning')
   })

--- a/src/styles/components/Input/InputBackdrop.scss
+++ b/src/styles/components/Input/InputBackdrop.scss
@@ -37,16 +37,17 @@
 
   // States
   @each $state in $states {
-    @include parent(".is-#{$state} > #{$InputField} ~ ") {
+    &.is-#{$state} {
       border-color: _color(state, $state, border-color);
-    }
-    @include parent(".is-#{$state} > #{$InputField}:focus ~ ") {
-      box-shadow: 0 0 0 1px _color(state, $state, border-color) inset;
+      @include parent("#{$InputField}:focus ~ ") {
+        border-color: _color(state, $state, border-color);
+        box-shadow: 0 0 0 1px _color(state, $state, border-color) inset;
+      }
     }
   }
 
   // Disabled
-  @include parent(".is-disabled > #{$InputField} ~ ") {
+  &.is-disabled {
     background-color: _color(grey, 200);
   }
 }

--- a/src/styles/components/Input/InputHelpText.scss
+++ b/src/styles/components/Input/InputHelpText.scss
@@ -2,7 +2,7 @@
 @import "../../configs/constants";
 @import "../../configs/color";
 
-.c-InputHelperLabel {
+.c-InputHelpText {
   @import "../../resets/base";
   $block: this();
   $states: $STATES;
@@ -10,7 +10,7 @@
 
   // States
   @each $state in $states {
-    @include parent(".is-#{$state} ~ ") {
+    &.is-#{$state} {
       color: _color(state, $state, border-color);
     }
   }

--- a/src/styles/components/Input/__index.scss
+++ b/src/styles/components/Input/__index.scss
@@ -2,6 +2,6 @@
 @import "./InputBackdrop";
 @import "./InputField";
 @import "./InputGhost";
-@import "./InputHelperLabel";
+@import "./InputHelpText";
 @import "./InputResizer";
 @import "./InputWrapper";

--- a/src/styles/tests/components/InputBackdrop.scss.test.js
+++ b/src/styles/tests/components/InputBackdrop.scss.test.js
@@ -61,7 +61,7 @@ describe('Styles', () => {
 
 describe('States', () => {
   test('Applies error styles if defined', () => {
-    const markup = mount(<Input error />).html()
+    const markup = mount(<Input state='error' />).html()
     styles.html(markup)
 
     const o = styles.$('.c-InputBackdrop')
@@ -70,7 +70,7 @@ describe('States', () => {
   })
 
   test('Applies success styles if defined', () => {
-    const markup = mount(<Input success />).html()
+    const markup = mount(<Input state='success' />).html()
     styles.html(markup)
 
     const o = styles.$('.c-InputBackdrop')
@@ -79,7 +79,7 @@ describe('States', () => {
   })
 
   test('Applies warning styles if defined', () => {
-    const markup = mount(<Input warning />).html()
+    const markup = mount(<Input state='warning' />).html()
     styles.html(markup)
 
     const o = styles.$('.c-InputBackdrop')

--- a/stories/index.js
+++ b/stories/index.js
@@ -114,9 +114,9 @@ storiesOf('Input', module)
   .add('disabled', () => <Input disabled autoFocus />)
   .add('states', () => (
     <div>
-      <Input error autoFocus /><br />
-      <Input success="You're Awesome!" autoFocus /><br />
-      <Input warning autoFocus />
+      <Input state='error' autoFocus /><br />
+      <Input state='success' helpText="You're Awesome!" autoFocus /><br />
+      <Input state='warning' autoFocus />
     </div>
   ))
   .add('sizes', () => (
@@ -191,9 +191,9 @@ storiesOf('Select', module)
   ))
   .add('states', () => (
     <div>
-      <Select error /><br />
-      <Select success /><br />
-      <Select warning />
+      <Select state='error' /><br />
+      <Select state='success' /><br />
+      <Select state='warning' />
     </div>
   ))
   .add('sizes', () => (
@@ -228,9 +228,9 @@ storiesOf('Text', module)
   .add('states', () => (
     <div>
       <Text>Default</Text><br />
-      <Text error>Error</Text><br />
-      <Text success>Success</Text><br />
-      <Text warning>Warning</Text><br />
+      <Text state='error'>Error</Text><br />
+      <Text state='success'>Success</Text><br />
+      <Text state='warning'>Warning</Text><br />
     </div>
   ))
   .add('truncate', () => (


### PR DESCRIPTION
This commit decouples state usage from 1 state per prop, to using a generic 'state' prop that accepts a variety of states. This translates to cleaner code for JS and CSS.

The only difference is helpText has to be entered in via the `helpText` prop vs. inline with the previous state prop. That's okay, as it offers more flexibility.

This pattern has been updated for `Input`, `Select`, and `Text` components.

Storybook + Tests + Docs have been updated to match.

#### Example

##### Before

```
<Input success />
```

##### After

```
<Input state='success' />
```