### PR TITLE
Fix HelpText state and add stories

### DIFF
--- a/src/components/HelpText/HelpText.js
+++ b/src/components/HelpText/HelpText.js
@@ -26,6 +26,7 @@ const HelpText = (props: Props) => {
     'c-HelpText',
     isCompact && `is-compact`,
     shade && `is-${shade}`,
+    state && `is-${state}`,
     className
   )
 

--- a/src/components/HelpText/HelpText.js
+++ b/src/components/HelpText/HelpText.js
@@ -26,12 +26,11 @@ const HelpText = (props: Props) => {
     'c-HelpText',
     isCompact && `is-compact`,
     shade && `is-${shade}`,
-    state && `is-${state}`,
     className
   )
 
   const contentMarkup = isString(children) ? (
-    <Text className="c-HelpText__text" shade={shade} size={size}>
+    <Text className="c-HelpText__text" shade={shade} size={size} state={state}>
       {children}
     </Text>
   ) : (

--- a/src/components/HelpText/__tests__/HelpText.test.js
+++ b/src/components/HelpText/__tests__/HelpText.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import HelpText from '../HelpText'
+import Text from '../../Text'
 
 describe('ClassName', () => {
   test('Applies custom className if specified', () => {
@@ -56,5 +57,16 @@ describe('States', () => {
     const wrapper = mount(<HelpText state="warning" />)
 
     expect(wrapper.getDOMNode().classList.contains('is-warning')).toBe(true)
+  })
+
+  test('Passes state to child HelpText', () => {
+    const wrapper = mount(<HelpText state="error">This is a string</HelpText>)
+
+    expect(
+      wrapper
+        .find(Text)
+        .first()
+        .props().state
+    ).toBe('error')
   })
 })

--- a/src/components/HelpText/styles/HelpText.css.js
+++ b/src/components/HelpText/styles/HelpText.css.js
@@ -1,12 +1,15 @@
 // @flow
 import baseStyles from '../../../styles/resets/baseStyles.css.js'
 import styled from '../../styled'
+import { makeStateColorStyles } from '../../../styles/mixins/stateStyles.css.js'
 import { getColor } from '../../../styles/utilities/color'
 
 export const HelpTextUI = styled('div')`
   ${baseStyles}
   color: ${getColor('text.subtle')};
   padding: 4px 0;
+
+  ${makeStateColorStyles()}
 
   &.is-compact {
     margin-top: -8px;

--- a/src/components/HelpText/styles/HelpText.css.js
+++ b/src/components/HelpText/styles/HelpText.css.js
@@ -1,15 +1,12 @@
 // @flow
 import baseStyles from '../../../styles/resets/baseStyles.css.js'
 import styled from '../../styled'
-import { makeStateColorStyles } from '../../../styles/mixins/stateStyles.css.js'
 import { getColor } from '../../../styles/utilities/color'
 
 export const HelpTextUI = styled('div')`
   ${baseStyles}
   color: ${getColor('text.subtle')};
   padding: 4px 0;
-
-  ${makeStateColorStyles()}
 
   &.is-compact {
     margin-top: -8px;

--- a/stories/HelpText.stories.tsx
+++ b/stories/HelpText.stories.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { storiesOf } from '@storybook/react'
+import HelpText from '../src/components/HelpText'
+
+storiesOf('HelpText', module)
+  .add('default', () => <HelpText>I am help text. Behold my text.</HelpText>)
+  .add('states', () => (
+    <div>
+      <HelpText>Default</HelpText>
+      <br />
+      <HelpText state="error">Error</HelpText>
+      <br />
+      <HelpText state="success">Success</HelpText>
+      <br />
+      <HelpText state="warning">Warning</HelpText>
+      <br />
+    </div>
+  ))

--- a/stories/HelpText.stories.tsx
+++ b/stories/HelpText.stories.tsx
@@ -6,6 +6,26 @@ storiesOf('HelpText', module)
   .add('default', () => <HelpText>I am help text. Behold my text.</HelpText>)
   .add('states', () => (
     <div>
+      <HelpText>
+        <strong>Default</strong>
+      </HelpText>
+      <br />
+      <HelpText state="error">
+        <strong>Error</strong>
+      </HelpText>
+      <br />
+      <HelpText state="success">
+        <strong>Success</strong>
+      </HelpText>
+      <br />
+      <HelpText state="warning">
+        <strong>Warning</strong>
+      </HelpText>
+      <br />
+    </div>
+  ))
+  .add('states with string children', () => (
+    <div>
       <HelpText>Default</HelpText>
       <br />
       <HelpText state="error">Error</HelpText>


### PR DESCRIPTION
## Fix HelpText state and add stories

The `state` prop of `HelpText` was not being respected and it was always using the `faint` text style. This PR moves the state styling to the child `Text` component rather than adding styles to the `HelpText` component as they were are not specific enough.

![screen shot 2018-12-03 at 19 05 36](https://user-images.githubusercontent.com/6132043/49395627-f5407a80-f72e-11e8-9cdb-8bd919300dd1.png)
![screen shot 2018-12-03 at 19 05 31](https://user-images.githubusercontent.com/6132043/49395628-f5407a80-f72e-11e8-92ad-c17c620aeab6.png)
![screen shot 2018-12-03 at 19 05 27](https://user-images.githubusercontent.com/6132043/49395629-f5407a80-f72e-11e8-8c6f-fcd1e2ddf444.png)

I added a story to test these changes.