### PR TITLE
Avatar: Restore Blue color (default) and setup Theming

### DIFF
--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -2,30 +2,40 @@
 
 An Avatar component displays a user's avatar image, or their initials if an image isn't available.
 
-
 ## Example
 
 ```jsx
 <Avatar name="Will Ferrell" image="will.png" />
 ```
 
+## Theming
+
+This component can be themed using a [ThemeProvider](../styled).
+
+```jsx
+<ThemeProvier theme={myTheme}>
+  ...
+  <Avatar name="Will Ferrell" />
+  ...
+</ThemeProvider>
+```
 
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| borderColor | `string` | Color for the Avatar border. |
-| className | `string` | Custom class names to be added to the component. |
-| count | `number`/`string` | Used to display an additional avatar count. |
-| image | `string` | URL of the image to display. |
-| light | `bool` | Applies a "light" style to the component. |
-| initials | `string` | Custom initials to display. |
-| name | `string` | Name of the user. Required. |
-| onError | `function` | Callback when avatar image fails to load. |
-| onLoad | `function` | Callback when avatar image loads. |
-| outerBorderColor | `string` | Color for the Avatar's outer border. |
-| shape | `string` | Shape of the avatar. |
-| size | `string` | Size of the avatar. |
-| title | `string` | Text for the image `alt` and `title` attributes. |
-| status | `string` | Renders a [StatusDot](../StatusDot) with the status type. |
-| statusIcon | `string` | Name of the [Icon](../Icon) to render into the [StatusDot](../StatusDot). |
+| Prop             | Type              | Description                                                               |
+| ---------------- | ----------------- | ------------------------------------------------------------------------- |
+| borderColor      | `string`          | Color for the Avatar border.                                              |
+| className        | `string`          | Custom class names to be added to the component.                          |
+| count            | `number`/`string` | Used to display an additional avatar count.                               |
+| image            | `string`          | URL of the image to display.                                              |
+| light            | `bool`            | Applies a "light" style to the component.                                 |
+| initials         | `string`          | Custom initials to display.                                               |
+| name             | `string`          | Name of the user. Required.                                               |
+| onError          | `function`        | Callback when avatar image fails to load.                                 |
+| onLoad           | `function`        | Callback when avatar image loads.                                         |
+| outerBorderColor | `string`          | Color for the Avatar's outer border.                                      |
+| shape            | `string`          | Shape of the avatar.                                                      |
+| size             | `string`          | Size of the avatar.                                                       |
+| title            | `string`          | Text for the image `alt` and `title` attributes.                          |
+| status           | `string`          | Renders a [StatusDot](../StatusDot) with the status type.                 |
+| statusIcon       | `string`          | Name of the [Icon](../Icon) to render into the [StatusDot](../StatusDot). |

--- a/src/components/Avatar/styles/Avatar.css.js
+++ b/src/components/Avatar/styles/Avatar.css.js
@@ -1,6 +1,6 @@
 // @flow
 import baseStyles from '../../../styles/resets/baseStyles.css.js'
-import { getColor } from '../../../styles/utilities/color'
+import { getColor, getThemeBrandProp } from '../../../styles/utilities/color'
 import forEach from '../../../styles/utilities/forEach'
 import variableFontSize from '../../../styles/utilities/variableFontSize'
 import styled from '../../styled'
@@ -8,7 +8,7 @@ import styled from '../../styled'
 export const config = {
   borderRadius: 3,
   borderWidth: 2,
-  color: getColor('purple.500'),
+  color: getColor('blue.500'),
   position: 'relative',
   size: {
     lg: {
@@ -40,10 +40,11 @@ export const config = {
 
 export const AvatarUI = styled('div')`
   ${baseStyles}
-  color: ${config.color};
   height: ${config.size.md.size}px;
   position: relative;
   width: ${config.size.md.size}px;
+
+  ${props => getColorStyles(props)}
 
   &.is-light {
     color: ${getColor('grey.400')};
@@ -116,6 +117,12 @@ export const StatusUI = styled('div')`
     right: -4px;
   }
 `
+
+function getColorStyles(props: Object): string {
+  return `
+    color: ${getThemeBrandProp(props, 'brandColor', config.color)};
+  `
+}
 
 function getSizeStyles(): string {
   return forEach(config.size, (size, props) => {

--- a/stories/Avatar/index.js
+++ b/stories/Avatar/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Avatar, Flexy } from '../../src/index.js'
+import { ThemeProvider } from '../../src/components/styled'
 import AvatarSpec from './specs/Avatar'
 
 const stories = storiesOf('Avatar', module)
@@ -12,6 +13,20 @@ stories.add('default', () => (
 
 stories.add('fallback', () => (
   <Avatar name={fixture.name} image="https://notfound" />
+))
+
+stories.add('themed', () => (
+  <div>
+    <ThemeProvider theme={{ brandColor: { brandColor: 'red' } }}>
+      <Avatar name={fixture.name} image="https://notfound" />
+    </ThemeProvider>
+    <ThemeProvider theme={{ brandColor: { brandColor: 'green' } }}>
+      <Avatar name={fixture.name} image="https://notfound" />
+    </ThemeProvider>
+    <ThemeProvider theme={{ brandColor: { brandColor: 'blue' } }}>
+      <Avatar name={fixture.name} image="https://notfound" />
+    </ThemeProvider>
+  </div>
 ))
 
 stories.add('status', () => (


### PR DESCRIPTION
## Avatar: Restore Blue color (default) and setup Theming

![screen shot 2018-09-19 at 8 20 39 am](https://user-images.githubusercontent.com/2322354/45752974-3bcd1100-bbe5-11e8-8a2b-a53dfa31000f.jpg)

This update adjusts the `Avatar` component to use the color of `blue.500`
as the default color, instead of `purple.500`.

It has also been setup to respond to a `brandColor` defined by any
`ThemeProvider` (falling back to `blue.500`, if none are available).


Added the tag of Bug as the avatar was previously blue before a [recent refactor]
(https://github.com/helpscout/blue/releases/tag/v1.2.8), which changed it to purple.

### Theming example

```jsx
<ThemeProvider theme={{ brandColor: { brandColor: 'red' } }}>
  ...
  <Avatar />
  ...
</ThemeProvider>
```