### PR TITLE
ChatScroller: Re-add ability to target an outer selector

### DIFF
--- a/src/components/ChatScroller/ChatScroller.tsx
+++ b/src/components/ChatScroller/ChatScroller.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
+import getDocumentFromComponent from '@helpscout/react-utils/dist/getDocumentFromComponent'
 import propConnect from '../PropProvider/propConnect'
 import { smoothScrollTo } from '../../utilities/smoothScroll'
 import { last } from '../../utilities/arrays'
@@ -36,9 +37,10 @@ export class ChatScroller extends React.PureComponent<Props> {
     smoothScrollDuration: 100,
   }
 
-  childRef: any = null
-  node: any = null
-  scrollableNode: any = null
+  childRef: any
+  document: Document
+  node: any
+  scrollableNode: any
 
   componentDidMount() {
     this.setNodes()
@@ -122,10 +124,12 @@ export class ChatScroller extends React.PureComponent<Props> {
 
   setNodes() {
     this.node = ReactDOM.findDOMNode(this.childRef)
+    this.document = getDocumentFromComponent(this.node)
+    const innerNode =
+      this.node && this.node.querySelector(this.props.scrollableSelector)
+    const outerNode = this.document.querySelector(this.props.scrollableSelector)
 
-    this.scrollableNode =
-      this.props.scrollableNode ||
-      (this.node && this.node.querySelector(this.props.scrollableSelector))
+    this.scrollableNode = this.props.scrollableNode || innerNode || outerNode
   }
 
   setChildNodeRef = ref => (this.childRef = ref)

--- a/stories/ChatScroller.stories.js
+++ b/stories/ChatScroller.stories.js
@@ -104,6 +104,7 @@ stories.add('Custom selector', () => {
             <ChatScroller
               messages={this.state.messages}
               isTyping={this.state.isTyping}
+              scrollableSelector=".custom .c-Scrollable__content"
             >
               <div style={{ display: 'flex', height: '100%', width: '100%' }}>
                 <div style={{ padding: '0 15px' }}>


### PR DESCRIPTION
## ChatScroller: Re-add ability to target an outer selector

![screen recording 2019-01-04 at 12 37 pm](https://user-images.githubusercontent.com/2322354/50702420-e6473380-101e-11e9-9ee8-2f8cf8ec7860.gif)


This update re-adds the ability for ChatScroller to reference a DOM element
that may exist outside of it's contents.

The order of operations flows like:

1. Specified DOM Node (via `scrollableNode`)
2. Child `scrollableSelector` query
3. Document `scrollableSelector` query

Note: Document is iFrame friendly as it references the `document` containing
`ChatScroller` rather than assuming `window.document`.