### PR TITLE
ChatScroller: Reset Nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.5.11",
+  "version": "2.5.12-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.5.11",
+  "version": "2.5.12-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/ChatScroller/ChatScroller.tsx
+++ b/src/components/ChatScroller/ChatScroller.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import getDocumentFromComponent from '@helpscout/react-utils/dist/getDocumentFromComponent'
+import getShallowDiffs from '@helpscout/react-utils/dist/getShallowDiffs'
 import propConnect from '../PropProvider/propConnect'
 import { smoothScrollTo } from '../../utilities/smoothScroll'
-import { last } from '../../utilities/arrays'
+import { last, includes } from '../../utilities/arrays'
 import { allDefined } from '../../utilities/check'
 import { noop } from '../../utilities/other'
 import { COMPONENT_KEY } from './ChatScroller.utils'
@@ -49,6 +50,8 @@ export class ChatScroller extends React.PureComponent<Props> {
   }
 
   componentDidUpdate(prevProps) {
+    this.resetNodes(prevProps)
+
     if (this.shouldScrollOnUpdate(prevProps)) {
       this.autoScrollToLatestMessage()
     }
@@ -56,6 +59,18 @@ export class ChatScroller extends React.PureComponent<Props> {
       prevProps.forceScrollToBottomProp !== this.props.forceScrollToBottomProp
     ) {
       this.forceScrollToBottom()
+    }
+  }
+
+  resetNodes(nextProps) {
+    const { diffs } = getShallowDiffs(nextProps, this.props)
+
+    if (!diffs.length) return
+
+    const matches = ['scrollableSelector', 'scrollableNode']
+
+    if (diffs.some(item => includes(matches, item))) {
+      this.setNodes()
     }
   }
 

--- a/src/components/ChatScroller/__tests__/ChatScroller.test.js
+++ b/src/components/ChatScroller/__tests__/ChatScroller.test.js
@@ -56,6 +56,54 @@ describe('Nodes', () => {
 
     expect(node).toBe(el)
   })
+
+  test('Can reset scrollableNode on scrollableNode prop change', () => {
+    const el = document.createElement('div')
+    const nextEl = document.createElement('span')
+    const wrapper = mount(
+      <ChatScroller scrollableNode={el}>
+        <div />
+      </ChatScroller>
+    )
+
+    wrapper.setProps({ scrollableNode: nextEl })
+
+    const node = wrapper.instance().scrollableNode
+
+    expect(node).not.toBe(el)
+    expect(node).toBe(nextEl)
+  })
+
+  test('Can reset scrollableNode on scrollableSelector prop change', () => {
+    const wrapper = mount(
+      <ChatScroller scrollableSelector=".derek">
+        <div>
+          <div className="derek" />
+          <div className="hansel" />
+        </div>
+      </ChatScroller>
+    )
+
+    wrapper.setProps({ scrollableSelector: '.hansel' })
+    const node = wrapper.instance().scrollableNode
+
+    expect(node.classList.contains('hansel')).toBe(true)
+  })
+
+  test('scrollableNode does not reset on unrelated prop changes', () => {
+    const el = document.createElement('div')
+    const wrapper = mount(
+      <ChatScroller scrollableNode={el}>
+        <div />
+      </ChatScroller>
+    )
+
+    wrapper.setProps({ title: 'Hello!' })
+
+    const node = wrapper.instance().scrollableNode
+
+    expect(node).toBe(el)
+  })
 })
 
 describe('getLatestMessageNode', () => {


### PR DESCRIPTION
## ChatScroller: Reset Nodes

![](https://media.giphy.com/media/sChf4Eo55W8x2/giphy.gif "Reset!")

This update allows for `ChatScroller` to reset it's target DOM node when
either the `scrollableNode` or `scrollableSelector` props are updated.

Previously, the method to set the DOM node only ran during initialization.
With this update, `ChatScroller` is now able to observe different nodes
during it's lifecycle, depending on the implementation.