### PR TITLE
Select: Adjust error icon alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.5.11-0",
+  "version": "2.5.11-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.5.10",
+  "version": "2.5.11-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.5.10",
+  "version": "2.5.11-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.5.11-0",
+  "version": "2.5.11-1",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/Select/Select.css.ts
+++ b/src/components/Select/Select.css.ts
@@ -28,7 +28,7 @@ export const ItemUI = styled('div')`
   z-index: 1;
 
   &.is-icon {
-    margin-right: -5px;
+    margin-right: -4px;
   }
 `
 

--- a/src/components/Select/Select.css.ts
+++ b/src/components/Select/Select.css.ts
@@ -26,6 +26,10 @@ export const SelectUI = styled('div')`
 export const ItemUI = styled('div')`
   position: relative;
   z-index: 1;
+
+  &.is-icon {
+    margin-right: -5px;
+  }
 `
 
 export const FieldUI = styled('select')`


### PR DESCRIPTION
## Select: Adjust error icon alignment

![screen shot 2019-01-09 at 3 21 27 pm](https://user-images.githubusercontent.com/2322354/50926129-40326980-1422-11e9-9ce1-d9c15a0520e0.png)

This update adjusts the alignment of the "error" icon that appears
on the right of a `Select` component. The adjustment was to reduce the
right margin, to ensure that it lines up correctly next to `Input` components
in error states.