### PR TITLE
FormLabel: Adds a new mode (inline)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13781,7 +13781,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -15710,7 +15710,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -24534,7 +24534,7 @@
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
@@ -26524,7 +26524,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -16,7 +16,7 @@ export interface Props {
   id?: string
   label?: any
   helpText?: any
-  inline?: boolean
+  isInline: boolean
 }
 
 export interface State {
@@ -31,6 +31,10 @@ class FormLabel extends React.Component<Props, State> {
     this.state = {
       id: props.for || props.id || uniqueID(),
     }
+  }
+
+  static defaultProps = {
+    isInline: false,
   }
 
   getContextProps = () => {
@@ -69,7 +73,7 @@ class FormLabel extends React.Component<Props, State> {
     const {
       className,
       children,
-      inline,
+      isInline,
       for: htmlFor,
       id: idProp,
       ...rest
@@ -77,7 +81,7 @@ class FormLabel extends React.Component<Props, State> {
 
     const componentClassName = classNames(
       'c-FormLabel',
-      inline && 'c-FormLabel--inline',
+      isInline && 'is-inline',
       className
     )
     const labelMarkup = this.getLabelMarkup()
@@ -89,7 +93,7 @@ class FormLabel extends React.Component<Props, State> {
           {...getValidProps(rest)}
           className={componentClassName}
           isHelpTextPresent={!!helpTextMarkup}
-          inline={inline}
+          isInline={isInline}
         >
           <div className="c-FormLabel__label">
             {labelMarkup}

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -88,6 +88,7 @@ class FormLabel extends React.Component<Props, State> {
         <FormLabelUI
           {...getValidProps(rest)}
           className={componentClassName}
+          isHelpTextPresent={!!helpTextMarkup}
           inline={inline}
         >
           <div className="c-FormLabel__label">

--- a/src/components/FormLabel/FormLabel.tsx
+++ b/src/components/FormLabel/FormLabel.tsx
@@ -16,6 +16,7 @@ export interface Props {
   id?: string
   label?: any
   helpText?: any
+  inline?: boolean
 }
 
 export interface State {
@@ -68,21 +69,32 @@ class FormLabel extends React.Component<Props, State> {
     const {
       className,
       children,
+      inline,
       for: htmlFor,
       id: idProp,
       ...rest
     } = this.props
 
-    const componentClassName = classNames('c-FormLabel', className)
+    const componentClassName = classNames(
+      'c-FormLabel',
+      inline && 'c-FormLabel--inline',
+      className
+    )
     const labelMarkup = this.getLabelMarkup()
     const helpTextMarkup = this.getHelpTextMarkup()
 
     return (
       <Context.Provider value={this.getContextProps()}>
-        <FormLabelUI {...getValidProps(rest)} className={componentClassName}>
-          {labelMarkup}
-          {helpTextMarkup}
-          <div className="c-FromLabel__content">{children}</div>
+        <FormLabelUI
+          {...getValidProps(rest)}
+          className={componentClassName}
+          inline={inline}
+        >
+          <div className="c-FormLabel__label">
+            {labelMarkup}
+            {helpTextMarkup}
+          </div>
+          <div className="c-FormLabel__content">{children}</div>
         </FormLabelUI>
       </Context.Provider>
     )

--- a/src/components/FormLabel/README.md
+++ b/src/components/FormLabel/README.md
@@ -10,13 +10,20 @@ This component is a wrapper for Control components, such as [`Input`](../../Inpu
 </FormLabel>
 ```
 
+```jsx
+<FormLabel label="First name" inline>
+  <Switch />
+</FormLabel>
+```
+
 ## Props
 
-| Prop      | Type     | Description                                                          |
-| --------- | -------- | -------------------------------------------------------------------- |
-| children  | `any`    | Content to render.                                                   |
-| className | `string` | Custom class names to be added to the component.                     |
-| for       | `string` | Determines what the `label` is associated with. Preferred over `id`. |
-| helpText  | `string` | Content to render a [`HelpText`](../../HelpText).                    |
-| id        | `string` | Custom ID to bind the `label` with the Control component.            |
-| label     | `string` | Content to render a [`Label`](../../Label).                          |
+| Prop      | Type      | Description                                                                                              |
+| --------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| children  | `any`     | Content to render.                                                                                       |
+| className | `string`  | Custom class names to be added to the component.                                                         |
+| for       | `string`  | Determines what the `label` is associated with. Preferred over `id`.                                     |
+| helpText  | `string`  | Content to render a [`HelpText`](../../HelpText).                                                        |
+| id        | `string`  | Custom ID to bind the `label` with the Control component.                                                |
+| label     | `string`  | Content to render a [`Label`](../../Label).                                                              |
+| inline    | `boolean` | Determines whether to render the label and form input inline (made specially for checkboxes or `Switch`) |

--- a/src/components/FormLabel/__tests__/FormLabel.test.js
+++ b/src/components/FormLabel/__tests__/FormLabel.test.js
@@ -111,3 +111,25 @@ describe('Context', () => {
     expect(o.prop('id')).toContain('FormControl')
   })
 })
+
+describe('Inline', () => {
+  test('Renders the content inline with the label', () => {
+    const wrapper = mount(
+      <FormLabel inline>
+        <Input />
+      </FormLabel>
+    )
+
+    expect(wrapper.find('.c-FormLabel--inline').length).toBeTruthy()
+  })
+
+  test('Renders the content normally with inline off', () => {
+    const wrapper = mount(
+      <FormLabel>
+        <Input />
+      </FormLabel>
+    )
+
+    expect(wrapper.find('.c-FormLabel--inline').length).toBe(0)
+  })
+})

--- a/src/components/FormLabel/__tests__/FormLabel.test.js
+++ b/src/components/FormLabel/__tests__/FormLabel.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import FormLabel from '../FormLabel'
 import Input from '../../Input'
+import { calculateContentRules } from '../styles/FormLabel.css'
 
 describe('ClassName', () => {
   test('Has default className', () => {
@@ -131,5 +132,30 @@ describe('Inline', () => {
     )
 
     expect(wrapper.find('.c-FormLabel--inline').length).toBe(0)
+  })
+
+  test('calculateContentRules generates the correct rules to align content in inline mode', () => {
+    const inlineWithoutHelpText = calculateContentRules({
+      inline: true,
+      isHelpTextPresent: false,
+    })
+    expect(inlineWithoutHelpText).toBe('align-self: center;')
+
+    const inlineWithHelpText = calculateContentRules({
+      inline: true,
+      isHelpTextPresent: true,
+    })
+    expect(inlineWithHelpText).toBe(
+      `
+        align-self: flex-start;
+        margin-top: 1.4em;
+      `
+    )
+
+    const inlineOff = calculateContentRules({
+      inline: false,
+      isHelpTextPresent: false,
+    })
+    expect(inlineOff).toBe('align-self: initial;')
   })
 })

--- a/src/components/FormLabel/__tests__/FormLabel.test.js
+++ b/src/components/FormLabel/__tests__/FormLabel.test.js
@@ -116,12 +116,12 @@ describe('Context', () => {
 describe('Inline', () => {
   test('Renders the content inline with the label', () => {
     const wrapper = mount(
-      <FormLabel inline>
+      <FormLabel isInline>
         <Input />
       </FormLabel>
     )
 
-    expect(wrapper.find('.c-FormLabel--inline').length).toBeTruthy()
+    expect(wrapper.find('.is-inline').length).toBeTruthy()
   })
 
   test('Renders the content normally with inline off', () => {
@@ -131,18 +131,18 @@ describe('Inline', () => {
       </FormLabel>
     )
 
-    expect(wrapper.find('.c-FormLabel--inline').length).toBe(0)
+    expect(wrapper.find('.is-inline').length).toBe(0)
   })
 
   test('calculateContentRules generates the correct rules to align content in inline mode', () => {
     const inlineWithoutHelpText = calculateContentRules({
-      inline: true,
+      isInline: true,
       isHelpTextPresent: false,
     })
     expect(inlineWithoutHelpText).toBe('align-self: center;')
 
     const inlineWithHelpText = calculateContentRules({
-      inline: true,
+      isInline: true,
       isHelpTextPresent: true,
     })
     expect(inlineWithHelpText).toBe(
@@ -153,7 +153,7 @@ describe('Inline', () => {
     )
 
     const inlineOff = calculateContentRules({
-      inline: false,
+      isInline: false,
       isHelpTextPresent: false,
     })
     expect(inlineOff).toBe('align-self: initial;')

--- a/src/components/FormLabel/styles/FormLabel.css.ts
+++ b/src/components/FormLabel/styles/FormLabel.css.ts
@@ -4,32 +4,45 @@ import styled from '../../styled'
 export const FormLabelUI = styled('div')`
   ${baseStyles};
   display: flex;
-  flex-flow: ${props => (props.inline ? 'row' : 'column')};
-  justify-content: space-between;
-  align-items: ${props => (props.inline ? 'flex-end' : 'stretch')};
+  flex-flow: column;
+  align-items: stretch;
 
-  & .c-FormLabel__label {
-    margin-right: ${props => (props.inline ? '40px' : '0')};
+  &.is-inline {
+    flex-flow: row;
+    align-items: flex-end;
+    justify-content: space-between;
+
+    .c-FormLabel__label {
+      margin-right: 40px;
+    }
+    .c-FormLabel__helpText {
+      padding-bottom: 0;
+    }
   }
-  & .c-FormLabel__helpText {
-    padding-bottom: ${props => (props.inline ? '0' : '4px')};
-  }
+
   & .c-FormLabel__content {
     ${props => calculateContentRules(props)};
   }
 `
+
+export const FormLabelHelpTextUI = styled('div')`
+  padding-bottom: 4px;
+`
+
+export default FormLabelUI
+
 /**
  * Method to generate the correct rules to align the content
  * vertically in inline mode depending on whether Help Text
  * is present or not
- * @param props {inline:boolean, isHelpTextPresent:boolean }
+ * @param props {isInline:boolean, isHelpTextPresent:boolean }
  */
-type funcArg = { inline: boolean; isHelpTextPresent: boolean }
+type funcArg = { isInline: boolean; isHelpTextPresent: boolean }
 export function calculateContentRules({
-  inline,
+  isInline,
   isHelpTextPresent,
 }: funcArg): string {
-  if (inline) {
+  if (isInline) {
     if (isHelpTextPresent) {
       return `
         align-self: flex-start;
@@ -40,9 +53,3 @@ export function calculateContentRules({
   }
   return 'align-self: initial;'
 }
-
-export const FormLabelHelpTextUI = styled('div')`
-  padding-bottom: 4px;
-`
-
-export default FormLabelUI

--- a/src/components/FormLabel/styles/FormLabel.css.ts
+++ b/src/components/FormLabel/styles/FormLabel.css.ts
@@ -3,6 +3,17 @@ import styled from '../../styled'
 
 export const FormLabelUI = styled('div')`
   ${baseStyles};
+  display: flex;
+  flex-flow: ${props => (props.inline ? 'row' : 'column')};
+  justify-content: space-between;
+  align-items: ${props => (props.inline ? 'flex-end' : 'stretch')};
+
+  & .c-FormLabel__label {
+    margin-right: ${props => (props.inline ? '40px' : '0')};
+  }
+  & .c-FormLabel__helpText {
+    padding-bottom: ${props => (props.inline ? '0' : '4px')};
+  }
 `
 
 export const FormLabelHelpTextUI = styled('div')`

--- a/src/components/FormLabel/styles/FormLabel.css.ts
+++ b/src/components/FormLabel/styles/FormLabel.css.ts
@@ -14,7 +14,32 @@ export const FormLabelUI = styled('div')`
   & .c-FormLabel__helpText {
     padding-bottom: ${props => (props.inline ? '0' : '4px')};
   }
+  & .c-FormLabel__content {
+    ${props => calculateContentRules(props)};
+  }
 `
+/**
+ * Method to generate the correct rules to align the content
+ * vertically in inline mode depending on whether Help Text
+ * is present or not
+ * @param props {inline:boolean, isHelpTextPresent:boolean }
+ */
+type funcArg = { inline: boolean; isHelpTextPresent: boolean }
+export function calculateContentRules({
+  inline,
+  isHelpTextPresent,
+}: funcArg): string {
+  if (inline) {
+    if (isHelpTextPresent) {
+      return `
+        align-self: flex-start;
+        margin-top: 1.4em;
+      `
+    }
+    return 'align-self: center;'
+  }
+  return 'align-self: initial;'
+}
 
 export const FormLabelHelpTextUI = styled('div')`
   padding-bottom: 4px;

--- a/stories/FormLabel.stories.js
+++ b/stories/FormLabel.stories.js
@@ -21,7 +21,7 @@ storiesOf('FormLabel', module)
     <Page>
       <Page.Card>
         <FormGroup>
-          <FormLabel label="Label for the Switch" inline>
+          <FormLabel label="Label for the Switch" isInline>
             <Switch />
           </FormLabel>
         </FormGroup>
@@ -31,7 +31,7 @@ storiesOf('FormLabel', module)
           <FormLabel
             label="Label for the Switch"
             helpText="Enable this feature or you might regret it later."
-            inline
+            isInline
           >
             <Switch />
           </FormLabel>
@@ -42,7 +42,7 @@ storiesOf('FormLabel', module)
           <FormLabel
             label="Label for the Switch"
             helpText="Enable this feature or you might regret it later.Enable this feature or you might regret it later.Enable this feature or you might regret it later."
-            inline
+            isInline
           >
             <Switch />
           </FormLabel>

--- a/stories/FormLabel.stories.js
+++ b/stories/FormLabel.stories.js
@@ -18,13 +18,35 @@ storiesOf('FormLabel', module)
     </Page>
   ))
   .add('inline', () => (
-    <FormGroup>
-      <FormLabel
-        label="Label for the Switch"
-        helpText="Enable this feature or you might regret it later."
-        inline
-      >
-        <Switch />
-      </FormLabel>
-    </FormGroup>
+    <Page>
+      <Page.Card>
+        <FormGroup>
+          <FormLabel label="Label for the Switch" inline>
+            <Switch />
+          </FormLabel>
+        </FormGroup>
+      </Page.Card>
+      <Page.Card>
+        <FormGroup>
+          <FormLabel
+            label="Label for the Switch"
+            helpText="Enable this feature or you might regret it later."
+            inline
+          >
+            <Switch />
+          </FormLabel>
+        </FormGroup>
+      </Page.Card>
+      <Page.Card>
+        <FormGroup>
+          <FormLabel
+            label="Label for the Switch"
+            helpText="Enable this feature or you might regret it later.Enable this feature or you might regret it later.Enable this feature or you might regret it later."
+            inline
+          >
+            <Switch />
+          </FormLabel>
+        </FormGroup>
+      </Page.Card>
+    </Page>
   ))

--- a/stories/FormLabel.stories.js
+++ b/stories/FormLabel.stories.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Page, FormLabel, FormGroup, Input, Switch } from '../src/index.js'
+
+storiesOf('FormLabel', module)
+  .add('default', () => (
+    <Page>
+      <Page.Card>
+        <FormGroup>
+          <FormLabel
+            label="This is the label for the Input down there"
+            helpText="Ignore this message, says nothing interesting."
+          >
+            <Input />
+          </FormLabel>
+        </FormGroup>
+      </Page.Card>
+    </Page>
+  ))
+  .add('inline', () => (
+    <FormGroup>
+      <FormLabel
+        label="Label for the Switch"
+        helpText="Enable this feature or you might regret it later."
+        inline
+      >
+        <Switch />
+      </FormLabel>
+    </FormGroup>
+  ))

--- a/stories/Page/Page.Card.stories.js
+++ b/stories/Page/Page.Card.stories.js
@@ -104,7 +104,7 @@ function ExampleContent() {
         <FormLabel
           label="Site Visibility"
           helpText="Turns your site on or off to visitors. Visit site."
-          inline
+          isInline
         >
           <Switch active />
         </FormLabel>

--- a/stories/Page/Page.Card.stories.js
+++ b/stories/Page/Page.Card.stories.js
@@ -104,6 +104,7 @@ function ExampleContent() {
         <FormLabel
           label="Site Visibility"
           helpText="Turns your site on or off to visitors. Visit site."
+          inline
         >
           <Switch active />
         </FormLabel>


### PR DESCRIPTION
## Inline Form Labels

This PR proposes the addition of an "inline" mode on `FormLabel`, where the label (including help text) sits on the right and the content on the left. This is specially designed for when the content is a checkbox or a `<Switch>` as most recent designs lays them out.

The alignment of items is done using flexbox

This PR:

- Adds the prop `inline` to enable this mode
- Adds tests
- Adds stories

### Screens

#### Default mode
```jsx
<FormLabel
  label="This is the label for the Input down there"
  helpText="Ignore this message, says nothing interesting."
>
  <Input />
</FormLabel>
```
![default](https://user-images.githubusercontent.com/1414086/49219250-0148d700-f3d3-11e8-8b22-029e8305ffc4.png)


#### Inline without help text present and with (one line, multi-line)
```jsx
<FormLabel
  label="Label for the Switch"
  inline
>
  <Switch />
</FormLabel>
```

```jsx
<FormLabel
  label="Label for the Switch"
  helpText="Enable this feature or you might regret it later."
  inline
>
  <Switch />
</FormLabel>
```

```jsx
<FormLabel
  label="Label for the Switch"
  helpText="Enable this feature or you might regret it later. Enable this feature or you might regret it later. Enable this feature or you might regret it later."
  inline
>
  <Switch />
</FormLabel>
```

![inline labels](https://user-images.githubusercontent.com/1414086/49219198-dd859100-f3d2-11e8-94ec-1d13f6810e29.png)

#### Example inside a page

![inpage](https://user-images.githubusercontent.com/1414086/49219199-dd859100-f3d2-11e8-87f3-d018dc71e9e3.png)

