### PR TITLE
Move help text inside the label when Choice is stacked

### DIFF
--- a/src/components/Choice/Choice.js
+++ b/src/components/Choice/Choice.js
@@ -303,8 +303,9 @@ class Choice extends Component<Props, State> {
           <ChoiceUI {...getValidProps(rest)} className={componentClassName}>
             <ChoiceLabelUI htmlFor={choiceID} className={labelClassName}>
               {this.getInputMarkup(contextProps)}
+              {stacked ? this.getHelpTextMarkup() : null}
             </ChoiceLabelUI>
-            {this.getHelpTextMarkup()}
+            {!stacked ? this.getHelpTextMarkup() : null}
           </ChoiceUI>
         )}
       </ChoiceGroupContext.Consumer>

--- a/src/components/Choice/__tests__/Choice.test.js
+++ b/src/components/Choice/__tests__/Choice.test.js
@@ -116,6 +116,25 @@ describe('HelpText', () => {
     expect(text.text()).toBe(helpText)
     wrapper.unmount()
   })
+
+  test('Renders helpText outside label when not stacked', () => {
+    const helpText = 'Help Text'
+    const wrapper = mount(<Choice label="Label" helpText={helpText} />)
+    const text = wrapper.find('label').find(HelpText)
+
+    expect(text.length).toBeFalsy()
+    wrapper.unmount()
+  })
+
+  test('Renders helpText inside label when stacked', () => {
+    const helpText = 'Help Text'
+    const wrapper = mount(<Choice label="Label" helpText={helpText} stacked />)
+    const text = wrapper.find('label').find(HelpText)
+
+    expect(text.length).toBeTruthy()
+    expect(text.text()).toBe(helpText)
+    wrapper.unmount()
+  })
 })
 
 describe('Label', () => {


### PR DESCRIPTION
In a PR for Beacon Builder @ItsJonQ suggested making the help text part of the label so it's clickable when using the stacked style: https://github.com/helpscout/hs-app/pull/5934#issuecomment-442864744

This PR moves the help text inside the label only when it is stacked.

![choice-stacked-helptext-label](https://user-images.githubusercontent.com/6132043/49273416-c7c4aa00-f46c-11e8-9246-871f9035e856.gif)
