### PR TITLE
PropProvider/Connect: Pure by default

### DIFF
--- a/src/components/PropProvider/PropProvider.tsx
+++ b/src/components/PropProvider/PropProvider.tsx
@@ -10,7 +10,7 @@ export interface Props {
   value: PropProviderProps
 }
 
-class PropProvider extends React.Component<Props> {
+class PropProvider extends React.PureComponent<Props> {
   static defaultProps = {
     app: 'blue',
     value: {},

--- a/src/components/PropProvider/__tests__/propConnect.test.js
+++ b/src/components/PropProvider/__tests__/propConnect.test.js
@@ -199,4 +199,31 @@ describe('propConnect', () => {
 
     expect(wrapper.instance().wrappedInstance).toBeFalsy()
   })
+
+  test('Creates a React.PureComponent instance, by default', () => {
+    const Buddy = props => <div>{props.noms}</div>
+
+    const ConnectedBuddy = propConnect()(Buddy)
+    const wrapper = mount(<ConnectedBuddy />)
+
+    expect(wrapper.instance() instanceof React.PureComponent).toBe(true)
+  })
+
+  test('Can create a React.Component instance, if specified', () => {
+    const Buddy = props => <div>{props.noms}</div>
+
+    const ConnectedBuddy = propConnect(null, { pure: false })(Buddy)
+    const wrapper = mount(<ConnectedBuddy />)
+
+    expect(wrapper.instance() instanceof React.Component).toBe(true)
+  })
+
+  test('Can create a React.PureComponent instance, if specified', () => {
+    const Buddy = props => <div>{props.noms}</div>
+
+    const ConnectedBuddy = propConnect(null, { pure: true })(Buddy)
+    const wrapper = mount(<ConnectedBuddy />)
+
+    expect(wrapper.instance() instanceof React.PureComponent).toBe(true)
+  })
 })

--- a/src/components/PropProvider/propConnect.tsx
+++ b/src/components/PropProvider/propConnect.tsx
@@ -12,6 +12,10 @@ export interface Props {
   style: Object
 }
 
+const defaultOptions = {
+  pure: true,
+}
+
 /**
  * "Connects" a component with the PropProvider (context). Concept is
  * similar to Redux's connect higher-order function.
@@ -19,7 +23,8 @@ export interface Props {
  * @param   {string} name The component's config namespace.
  * @returns {React.Component} The connected React component.
  */
-function propConnect(name?: ConfigGetter) {
+function propConnect(name?: ConfigGetter, options: Object = {}) {
+  const { pure } = { ...defaultOptions, ...options }
   // @ts-ignore
   let namespace: string = isString(name) ? name : ''
 
@@ -28,8 +33,9 @@ function propConnect(name?: ConfigGetter) {
       namespace = getComponentName(WrappedComponent)
     }
     const displayName = `connected(${namespace})`
+    const OuterBaseComponent = pure ? React.PureComponent : React.Component
 
-    class Connect extends React.Component<Props> {
+    class Connect extends OuterBaseComponent<Props> {
       static defaultProps = {
         style: {},
       }


### PR DESCRIPTION
## PropProvider/Connect: Pure by default

![](https://media.giphy.com/media/m1XKjKqVjY3hC/giphy.gif)

This update adjusts `PropProvider` and `propConnect` to be `React.PureComponent`
classes by default (for added performance).

`propConnect` now has an extra options arg that allows you to create
`React.Component` instances, if you choose.

This update is similar to the enhancements we've done in [Fancy](https://github.com/helpscout/fancy/pull/34) and [Wedux](https://github.com/helpscout/wedux/blob/master/src/connect.ts#L29)