### PR TITLE
Fancy: Update to polyfill WeakMap for IE11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4934,9 +4934,9 @@
       }
     },
     "@helpscout/fancy": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.2.2.tgz",
-      "integrity": "sha512-keZ7TEty9Dt7w+9aAWsCIKi1MWDhwGh2rGZbrHH2EFSlHmXfkTo6RZUWbwwx/ymR/qbcXbAVFowftLI6c1wIjA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.2.3.tgz",
+      "integrity": "sha512-AzarCxL1apJ7qxNb9Qj46QcrW6wipT0qNyIDYbAIeG4yxUCB9ZXiM7XSGayXwNRrJ3X4vaFy6MPzrf0nbHkjDQ==",
       "requires": {
         "@emotion/hash": "0.6.6",
         "@emotion/memoize": "0.6.6",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-dom": "^16 || ^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "2.2.2",
+    "@helpscout/fancy": "2.2.3",
     "@helpscout/react-utils": "1.0.6",
     "@helpscout/wedux": "0.0.10",
     "@seedcss/seed-button": "0.0.6",


### PR DESCRIPTION
## Fancy: Update to polyfill WeakMap for IE11

This update bumps Fancy to v2.2.3, which adds a slim Poyfill for WeakMap to
resolve IE11 issues. Fancy's core, `create-emotion`, uses a WeakMap as a cache
for certain generated styles.