### PR TITLE
Remove pluralize dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22074,7 +22074,8 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
     },
     "pn": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -79,10 +79,9 @@
     "dash-get": "1.0.0",
     "highlight.js": "^9.12.0",
     "path-to-regexp": "^2.4.0",
-    "pluralize": "^7.0.0",
     "polished": "^2.3.0",
     "popper.js": "1.14.3",
-    "prop-types": "^15.6.1",
+    "prop-types": "^15",
     "react-sortable-hoc": "^0.6.7",
     "react-transition-group": "2.2.0"
   },

--- a/src/components/ChatSidebar/ChatSidebar.js
+++ b/src/components/ChatSidebar/ChatSidebar.js
@@ -1,10 +1,10 @@
 // @flow
 import React, { PureComponent as Component } from 'react'
-import pluralize from 'pluralize'
 import StatusBar from '../StatusBar'
 import { classNames } from '../../utilities/classNames'
 import { namespaceComponent } from '../../utilities/component'
 import { noop } from '../../utilities/other'
+import pluralize from '../../utilities/pluralize'
 import { smoothScrollTo } from '../../utilities/smoothScroll'
 import { COMPONENT_KEY } from './utils'
 import {

--- a/src/utilities/__tests__/pluralize.test.ts
+++ b/src/utilities/__tests__/pluralize.test.ts
@@ -1,0 +1,22 @@
+import pluralize from '../pluralize'
+
+test('Pluralizes a zero count', () => {
+  expect(pluralize('message', 0)).toBe('messages')
+})
+
+test('Pluralizes a one count', () => {
+  expect(pluralize('message', 1)).toBe('message')
+})
+
+test('Pluralizes a +2 count', () => {
+  expect(pluralize('message', 100)).toBe('messages')
+})
+
+test('Pluralizes a one count, by default', () => {
+  expect(pluralize('message')).toBe('message')
+})
+
+test('Returns an empty string if value arg is falsy', () => {
+  // @ts-ignore
+  expect(pluralize()).toBe('')
+})

--- a/src/utilities/pluralize.ts
+++ b/src/utilities/pluralize.ts
@@ -1,0 +1,10 @@
+/**
+ * A super tiny, but naive, way to pluralize a word based on a count value.
+ * @param word {string} The word to pluralize.
+ * @param count {number} The count to check against.
+ * @returns {string} The pluralized word.
+ */
+export default function pluralize(word: string, count: number = 1): string {
+  if (!word) return ''
+  return count === 1 ? word : `${word}s`
+}


### PR DESCRIPTION
## Remove pluralize dependency

![](https://media.giphy.com/media/l41YtZOb9EUABnuqA/giphy.gif)

This update removes the `pluralize` dependency. Instead, we're gonna use
our own super tiny (but kinda naive) way of pluralizing. This should be okay
since we're currently only using it for one label in the library.