### PR TITLE
Modal: Prevent className/style prop pass

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -218,6 +218,7 @@ class Modal extends Component<Props> {
   getInnerContentMarkup = () => {
     const {
       cardClassName,
+      className,
       modalAnimationDelay,
       modalAnimationDuration,
       modalAnimationEasing,

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -224,6 +224,7 @@ class Modal extends Component<Props> {
       modalAnimationSequence,
       portalIsOpen,
       seamless,
+      style,
       ...rest
     } = this.props
 

--- a/stories/Modal.stories.js
+++ b/stories/Modal.stories.js
@@ -11,6 +11,7 @@ import {
   Input,
   Switch,
   Toolbar,
+  styled,
 } from '../src/index.js'
 import { FrameProvider } from '../src/components/styled'
 import { MemoryRouter } from 'react-router'
@@ -498,3 +499,23 @@ class HSAppExample extends React.Component {
 }
 
 stories.add('HSApp', () => <HSAppExample />)
+
+stories.add('styled', () => {
+  const StyledModal = styled(Modal)`
+    .c-ModalOverlay {
+      background: purple;
+    }
+  `
+
+  return (
+    <StyledModal isOpen>
+      <Modal.Content>
+        <Modal.Body>
+          {ContentSpec.generate(12).map(({ id, content }) => (
+            <p key={id}>{content}</p>
+          ))}
+        </Modal.Body>
+      </Modal.Content>
+    </StyledModal>
+  )
+})


### PR DESCRIPTION
## Modal: Prevent className/style prop pass

![](https://media.giphy.com/media/3ohs4g2ZdPTPmdIVSo/giphy.gif)

This update fixes a lil' bug with `Modal` where `style` and `className` props were being unexpectedly passed to inner components.