### PR TITLE
Input scroll fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.4.13",
+  "version": "2.4.14-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.4.13",
+  "version": "2.4.14-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -333,6 +333,8 @@ export class Input extends Component<Props, State> {
 
   handleOnWheel = (event: WheelEvent) => {
     const { multiline, onWheel, scrollLock } = this.props
+    event.stopPropagation()
+
     if (!multiline || !scrollLock) return
 
     const stopPropagation = true

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -137,6 +137,18 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalled()
   })
 
+  test('onWheel callback stops event from bubbling, even without scrollLock', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input scrollLock={false} />)
+    const input = wrapper.find('textarea')
+
+    input.simulate('wheel', {
+      stopPropagation: spy,
+    })
+
+    expect(spy).toHaveBeenCalled()
+  })
+
   test('onKeydown callback fires when input keyDown occurs', () => {
     const spy = jest.fn()
     const wrapper = mount(<Input multiline={true} onKeyDown={spy} />)

--- a/stories/Modal.stories.js
+++ b/stories/Modal.stories.js
@@ -116,6 +116,7 @@ class StatefulComponent extends React.Component {
                     maxHeight={140}
                     onChange={this.handleOnInputChange}
                     value={value}
+                    scrollLock={false}
                   />
                   <Button onClick={this.handleOnSubmit} primary>
                     Submit


### PR DESCRIPTION
## Input: Scroll fix

![screen recording 2018-12-07 at 04 01 pm](https://user-images.githubusercontent.com/2322354/49672767-3049f300-fa3a-11e8-82a4-ac586ab3b39a.gif)

This update fixes the `Input` component's scroll (wheel) event went
it becomes scrollable. It ensures that it still works in an environment
such as a `Modal`.