### PR TITLE
propConnect: Add wrappedRef

### DIFF
--- a/src/components/PropProvider/__tests__/propConnect.test.js
+++ b/src/components/PropProvider/__tests__/propConnect.test.js
@@ -226,4 +226,19 @@ describe('propConnect', () => {
 
     expect(wrapper.instance() instanceof React.PureComponent).toBe(true)
   })
+
+  test('Can retrieve inner component reference via wrappedRef', () => {
+    class Buddy extends React.Component {
+      render() {
+        return <div>{this.props.noms}</div>
+      }
+    }
+
+    const spy = jest.fn()
+
+    const ConnectedBuddy = propConnect(null, { pure: true })(Buddy)
+    const wrapper = mount(<ConnectedBuddy wrappedRef={spy} />)
+
+    expect(spy).toHaveBeenCalledWith(wrapper.instance().wrappedInstance)
+  })
 })

--- a/src/components/PropProvider/docs/propConnect.md
+++ b/src/components/PropProvider/docs/propConnect.md
@@ -86,3 +86,9 @@ const remapConfigToProps = {
 
 const ConnectedDerekComponent = propConnect(remapConfigToProps)(DerekComponent)
 ```
+
+## Props
+
+| Prop       | Type       | Description                                                                       |
+| ---------- | ---------- | --------------------------------------------------------------------------------- |
+| wrappedRef | `Function` | Retrieve the inner Component instance. Only available for Class-based components. |

--- a/src/components/PropProvider/propConnect.tsx
+++ b/src/components/PropProvider/propConnect.tsx
@@ -10,9 +10,11 @@ import {
   isComponentNamespaced,
 } from '../../utilities/component'
 import { isDefined, isString } from '../../utilities/is'
+import { noop } from '../../utilities/other'
 
 export interface Props {
   className?: string
+  wrappedRef: (inst: any) => void
   style: Object
 }
 
@@ -47,6 +49,7 @@ function propConnect(name?: ConfigGetter, options: Object = {}) {
     class Connect extends OuterBaseComponent<Props> {
       static defaultProps = {
         style: {},
+        wrappedRef: noop,
       }
       static displayName = displayName
 
@@ -59,6 +62,7 @@ function propConnect(name?: ConfigGetter, options: Object = {}) {
 
       setWrappedInstance(ref) {
         this.wrappedInstance = ref
+        this.props.wrappedRef(ref)
       }
 
       getNamespacedProps = (contextProps: PropProviderProps): Object => {
@@ -88,13 +92,14 @@ function propConnect(name?: ConfigGetter, options: Object = {}) {
       }
 
       getMergedProps = (contextProps: PropProviderProps): Object => {
+        const { wrappedRef, ...rest } = this.props
         const namespacedProps = this.getNamespacedProps(contextProps)
         const className = this.getMergedClassNameProp(contextProps)
         const style = this.getMergedStyleProp(contextProps)
 
         return {
           ...namespacedProps,
-          ...this.props,
+          ...rest,
           className,
           style,
           [propProviderDataAttr]: getGlobalApp(contextProps),


### PR DESCRIPTION
## propConnect: Add wrappedRef

![](https://media.giphy.com/media/l0IycQmt79g9XzOWQ/giphy.gif)

This update adds a new `wrappedRef` prop to `propConnect`, which allows for consumers
to retrieve the original component instance of a connected component.

🍐 'ed on this with @knicklabs !