### PR TITLE
Don't render Toolbar Item/Block without any children

### DIFF
--- a/src/components/Toolbar/Block.js
+++ b/src/components/Toolbar/Block.js
@@ -6,6 +6,10 @@ class Block extends Component {
   render() {
     const { className, children, ...rest } = this.props
 
+    if (!children) {
+      return null
+    }
+
     const componentClassName = classNames('c-ToolbarBlock', className)
 
     return (

--- a/src/components/Toolbar/Item.js
+++ b/src/components/Toolbar/Item.js
@@ -6,6 +6,10 @@ class Item extends Component {
   render() {
     const { className, children, ...rest } = this.props
 
+    if (!children) {
+      return null
+    }
+
     const componentClassName = classNames('c-ToolbarItem', className)
 
     return (

--- a/src/components/Toolbar/tests/Block.test.js
+++ b/src/components/Toolbar/tests/Block.test.js
@@ -5,14 +5,22 @@ import { Flexy } from '../../index'
 
 describe('ClassName', () => {
   test('Has default className', () => {
-    const wrapper = shallow(<Block />)
+    const wrapper = shallow(
+      <Block>
+        <div className="mugatu">That Hansel!</div>
+      </Block>
+    )
 
     expect(wrapper.hasClass('c-ToolbarBlock')).toBe(true)
   })
 
   test('Applies custom className if specified', () => {
     const customClass = 'piano-key-neck-tie'
-    const wrapper = shallow(<Block className={customClass} />)
+    const wrapper = shallow(
+      <Block className={customClass}>
+        <div className="mugatu">That Hansel!</div>
+      </Block>
+    )
 
     expect(wrapper.hasClass(customClass)).toBe(true)
   })
@@ -31,9 +39,30 @@ describe('Children', () => {
   })
 })
 
+describe('Childless', () => {
+  test('Renders nothing', () => {
+    const wrapper = shallow(<Block />)
+    const div = wrapper.find('div')
+
+    expect(div.length).toBe(0)
+  })
+
+  test('Renders nothing with null children', () => {
+    const wrapper = shallow(<Block>{null}</Block>)
+    const div = wrapper.find('div')
+
+    expect(div.length).toBe(0)
+  })
+})
+
 describe('Flexy', () => {
   test('Is constructed using Flexy.Block', () => {
-    const wrapper = shallow(<Block />)
+    const wrapper = shallow(
+      <Block>
+        <div className="mugatu">That Hansel!</div>
+      </Block>
+    )
+
     const o = wrapper.find(Flexy.Block)
 
     expect(o.length).toBe(1)

--- a/src/components/Toolbar/tests/Item.test.js
+++ b/src/components/Toolbar/tests/Item.test.js
@@ -5,14 +5,22 @@ import { Flexy } from '../../index'
 
 describe('ClassName', () => {
   test('Has default className', () => {
-    const wrapper = shallow(<Item />)
+    const wrapper = shallow(
+      <Item>
+        <div className="mugatu">That Hansel!</div>
+      </Item>
+    )
 
     expect(wrapper.hasClass('c-ToolbarItem')).toBe(true)
   })
 
   test('Applies custom className if specified', () => {
     const customClass = 'piano-key-neck-tie'
-    const wrapper = shallow(<Item className={customClass} />)
+    const wrapper = shallow(
+      <Item className={customClass}>
+        <div className="mugatu">That Hansel!</div>
+      </Item>
+    )
 
     expect(wrapper.hasClass(customClass)).toBe(true)
   })
@@ -31,9 +39,30 @@ describe('Children', () => {
   })
 })
 
+describe('Childless', () => {
+  test('Renders nothing', () => {
+    const wrapper = shallow(<Item />)
+    const div = wrapper.find('div')
+
+    expect(div.length).toBe(0)
+  })
+
+  test('Renders nothing with null children', () => {
+    const wrapper = shallow(<Item>{null}</Item>)
+    const div = wrapper.find('div')
+
+    expect(div.length).toBe(0)
+  })
+})
+
 describe('Flexy', () => {
   test('Is constructed using Flexy.Item', () => {
-    const wrapper = shallow(<Item />)
+    const wrapper = shallow(
+      <Item>
+        <div className="mugatu">That Hansel!</div>
+      </Item>
+    )
+
     const o = wrapper.find(Flexy.Item)
 
     expect(o.length).toBe(1)


### PR DESCRIPTION
## Don't render Toolbar Item/Block without any children

Some toolbar items in HS App were rendering with no children when we didn't want to show that element. In https://github.com/helpscout/hs-app/pull/6264 I moved the `Toolbar.Item` inside the component so it also wouldn't be rendered but this seemed to be mixing concerns. @TerrenceLJones had the idea of instead changing HSDS to not render if there are no children like we did for other components. 