### PR TITLE
Input: Resizer - Recalculate height on mount

### DIFF
--- a/src/components/Input/__tests__/Resizer.test.js
+++ b/src/components/Input/__tests__/Resizer.test.js
@@ -122,3 +122,15 @@ describe('offsetAmount', () => {
     expect(chars).not.toContain('R')
   })
 })
+
+describe('isMounted/didMount', () => {
+  test('Unsets _isMounted on unmount', () => {
+    const wrapper = mount(<Resizer offsetAmount={5} />)
+    const inst = wrapper.instance()
+
+    expect(inst._isMounted).toBe(true)
+
+    wrapper.unmount()
+    expect(inst._isMounted).toBe(false)
+  })
+})


### PR DESCRIPTION
## Input: Resizer - Recalculate height on mount

![](https://media.giphy.com/media/l396Sok6H728brWlG/giphy.gif)

This update enhanced `Input.Resizer` to recalculate it's height on mount behind
a `requestAnimationFrame` call. This is to help ensure correct height values when
loaded into a heavier page/component (computation wise).

`Input.Resizer` has also been converted to Typescript, with minor performance/render
refactors for how it handles defining instance variables.