### PR TITLE
Enable Programmatic Control of Accordion Sections

### DIFF
--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -48,6 +48,11 @@ const buildOpenSections = sectionIds =>
     {}
   )
 
+const stringifyArray = arr => arr.sort().toString()
+
+const didOpenSectionIdsChange = (prevSectionIds, nextSectionIds) =>
+  stringifyArray(prevSectionIds) !== stringifyArray(nextSectionIds)
+
 class Accordion extends PureComponent<AccordionProps, AccordionState> {
   static Body = Body
   static Section = Section
@@ -65,7 +70,12 @@ class Accordion extends PureComponent<AccordionProps, AccordionState> {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.forceSetOpen(nextProps)
+    const { openSectionIds: nextOpenSectionIds } = nextProps
+    const { openSectionIds: prevOpenSectionIds } = this.props
+
+    if (didOpenSectionIdsChange(prevOpenSectionIds, nextOpenSectionIds)) {
+      this.forceSetOpen(nextProps)
+    }
   }
 
   forceSetOpen({ openSectionIds }) {

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -39,7 +39,7 @@ const getComponentClassName = ({
   )
 }
 
-const buildOpenSections = (sectionIds = []) =>
+const buildOpenSections = sectionIds =>
   sectionIds.reduce(
     (accumulator, id) => ({
       ...accumulator,

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -1,6 +1,6 @@
 // @flow
 import type { AccordionProps, AccordionState } from './types'
-import React, { cloneElement, Children, Component } from 'react'
+import React, { cloneElement, Children, PureComponent } from 'react'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import Body from './Body'
 import Section from './Section'
@@ -39,7 +39,16 @@ const getComponentClassName = ({
   )
 }
 
-class Accordion extends Component<AccordionProps, AccordionState> {
+const buildOpenSections = (sectionIds = []) =>
+  sectionIds.reduce(
+    (accumulator, id) => ({
+      ...accumulator,
+      [id]: true,
+    }),
+    {}
+  )
+
+class Accordion extends PureComponent<AccordionProps, AccordionState> {
   static Body = Body
   static Section = Section
   static Title = Title
@@ -47,11 +56,43 @@ class Accordion extends Component<AccordionProps, AccordionState> {
   static defaultProps = {
     onOpen: noop,
     onClose: noop,
+    openSectionIds: [],
     size: 'md',
   }
 
-  state = {
-    sections: {},
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      sections: buildOpenSections(props.openSectionIds),
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.forceSetOpen(nextProps)
+  }
+
+  forceSetOpen({ openSectionIds }) {
+    const sections = buildOpenSections(openSectionIds)
+    this.setState({ sections })
+  }
+
+  getOpenSectionIds() {
+    const { sections } = this.state
+    return Object.keys(sections).reduce((accumulator, key) => {
+      if (sections[key] && sections[key] === true) {
+        return [...accumulator, key]
+      }
+      return accumulator
+    }, [])
+  }
+
+  onClose = uuid => {
+    this.props.onClose(uuid, this.getOpenSectionIds())
+  }
+
+  onOpen = uuid => {
+    this.props.onOpen(uuid, this.getOpenSectionIds())
   }
 
   setOpen = (uuid: string, isOpen: boolean) => {
@@ -77,8 +118,6 @@ class Accordion extends Component<AccordionProps, AccordionState> {
       className,
       children,
       duration,
-      onOpen,
-      onClose,
       isPage,
       isSeamless,
       size,
@@ -90,8 +129,8 @@ class Accordion extends Component<AccordionProps, AccordionState> {
       duration,
       isPage,
       isSeamless,
-      onOpen,
-      onClose,
+      onOpen: this.onOpen,
+      onClose: this.onClose,
       sections,
       setOpen: this.setOpen,
       size,

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -60,12 +60,8 @@ class Accordion extends PureComponent<AccordionProps, AccordionState> {
     size: 'md',
   }
 
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      sections: buildOpenSections(props.openSectionIds),
-    }
+  state = {
+    sections: buildOpenSections(this.props.openSectionIds),
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/components/Accordion/Section.js
+++ b/src/components/Accordion/Section.js
@@ -42,11 +42,16 @@ class Section extends Component<SectionProps> {
     setOpen: noop,
   }
 
+  getId() {
+    const { id, uuid } = this.props
+    return id || uuid
+  }
+
   render() {
     const {
-      uuid,
       className,
       duration,
+      id,
       isPage,
       isSeamless,
       children,
@@ -55,11 +60,13 @@ class Section extends Component<SectionProps> {
       sections,
       setOpen,
       size,
+      uuid,
       ...rest
     } = this.props
 
+    const sectionId = this.getId()
     const isOpen = Object.keys(sections).length
-      ? sections[uuid]
+      ? sections[sectionId]
       : this.props.isOpen
     const componentClassName = getComponentClassName({ ...this.props, isOpen })
     const extraChildProps = {
@@ -69,7 +76,7 @@ class Section extends Component<SectionProps> {
       isPage,
       isSeamless,
       size,
-      uuid,
+      uuid: sectionId,
     }
 
     const content =

--- a/src/components/Accordion/__tests__/Accordion.test.js
+++ b/src/components/Accordion/__tests__/Accordion.test.js
@@ -123,30 +123,48 @@ describe('State', () => {
     wrapper.setProps({ openSectionIds: [] })
     expect(wrapper.state('sections')).toEqual({})
   })
+})
 
-  describe('onOpen', () => {
-    test('It should pass an array of open section ids as the second argument to the callback', () => {
-      const spy = jest.fn()
-      const wrapper = mount(<Accordion onOpen={spy} openSectionIds={[1, 2]} />)
-      const instance = wrapper.instance()
-      instance.onOpen(1)
-      expect(spy).toHaveBeenCalledWith(1, ['1', '2'])
-      wrapper.setState({ sections: { 6: true, 7: false } })
-      instance.onOpen(1)
-      expect(spy).toHaveBeenCalledWith(1, ['6'])
-    })
+describe('forceSetOpen', () => {
+  test('It should invoke forceSetOpen if the openSectionIds change', () => {
+    const wrapper = mount(<Accordion openSectionIds={[1, 2]} />)
+    const instance = wrapper.instance()
+    const spy = jest.spyOn(instance, 'forceSetOpen')
+    wrapper.setProps({ openSectionIds: [3, 4] })
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  describe('onClose', () => {
-    test('It should pass an array of open section ids as the second argument to the callback', () => {
-      const spy = jest.fn()
-      const wrapper = mount(<Accordion onClose={spy} openSectionIds={[1, 2]} />)
-      const instance = wrapper.instance()
-      instance.onClose(1)
-      expect(spy).toHaveBeenCalledWith(1, ['1', '2'])
-      wrapper.setProps({ openSectionIds: [6] })
-      instance.onClose(1)
-      expect(spy).toHaveBeenCalledWith(1, ['6'])
-    })
+  test('It should not invoke forceSetOpen if the openSectionIds did not change', () => {
+    const wrapper = mount(<Accordion openSectionIds={[1, 2]} />)
+    const instance = wrapper.instance()
+    const spy = jest.spyOn(instance, 'forceSetOpen')
+    wrapper.setProps({ size: 'lg' })
+    expect(spy).not.toHaveBeenCalled()
+  })
+})
+
+describe('onOpen', () => {
+  test('It should pass an array of open section ids as the second argument to the callback', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Accordion onOpen={spy} openSectionIds={[1, 2]} />)
+    const instance = wrapper.instance()
+    instance.onOpen(1)
+    expect(spy).toHaveBeenCalledWith(1, ['1', '2'])
+    wrapper.setState({ sections: { 6: true, 7: false } })
+    instance.onOpen(1)
+    expect(spy).toHaveBeenCalledWith(1, ['6'])
+  })
+})
+
+describe('onClose', () => {
+  test('It should pass an array of open section ids as the second argument to the callback', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Accordion onClose={spy} openSectionIds={[1, 2]} />)
+    const instance = wrapper.instance()
+    instance.onClose(1)
+    expect(spy).toHaveBeenCalledWith(1, ['1', '2'])
+    wrapper.setProps({ openSectionIds: [6] })
+    instance.onClose(1)
+    expect(spy).toHaveBeenCalledWith(1, ['6'])
   })
 })

--- a/src/components/Accordion/__tests__/Accordion.test.js
+++ b/src/components/Accordion/__tests__/Accordion.test.js
@@ -114,4 +114,39 @@ describe('State', () => {
     instance.setOpen('456', true)
     expect(wrapper.state('sections')).toEqual({ '123': true, '456': true })
   })
+
+  test('It should track the value of all programatically opened sections', () => {
+    const wrapper = mount(<Accordion openSectionIds={[1, 2]} />)
+    expect(wrapper.state('sections')).toEqual({ 1: true, 2: true })
+    wrapper.setProps({ openSectionIds: [4, 5, 6] })
+    expect(wrapper.state('sections')).toEqual({ 4: true, 5: true, 6: true })
+    wrapper.setProps({ openSectionIds: [] })
+    expect(wrapper.state('sections')).toEqual({})
+  })
+
+  describe('onOpen', () => {
+    test('It should pass an array of open section ids as the second argument to the callback', () => {
+      const spy = jest.fn()
+      const wrapper = mount(<Accordion onOpen={spy} openSectionIds={[1, 2]} />)
+      const instance = wrapper.instance()
+      instance.onOpen(1)
+      expect(spy).toHaveBeenCalledWith(1, ['1', '2'])
+      wrapper.setProps({ openSectionIds: [6] })
+      instance.onOpen(1)
+      expect(spy).toHaveBeenCalledWith(1, ['6'])
+    })
+  })
+
+  describe('onClose', () => {
+    test('It should pass an array of open section ids as the second argument to the callback', () => {
+      const spy = jest.fn()
+      const wrapper = mount(<Accordion onClose={spy} openSectionIds={[1, 2]} />)
+      const instance = wrapper.instance()
+      instance.onClose(1)
+      expect(spy).toHaveBeenCalledWith(1, ['1', '2'])
+      wrapper.setProps({ openSectionIds: [6] })
+      instance.onClose(1)
+      expect(spy).toHaveBeenCalledWith(1, ['6'])
+    })
+  })
 })

--- a/src/components/Accordion/__tests__/Accordion.test.js
+++ b/src/components/Accordion/__tests__/Accordion.test.js
@@ -131,7 +131,7 @@ describe('State', () => {
       const instance = wrapper.instance()
       instance.onOpen(1)
       expect(spy).toHaveBeenCalledWith(1, ['1', '2'])
-      wrapper.setProps({ openSectionIds: [6] })
+      wrapper.setState({ sections: { 6: true, 7: false } })
       instance.onOpen(1)
       expect(spy).toHaveBeenCalledWith(1, ['6'])
     })

--- a/src/components/Accordion/__tests__/Section.test.js
+++ b/src/components/Accordion/__tests__/Section.test.js
@@ -54,7 +54,7 @@ describe('Uuid', () => {
 })
 
 describe('isOpen', () => {
-  test('Determines if it is open if sections includes itself', () => {
+  test('Determines if it is open if sections includes its uuid', () => {
     const wrapper = mount(<Section />)
     const uuid = wrapper.state('uuid')
     let el = wrapper.find(`div.${classNames.baseComponentClassName}`)
@@ -62,6 +62,19 @@ describe('isOpen', () => {
     expect(el.hasClass(classNames.isOpenClassName)).toBe(false)
 
     wrapper.setProps({ sections: { [uuid]: true } })
+
+    el = wrapper.find(`div.${classNames.baseComponentClassName}`)
+
+    expect(el.hasClass(classNames.isOpenClassName)).toBe(true)
+  })
+
+  test('Determines if it is open if sections includes its id', () => {
+    const wrapper = mount(<Section id="7" />)
+    let el = wrapper.find(`div.${classNames.baseComponentClassName}`)
+
+    expect(el.hasClass(classNames.isOpenClassName)).toBe(false)
+
+    wrapper.setProps({ sections: { '7': true } })
 
     el = wrapper.find(`div.${classNames.baseComponentClassName}`)
 

--- a/src/components/Accordion/docs/Accordion.md
+++ b/src/components/Accordion/docs/Accordion.md
@@ -30,12 +30,13 @@ inner `Body` expanded simultaneously.
 
 ## Props
 
-| Prop          | Type                  | Description                                                         |
-| ------------- | --------------------- | ------------------------------------------------------------------- |
-| allowMultiple | `boolean`             | Allows multipe sections to have their body revealed simultaneously. |
-| children      | `Accordion.Section[]` | Sections to be stacked and controled.                               |
-| className     | `string`              | Custom class names to be added to the component.                    |
-| isSeamless    | `boolean`             | Exlude borders and horizontal padding.                              |
-| onOpen        | `function`            | Callback to be invoked when the body of a section is revealed.      |
-| onClose       | `function`            | Callback to be invoked when the body of a section is concealed.     |
-| size          | `string`              | The amount of padding. Valid sizes are `xs`, `sm`, `md`, and `lg`.  |
+| Prop           | Type                  | Description                                                         |
+| -------------- | --------------------- | ------------------------------------------------------------------- |
+| allowMultiple  | `boolean`             | Allows multipe sections to have their body revealed simultaneously. |
+| children       | `Accordion.Section[]` | Sections to be stacked and controled.                               |
+| className      | `string`              | Custom class names to be added to the component.                    |
+| isSeamless     | `boolean`             | Exlude borders and horizontal padding.                              |
+| onOpen         | `function`            | Callback to be invoked when the body of a section is revealed.      |
+| onClose        | `function`            | Callback to be invoked when the body of a section is concealed.     |
+| openSectionIds | `array`               | An array of ids corresponding to sections that should be open.      |
+| size           | `string`              | The amount of padding. Valid sizes are `xs`, `sm`, `md`, and `lg`.  |

--- a/src/components/Accordion/docs/Section.md
+++ b/src/components/Accordion/docs/Section.md
@@ -4,6 +4,11 @@ This component is part of the graphical control element that is the `Accordion`.
 The `Section` houses a `Title` and `Body`. When the `Section` is open its
 `Body` is expanded, otherwise its `Body` is collapsed.
 
+Each section is assigned an auto-generated uuid which is used to track the
+open state of the section. You may optionally set an `id` prop which will be
+used instead of the uuid. This allows for programatic control of accordion
+sections using known id values.
+
 This component is to be used within an [`Accordion`](./Accordion.md).
 
 ## Example
@@ -21,5 +26,6 @@ This component is to be used within an [`Accordion`](./Accordion.md).
 | --------- | -------------------------------- | -------------------------------------------------- |
 | children  | `Accordion.Title|Accordion.Body` | Content to render.                                 |
 | className | `string`                         | Custom class names to be added to the component.   |
+| id        | `string`                         | The id used to track the section's open state.     |
 | onOpen    | `function`                       | Callback to be invoked when the section is opened. |
 | onClose   | `function`                       | Callback to be invoked when the section is closed. |

--- a/src/components/Accordion/types.js
+++ b/src/components/Accordion/types.js
@@ -14,6 +14,7 @@ export type AccordionProps = {
   isSeamless?: boolean,
   onOpen?: (uuid: string) => void,
   onClose?: (uuid: string) => void,
+  openSectionIds?: array,
   size?: Sizes
 }
 
@@ -38,6 +39,7 @@ export type SectionProps = {
   children: ChildrenArray<Element<typeof Title|Body>>,
   className?: string,
   duration?: number,
+  id?: string,
   isPage?: boolean,
   isSeamless?: boolean,
   onOpen?: (uuid: string) => void,

--- a/stories/Accordion.stories.js
+++ b/stories/Accordion.stories.js
@@ -31,9 +31,14 @@ const data = [
   { title: 'Section 4', body },
 ]
 
-const createSections = () =>
+const dataWithIds = data.map((item, index) => ({
+  ...item,
+  id: index + 1,
+}))
+
+const createSections = data =>
   data.map((datum, index) => (
-    <Accordion.Section key={index}>
+    <Accordion.Section key={index} id={datum.id}>
       <Accordion.Title>
         <Text truncate weight={700}>
           {datum.title}
@@ -48,41 +53,135 @@ const onClose = id => console.log('Close', id)
 
 stories.add('default', () => (
   <Accordion onOpen={onOpen} onClose={onClose}>
-    {createSections()}
+    {createSections(data)}
   </Accordion>
 ))
 
 stories.add('extra small', () => (
   <Accordion onOpen={onOpen} onClose={onClose} size="xs">
-    {createSections()}
+    {createSections(data)}
   </Accordion>
 ))
 
 stories.add('small', () => (
   <Accordion onOpen={onOpen} onClose={onClose} size="sm">
-    {createSections()}
+    {createSections(data)}
   </Accordion>
 ))
 
 stories.add('large', () => (
   <Accordion onOpen={onOpen} onClose={onClose} size="lg">
-    {createSections()}
+    {createSections(data)}
   </Accordion>
 ))
 
 stories.add('allow multiple', () => (
-  <Accordion allowMultiple>{createSections()}</Accordion>
+  <Accordion allowMultiple>{createSections(data)}</Accordion>
 ))
 
 stories.add('is seamless', () => (
-  <Accordion isSeamless>{createSections()}</Accordion>
+  <Accordion isSeamless>{createSections(data)}</Accordion>
 ))
 
 stories.add('is seamless in page', () => (
   <Page title="Accordion">
     <Page.Card>
       <Page.Header title="Accordion" subtitle="In seamless mode" />
-      <Accordion>{createSections()}</Accordion>
+      <Accordion>{createSections(data)}</Accordion>
     </Page.Card>
   </Page>
 ))
+
+stories.add('uses custom ids', () => {
+  class AccordionWithCustomIds extends React.Component {
+    state = {
+      value: 3,
+    }
+
+    handleChange = e => {
+      this.updateSectionId(e.target.value)
+    }
+
+    updateSectionId = value => {
+      this.setState({
+        value: parseInt(value, 10),
+      })
+    }
+
+    render() {
+      const { value } = this.state
+
+      return (
+        <div>
+          <form
+            onSubmit={e => e.preventDefault()}
+            style={{ marginBottom: '10px' }}
+          >
+            <input
+              interval="1"
+              min="1"
+              max="4"
+              onChange={this.handleChange}
+              type="number"
+              value={value}
+              style={{ width: '100px' }}
+            />
+          </form>
+          <Accordion onOpen={this.updateSectionId} openSectionIds={[value]}>
+            {createSections(dataWithIds)}
+          </Accordion>
+        </div>
+      )
+    }
+  }
+
+  return <AccordionWithCustomIds />
+})
+
+stories.add('uses multiple custom ids', () => {
+  class AccordionWithCustomIds extends React.Component {
+    state = {
+      values: [1, 2],
+    }
+
+    handleChange = e => {
+      this.updateSectionIds(e.target.value.split(','))
+    }
+
+    updateSectionIds = values => {
+      this.setState({
+        values,
+      })
+    }
+
+    render() {
+      const { values } = this.state
+
+      return (
+        <div>
+          <form
+            onSubmit={e => e.preventDefault()}
+            style={{ marginBottom: '10px' }}
+          >
+            <select onChange={this.handleChange}>
+              <option value="1,2">1,2</option>
+              <option value="1,4">1,4</option>
+              <option value="3,4">3,4</option>
+            </select>
+          </form>
+          <Accordion
+            allowMultiple
+            onOpen={(uuid, openSectionIds) =>
+              this.updateSectionIds(openSectionIds)
+            }
+            openSectionIds={values}
+          >
+            {createSections(dataWithIds)}
+          </Accordion>
+        </div>
+      )
+    }
+  }
+
+  return <AccordionWithCustomIds />
+})


### PR DESCRIPTION
This update adds support for programatically controlling the sections of an Accordion. The sections can be open and closed by setting/updating the `openSectionIds` property on the `Accordion` component. For each id in the array, the corresponding section will be open. All others, will be closed. 

To achieve this, the `Section` component needed to be updated to allow the library user to set an `id` which supersedes the `uuid` generated by the `Section`. Should an id be provided, that id will be used to track the open/closed state of `Section` in the `Accordion`.

This feature supports programmatically opening open or more Sections at a time. 

Below is an example of one Section being controlled at a time.

![Demo 1](https://d2ddoduugvun08.cloudfront.net/items/3S0e2Y341K1K273L0X0k/Screen%20Recording%202019-01-29%20at%2003.50%20PM.gif?X-CloudApp-Visitor-Id=2338876&v=9a78ffd0)

Below is an example of multiple Sections being controlled at a time.

![Demo 2](https://d2ddoduugvun08.cloudfront.net/items/283H120p0W143r1x390J/Screen%20Recording%202019-01-29%20at%2003.59%20PM.gif?X-CloudApp-Visitor-Id=2338876&v=e47a1985)
