### PR TITLE
ChatScroller: Fix reference for scrollableNode

### DIFF
--- a/src/components/ChatScroller/ChatScroller.tsx
+++ b/src/components/ChatScroller/ChatScroller.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import getDocumentFromComponent from '@helpscout/react-utils/dist/getDocumentFromComponent'
+import * as ReactDOM from 'react-dom'
 import propConnect from '../PropProvider/propConnect'
 import { smoothScrollTo } from '../../utilities/smoothScroll'
 import { last } from '../../utilities/arrays'
@@ -20,6 +20,7 @@ export interface Props {
   onScroll: (...args: any) => void
   scrollCondition: (...args: any) => void
   scrollableSelector: string
+  scrollableNode: null
   smoothScrollDuration: number
 }
 
@@ -35,8 +36,8 @@ export class ChatScroller extends React.PureComponent<Props> {
     smoothScrollDuration: 100,
   }
 
-  document: Document
   childRef: any = null
+  node: any = null
   scrollableNode: any = null
 
   componentDidMount() {
@@ -116,15 +117,15 @@ export class ChatScroller extends React.PureComponent<Props> {
     if (!this.scrollableNode) return
 
     smoothScrollTo(scrollProps)
-    this.props.onScroll()
+    this.props.onScroll({ target: this.scrollableNode })
   }
 
   setNodes() {
-    this.document = getDocumentFromComponent(this.childRef) || document
+    this.node = ReactDOM.findDOMNode(this.childRef)
 
-    this.scrollableNode = this.document.querySelector(
-      this.props.scrollableSelector
-    )
+    this.scrollableNode =
+      this.props.scrollableNode ||
+      (this.node && this.node.querySelector(this.props.scrollableSelector))
   }
 
   setChildNodeRef = ref => (this.childRef = ref)

--- a/src/components/ChatScroller/README.md
+++ b/src/components/ChatScroller/README.md
@@ -12,15 +12,16 @@ A ChatScroller component is light-weight wrapper automatically scrolls a Chat bo
 
 ## Props
 
-| Prop                  | Type       | Description                                            |
-| --------------------- | ---------- | ------------------------------------------------------ |
-| className             | `string`   | Custom class names to be added to the component.       |
-| distanceForAutoScroll | `number`   | A range to enable auto-scrolling.                      |
-| isTyping              | `bool`     | A chat-based event used to trigger auto-scrolling.     |
-| lastMessageId         | `string`   | Chat data used to trigger auto-scrolling.              |
-| messages              | `array`    | Chat data used to trigger auto-scrolling.              |
-| messageSelectors      | `string`   | DOM selector(s) for chat message elements.             |
-| onScroll              | `function` | Callback function when component is scrolled.          |
-| propsToCheck          | `Array`    | A collection of props to check to initiate the scroll. |
-| scrollableSelector    | `string`   | DOM selector for the scrollable message container.     |
-| smoothScrollDuration  | `number`   | Duration (ms) for smooth scrolling.                    |
+| Prop                  | Type          | Description                                            |
+| --------------------- | ------------- | ------------------------------------------------------ |
+| className             | `string`      | Custom class names to be added to the component.       |
+| distanceForAutoScroll | `number`      | A range to enable auto-scrolling.                      |
+| isTyping              | `bool`        | A chat-based event used to trigger auto-scrolling.     |
+| lastMessageId         | `string`      | Chat data used to trigger auto-scrolling.              |
+| messages              | `array`       | Chat data used to trigger auto-scrolling.              |
+| messageSelectors      | `string`      | DOM selector(s) for chat message elements.             |
+| onScroll              | `function`    | Callback function when component is scrolled.          |
+| propsToCheck          | `Array`       | A collection of props to check to initiate the scroll. |
+| scrollableNode        | `HTMLElement` | DOM Element to check for scrolling.                    |
+| scrollableSelector    | `string`      | DOM selector for the scrollable message container.     |
+| smoothScrollDuration  | `number`      | Duration (ms) for smooth scrolling.                    |

--- a/src/components/ChatScroller/__tests__/ChatScroller.test.js
+++ b/src/components/ChatScroller/__tests__/ChatScroller.test.js
@@ -43,6 +43,19 @@ describe('Nodes', () => {
 
     expect(node).toBeFalsy()
   })
+
+  test('Can set scrollableNode if defined', () => {
+    const el = document.createElement('div')
+    const wrapper = mount(
+      <ChatScroller scrollableNode={el}>
+        <div />
+      </ChatScroller>
+    )
+
+    const node = wrapper.instance().scrollableNode
+
+    expect(node).toBe(el)
+  })
 })
 
 describe('getLatestMessageNode', () => {


### PR DESCRIPTION
## ChatScroller: Fix reference for scrollableNode
![](https://i.giphy.com/media/vvWhQsVAFkyisScAsM/giphy.webp)

This update fixes ChatScroller to ensure that it references the correct scrollable
node.