### PR TITLE
Input: Reduce suffix error icon margin

### DIFF
--- a/src/components/Input/styles/Input.css.js
+++ b/src/components/Input/styles/Input.css.js
@@ -127,7 +127,7 @@ export const InlinePrefixSuffixUI = styled('div')`
     }
   }
 
-  &.is-prefix {
+  &.is-suffix {
     &.is-icon {
       margin-right: -8px;
     }


### PR DESCRIPTION
## Input: Reduce suffix error icon margin

This update fixes the (right) margin for error icons that appear within
`Input` and `Select` components.

The issue came from a typo where the style selector was `is-prefix`, but
needed to be `is-suffix`.

#### Before:
![screen shot 2019-01-09 at 1 58 36 pm](https://user-images.githubusercontent.com/2322354/50921818-ea0bf900-1416-11e9-9521-0e16c2185530.png)

#### After:

![screen shot 2019-01-09 at 1 58 27 pm](https://user-images.githubusercontent.com/2322354/50921827-eed0ad00-1416-11e9-90a0-2e382213d016.png)
