### PR TITLE
Add new heading size and story

### DIFF
--- a/src/components/Skeleton/Text.js
+++ b/src/components/Skeleton/Text.js
@@ -7,16 +7,26 @@ import { TextUI } from './styles/Text.css.js'
 class Text extends Component {
   static defaultProps = {
     heading: false,
+    size: 'md',
     style: {},
     width: '70%',
   }
 
   render() {
-    const { className, children, heading, style, width, ...rest } = this.props
+    const {
+      className,
+      children,
+      heading,
+      size,
+      style,
+      width,
+      ...rest
+    } = this.props
 
     const componentClassName = classNames(
       'c-SkeletonText',
       heading && 'is-heading',
+      size && `is-${size}`,
       className
     )
 

--- a/src/components/Skeleton/styles/Text.css.js
+++ b/src/components/Skeleton/styles/Text.css.js
@@ -3,11 +3,16 @@ import Block from '../Block'
 
 export const TextUI = styled(Block)`
   border-radius: 9999px;
-  height: 10px;
-  margin-bottom: 8px;
+  height: 9px;
+  margin-bottom: 11px;
   width: 100%;
 
   &.is-heading {
     height: 16px;
+
+    &.is-sm {
+      height: 9px;
+      margin-bottom: 15px;
+    }
   }
 `

--- a/stories/Skeleton.stories.js
+++ b/stories/Skeleton.stories.js
@@ -72,6 +72,20 @@ stories.add('paragraph', () => (
   </div>
 ))
 
+stories.add('Paragraph with heading', () => (
+  <div>
+    <Skeleton.Heading />
+    <Skeleton.Paragraph />
+  </div>
+))
+
+stories.add('paragraph with small heading', () => (
+  <div>
+    <Skeleton.Heading size="sm" />
+    <Skeleton.Paragraph />
+  </div>
+))
+
 stories.add('text', () => (
   <div>
     <Skeleton.Text width="70%" />


### PR DESCRIPTION
This is a small PR to:

1. Add a new heading size for Skeletons. The new small-sized heading should be the same height as text but with extra bottom margin to distinguish it from other lines of text.
2. Make a slight adjustment to the heigh and bottom margin of text. 

Example of small heading with text:

![Demo](https://d2ddoduugvun08.cloudfront.net/items/3B033q1Z1D3h2y143v3S/Image%202018-12-03%20at%204.09.32%20PM.png?X-CloudApp-Visitor-Id=2338876&v=76e80bc9)