### PR TITLE
ChatScroller: Enable external selector

### DIFF
--- a/.remake/component/remake-name/remake-name.tsx
+++ b/.remake/component/remake-name/remake-name.tsx
@@ -2,16 +2,21 @@ import * as React from 'react'
 import propConnect from '../PropProvider/propConnect'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import { classNames } from '../../utilities/classNames'
+import { noop } from '../../utilities/other'
 import { <%= name %>UI } from './<%= name %>.css'
 import { COMPONENT_KEY } from './<%= name %>.utils'
 
 export interface Props {
   className?: string,
-  children?: any
+  children?: any,
+  innerRef: (node: HTMLElement) => void,
 }
 
 export class <%= name %> extends React.PureComponent<Props> {
   static className = 'c-<%= name %>'
+  static defaultProps = {
+    innerRef: noop
+  }
 
   getClassName() {
     const { className } = this.props
@@ -22,10 +27,14 @@ export class <%= name %> extends React.PureComponent<Props> {
   }
 
   render() {
-    const { children, ...rest } = this.props
+    const { children, innerRef, ...rest } = this.props
 
     return (
-      <<%= name %>UI {...getValidProps(rest)} className={this.getClassName()}>
+      <<%= name %>UI
+        {...getValidProps(rest)}
+        className={this.getClassName()}
+        innerRef={innerRef}
+      >
         {children}
       </<%= name %>UI>
     )

--- a/src/components/ChatScroller/ChatScroller.utils.ts
+++ b/src/components/ChatScroller/ChatScroller.utils.ts
@@ -1,0 +1,1 @@
+export const COMPONENT_KEY = 'ChatScroller'

--- a/src/components/ChatScroller/README.md
+++ b/src/components/ChatScroller/README.md
@@ -12,14 +12,15 @@ A ChatScroller component is light-weight wrapper automatically scrolls a Chat bo
 
 ## Props
 
-| Prop                  | Type       | Description                                        |
-| --------------------- | ---------- | -------------------------------------------------- |
-| className             | `string`   | Custom class names to be added to the component.   |
-| distanceForAutoScroll | `number`   | A range to enable auto-scrolling.                  |
-| isTyping              | `bool`     | A chat-based event used to trigger auto-scrolling. |
-| lastMessageId         | `string`   | Chat data used to trigger auto-scrolling.          |
-| messages              | `array`    | Chat data used to trigger auto-scrolling.          |
-| messageSelectors      | `string`   | DOM selector(s) for chat message elements.         |
-| onScroll              | `function` | Callback function when component is scrolled.      |
-| scrollableSelector    | `string`   | DOM selector for the scrollable message container. |
-| smoothScrollDuration  | `number`   | Duration (ms) for smooth scrolling.                |
+| Prop                  | Type       | Description                                            |
+| --------------------- | ---------- | ------------------------------------------------------ |
+| className             | `string`   | Custom class names to be added to the component.       |
+| distanceForAutoScroll | `number`   | A range to enable auto-scrolling.                      |
+| isTyping              | `bool`     | A chat-based event used to trigger auto-scrolling.     |
+| lastMessageId         | `string`   | Chat data used to trigger auto-scrolling.              |
+| messages              | `array`    | Chat data used to trigger auto-scrolling.              |
+| messageSelectors      | `string`   | DOM selector(s) for chat message elements.             |
+| onScroll              | `function` | Callback function when component is scrolled.          |
+| propsToCheck          | `Array`    | A collection of props to check to initiate the scroll. |
+| scrollableSelector    | `string`   | DOM selector for the scrollable message container.     |
+| smoothScrollDuration  | `number`   | Duration (ms) for smooth scrolling.                    |

--- a/src/components/ChatScroller/__tests__/ChatScroller.test.js
+++ b/src/components/ChatScroller/__tests__/ChatScroller.test.js
@@ -1,29 +1,35 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import ChatScroller, { getScrollProps, shouldAutoScroll } from '../index'
+import { ChatScroller, getScrollProps, shouldAutoScroll } from '../ChatScroller'
 import Message from '../../Message'
 import Scrollable from '../../Scrollable'
 
+function mockSetNode(wrapper) {
+  const node = wrapper.find('div.c-ScrollableNode').getDOMNode()
+  wrapper.instance().scrollableNode = node
+
+  return wrapper
+}
+
 describe('Nodes', () => {
-  test('Does not set childNode if empty', () => {
+  test('Does not set childRef if empty', () => {
     const wrapper = mount(<ChatScroller />)
 
-    const node = wrapper.instance().childNode
+    const node = wrapper.instance().childRef
 
     expect(node).toBeFalsy()
   })
 
-  test('Sets childNode on mount', () => {
+  test('Sets childRef on mount', () => {
     const wrapper = mount(
       <ChatScroller>
         <div />
       </ChatScroller>
     )
 
-    const node = wrapper.instance().childNode
+    const node = wrapper.instance().childRef
 
     expect(node).toBeTruthy()
-    expect(node.tagName).toBe('DIV')
   })
 
   test('Does not set scrollableNode on mount, if not applicable', () => {
@@ -36,34 +42,6 @@ describe('Nodes', () => {
     const node = wrapper.instance().scrollableNode
 
     expect(node).toBeFalsy()
-  })
-
-  test('Sets scrollableNode on mount, if applicable', () => {
-    const wrapper = mount(
-      <ChatScroller>
-        <div>
-          <Scrollable />
-        </div>
-      </ChatScroller>
-    )
-
-    const node = wrapper.instance().scrollableNode
-
-    expect(node).toBeTruthy()
-    expect(node.tagName).toBe('DIV')
-  })
-
-  test('Can sets scrollableNode on mount, for Scrollable child', () => {
-    const wrapper = mount(
-      <ChatScroller>
-        <Scrollable />
-      </ChatScroller>
-    )
-
-    const node = wrapper.instance().scrollableNode
-
-    expect(node).toBeTruthy()
-    expect(node.tagName).toBe('DIV')
   })
 })
 
@@ -87,6 +65,8 @@ describe('getLatestMessageNode', () => {
         </Scrollable>
       </ChatScroller>
     )
+    // Mock the scrollableNode set
+    mockSetNode(wrapper)
     const node = wrapper.instance().getLatestMessageNode()
 
     expect(node).toBeTruthy()
@@ -106,6 +86,8 @@ describe('getLatestMessageNode', () => {
         </Scrollable>
       </ChatScroller>
     )
+    // Mock the scrollableNode set
+    mockSetNode(wrapper)
     const node = wrapper.instance().getLatestMessageNode()
 
     expect(node.innerHTML).toContain('BURGANDY!')
@@ -182,20 +164,8 @@ describe('handleScroll', () => {
       onScroll: spy,
     })
 
+    mockSetNode(wrapper)
     wrapper.instance().forceScrollToBottom()
-
-    expect(spy).toHaveBeenCalled()
-  })
-})
-
-describe('forceScrollToBottom', () => {
-  test('force scrolls to bottom on mount', () => {
-    const spy = jest.fn()
-    mount(
-      <ChatScroller onScroll={spy}>
-        <Scrollable />
-      </ChatScroller>
-    )
 
     expect(spy).toHaveBeenCalled()
   })

--- a/src/components/ChatScroller/index.ts
+++ b/src/components/ChatScroller/index.ts
@@ -1,0 +1,3 @@
+import ChatScroller from './ChatScroller'
+
+export default ChatScroller

--- a/src/utilities/smoothScroll.js
+++ b/src/utilities/smoothScroll.js
@@ -1,5 +1,6 @@
 import { isNodeElement } from './node'
 import { requestAnimationFrame } from './other'
+import { isFunction } from './is'
 
 // Source:
 // https://gist.github.com/gre/1650294
@@ -21,7 +22,13 @@ const easeInOutCubic = t => {
 //
 // For now, this method has been extensively tested manually
 // within Storybook.
-export const smoothScrollTo = ({ node, position, duration, direction }) => {
+export const smoothScrollTo = ({
+  node,
+  position,
+  duration,
+  direction,
+  callback,
+}) => {
   const scrollNode = isNodeElement(node) ? node : window
   const isWindow = scrollNode === window
   const scrollDuration = duration || 500
@@ -57,6 +64,10 @@ export const smoothScrollTo = ({ node, position, duration, direction }) => {
     // Proceed with animation as long as we wanted it to.
     if (time < scrollDuration) {
       requestAnimationFrame(step)
+    } else {
+      if (isFunction(callback)) {
+        callback()
+      }
     }
   }
 

--- a/stories/ChatScroller.stories.js
+++ b/stories/ChatScroller.stories.js
@@ -17,36 +17,95 @@ const MessageSpec = createSpec({
   message: faker.lorem.sentence(),
 })
 
-class Chat extends React.Component {
-  state = {
-    messages: MessageSpec.generate(5),
-    isTyping: false,
+stories.add('Default', () => {
+  class Chat extends React.Component {
+    state = {
+      messages: MessageSpec.generate(5),
+      isTyping: false,
+    }
+
+    addMessage = () => {
+      this.setState({
+        messages: [...this.state.messages, MessageSpec.generate()],
+      })
+    }
+
+    toggleTyping = () => {
+      this.setState({
+        isTyping: !this.state.isTyping,
+      })
+    }
+
+    render() {
+      return (
+        <div>
+          <button onClick={this.addMessage}>Add Message</button>
+          <button onClick={this.toggleTyping}>Toggle Typing</button>
+          <div style={{ width: 320, height: 300 }}>
+            <ChatScroller
+              messages={this.state.messages}
+              isTyping={this.state.isTyping}
+            >
+              <div style={{ display: 'flex', height: '100%', width: '100%' }}>
+                <Scrollable>
+                  <div style={{ padding: '0 15px' }}>
+                    <Message from avatar={<Avatar name="Arctic Puffin" />}>
+                      {this.state.messages.map(props => (
+                        <Message.Chat key={props.id}>
+                          {props.message}
+                        </Message.Chat>
+                      ))}
+                    </Message>
+                    {this.state.isTyping && <Message.Chat typing />}
+                  </div>
+                </Scrollable>
+              </div>
+            </ChatScroller>
+          </div>
+        </div>
+      )
+    }
   }
 
-  addMessage = () => {
-    this.setState({
-      messages: [...this.state.messages, MessageSpec.generate()],
-    })
-  }
+  return (
+    <div style={{ width: 400, height: 400 }}>
+      <Chat />
+    </div>
+  )
+})
 
-  toggleTyping = () => {
-    this.setState({
-      isTyping: !this.state.isTyping,
-    })
-  }
+stories.add('Custom selector', () => {
+  class Chat extends React.Component {
+    state = {
+      messages: MessageSpec.generate(5),
+      isTyping: false,
+    }
 
-  render() {
-    return (
-      <div>
-        <button onClick={this.addMessage}>Add Message</button>
-        <button onClick={this.toggleTyping}>Toggle Typing</button>
-        <div style={{ width: 320, height: 300 }}>
-          <ChatScroller
-            messages={this.state.messages}
-            isTyping={this.state.isTyping}
-          >
-            <div style={{ display: 'flex', height: '100%', width: '100%' }}>
-              <Scrollable>
+    addMessage = () => {
+      this.setState({
+        messages: [...this.state.messages, MessageSpec.generate()],
+      })
+    }
+
+    toggleTyping = () => {
+      this.setState({
+        isTyping: !this.state.isTyping,
+      })
+    }
+
+    render() {
+      return (
+        <div style={{ position: 'relative' }}>
+          <div style={{ position: 'fixed', top: 0, zIndex: 100 }}>
+            <button onClick={this.addMessage}>Add Message</button>
+            <button onClick={this.toggleTyping}>Toggle Typing</button>
+          </div>
+          <div style={{ width: 320, height: 300 }}>
+            <ChatScroller
+              messages={this.state.messages}
+              isTyping={this.state.isTyping}
+            >
+              <div style={{ display: 'flex', height: '100%', width: '100%' }}>
                 <div style={{ padding: '0 15px' }}>
                   <Message from avatar={<Avatar name="Arctic Puffin" />}>
                     {this.state.messages.map(props => (
@@ -57,17 +116,19 @@ class Chat extends React.Component {
                   </Message>
                   {this.state.isTyping && <Message.Chat typing />}
                 </div>
-              </Scrollable>
-            </div>
-          </ChatScroller>
+              </div>
+            </ChatScroller>
+          </div>
         </div>
-      </div>
-    )
+      )
+    }
   }
-}
 
-stories.add('default', () => (
-  <div style={{ width: 400, height: 400 }}>
-    <Chat />
-  </div>
-))
+  return (
+    <div style={{ width: 400, height: 400 }}>
+      <Scrollable className="custom">
+        <Chat />
+      </Scrollable>
+    </div>
+  )
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     "target": "es5"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", ".remake"]
+  "exclude": ["node_modules", ".remake/**/*"]
 }


### PR DESCRIPTION
## ChatScroller: Enable external selector

![screen recording 2018-12-17 at 01 27 pm](https://user-images.githubusercontent.com/2322354/50107079-9800fa80-01ff-11e9-9f2c-35016c52a69a.gif)

(GIF: Demo of `ChatScroller` controlling a parent scrollable node)

This update enhances `ChatScroller` to be able to control scrollable
nodes that may exist as parent nodes (instead of child only).

`ChatScroller` has also been refactored with the latest HSDS conventions,
including `propConnect` and Typescript.


