### PR TITLE
Reduce the size of the title of a preview card

### DIFF
--- a/src/components/PreviewCard/index.js
+++ b/src/components/PreviewCard/index.js
@@ -28,7 +28,7 @@ const PreviewCard = (props: Props) => {
     )
 
     const titleMarkup = title ? (
-      <Heading className="c-PreviewCard__title" size="h5">
+      <Heading className="c-PreviewCard__title" size="h6">
         {title}
       </Heading>
     ) : null

--- a/stories/PreviewCard.stories.js
+++ b/stories/PreviewCard.stories.js
@@ -1,0 +1,7 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { PreviewCard } from '../src/index.js'
+
+storiesOf('PreviewCard', module).add('default', () => (
+  <PreviewCard title="Preview title">Preview content text</PreviewCard>
+))


### PR DESCRIPTION
https://trello.com/c/QT8hg0Se/832-article-and-unfurl-cards-using-font-size-that-is-too-big

Reducing the size of the title of a `PreviewCard`. I also added a Storybook story for this component.

Before:

![screen shot 2019-01-31 at 13 20 45](https://user-images.githubusercontent.com/6132043/52056808-2258b000-255b-11e9-93ff-ba137acc7f64.png)

After:

![screen shot 2019-01-31 at 13 20 35](https://user-images.githubusercontent.com/6132043/52056816-2553a080-255b-11e9-9d67-271de705279f.png)