### PR TITLE
Input/Select: Firefox text/selection fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4934,9 +4934,9 @@
       }
     },
     "@helpscout/fancy": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.2.3.tgz",
-      "integrity": "sha512-AzarCxL1apJ7qxNb9Qj46QcrW6wipT0qNyIDYbAIeG4yxUCB9ZXiM7XSGayXwNRrJ3X4vaFy6MPzrf0nbHkjDQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.2.4.tgz",
+      "integrity": "sha512-SbASkoCWsH668FB8QDSbPQsjk7MZUVa8Er9yWMrm6VcxVgXE+gy8MzfU5mB+/Mu8317MIyRtNAzAmfi/iz2yJQ==",
       "requires": {
         "@emotion/hash": "0.6.6",
         "@emotion/memoize": "0.6.6",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-dom": "^16 || ^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "2.2.3",
+    "@helpscout/fancy": "2.2.4",
     "@helpscout/react-utils": "1.0.6",
     "@helpscout/wedux": "0.0.10",
     "@seedcss/seed-button": "0.0.6",

--- a/src/components/Input/styles/Input.css.js
+++ b/src/components/Input/styles/Input.css.js
@@ -213,11 +213,6 @@ export function makeFieldStyles(): string {
     ${makeSizeStyles()};
     ${makeStateStyles()};
 
-    @-moz-document url-prefix() {
-      color: transparent;
-      text-shadow: 0 0 0 black;
-    }
-
     &.is-resizable {
       resize: vertical !important;
     }

--- a/src/components/Select/Select.css.ts
+++ b/src/components/Select/Select.css.ts
@@ -33,6 +33,8 @@ export const ItemUI = styled('div')`
 `
 
 export const FieldUI = styled('select')`
+  ${getFirefoxStyles()};
+
   &.c-InputField {
     ${makeFieldStyles};
     padding-left: 8px;
@@ -85,3 +87,14 @@ export const SelectArrowsUI = styled('div')`
     right: 40px;
   }
 `
+
+function getFirefoxStyles() {
+  // Removes outline in Firefox
+  // https://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/11603104#11603104
+  return `
+    @-moz-document url-prefix() {
+      color: transparent !important;
+      text-shadow: 0 0 0 black !important;
+    }
+  `
+}


### PR DESCRIPTION
## Input/Select: Firefox text/selection fixes

![screen recording 2019-01-17 at 11 12 am](https://user-images.githubusercontent.com/2322354/51332308-82266580-1a49-11e9-9d70-bbef1b638ecf.gif)

(GIF shows Firefox rendering for Select and Input)

This update resolves the cursor rendering issue for Firefox. The select
border styles were accidentally added for `Input`. It has now been moved
to target just `Select` fields.