### PR TITLE
Button: Add support to render link (for href)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21251,6 +21251,11 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "memoize-one": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.0.tgz",
+      "integrity": "sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "compute-scroll-into-view": "1.0.11",
     "dash-get": "1.0.0",
     "highlight.js": "9.12.0",
+    "memoize-one": "^5.0.0",
     "path-to-regexp": "2.4.0",
     "popper.js": "1.14.3",
     "prop-types": "^15",

--- a/src/components/Button/Button.css.js
+++ b/src/components/Button/Button.css.js
@@ -1,9 +1,9 @@
 // @flow
-import baseStyles from '../../../styles/resets/baseStyles.css.js'
-import styled from '../../styled'
-import { getColor } from '../../../styles/utilities/color'
-import forEach from '../../../styles/utilities/forEach'
-import variableFontSize from '../../../styles/utilities/variableFontSize'
+import baseStyles from '../../styles/resets/baseStyles.css.js'
+import styled from '../styled'
+import { getColor } from '../../styles/utilities/color'
+import forEach from '../../styles/utilities/forEach'
+import variableFontSize from '../../styles/utilities/variableFontSize'
 
 export const config = {
   borderRadius: 3,
@@ -181,56 +181,58 @@ export const config = {
   },
 }
 
-export const ButtonUI = styled('button')`
-  ${baseStyles}
-  appearance: none;
-  align-items: center;
-  border: 1px solid transparent;
-  border-radius: ${config.borderRadius}px;
-  cursor: pointer;
-  display: inline-flex;
-  font-weight: normal;
-  height: ${config.size.md.height}px;
-  justify-content: center;
-  line-height: 1;
-  min-width: ${config.size.md.minWidth};
-  outline: none;
-  padding: 0 ${config.size.md.padding}px;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
+export const makeButtonUI = (selector: 'button') => {
+  return styled(selector)`
+    ${baseStyles};
+    appearance: none;
+    align-items: center;
+    border: 1px solid transparent;
+    border-radius: ${config.borderRadius}px;
+    cursor: pointer;
+    display: inline-flex;
+    font-weight: normal;
+    height: ${config.size.md.height}px;
+    justify-content: center;
+    line-height: 1;
+    min-width: ${config.size.md.minWidth};
+    outline: none;
+    padding: 0 ${config.size.md.padding}px;
+    position: relative;
+    text-align: center;
+    text-decoration: none;
 
-  &:focus {
-    z-index: 2;
-  }
+    &:focus {
+      z-index: 2;
+    }
 
-  &.is-first {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-  &.is-notOnly {
-    border-radius: 0;
-  }
-  &.is-last {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
+    &.is-first {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+    &.is-notOnly {
+      border-radius: 0;
+    }
+    &.is-last {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
 
-  &.is-block {
-    display: flex;
-    width: 100%;
-  }
+    &.is-block {
+      display: flex;
+      width: 100%;
+    }
 
-  ${makeButtonSizeStyles()}
+    ${makeButtonSizeStyles()}
 
-  ${props => makePrimaryStyles(props)}
-  ${makeButtonKindStyles('secondary', config.secondary)}
-  ${makeButtonKindStyles('secondaryAlt', config.secondaryAlt)}
-  ${makeButtonKindStyles('tertiary', config.tertiary)}
-  ${makeButtonKindStyles('default', config.default)}
-  ${makeButtonKindStyles('link', config.link)}
-  ${makeButtonKindStyles('suffix', config.suffix)}
-`
+    ${props => makePrimaryStyles(props)}
+    ${makeButtonKindStyles('secondary', config.secondary)}
+    ${makeButtonKindStyles('secondaryAlt', config.secondaryAlt)}
+    ${makeButtonKindStyles('tertiary', config.tertiary)}
+    ${makeButtonKindStyles('default', config.default)}
+    ${makeButtonKindStyles('link', config.link)}
+    ${makeButtonKindStyles('suffix', config.suffix)}
+  `
+}
 
 function makePrimaryStyles(props: Object = {}): string {
   const { theme } = props

--- a/src/components/Button/ButtonV2.js
+++ b/src/components/Button/ButtonV2.js
@@ -1,5 +1,6 @@
 // @flow
 import type { ButtonKind, ButtonSize } from './types'
+import memoize from 'memoize-one'
 import type { UIState } from '../../constants/types'
 import React, { PureComponent as Component } from 'react'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
@@ -8,7 +9,7 @@ import { namespaceComponent, isComponentNamed } from '../../utilities/component'
 import { includes } from '../../utilities/arrays'
 import { noop } from '../../utilities/other'
 import RouteWrapper from '../RouteWrapper'
-import { ButtonUI, ButtonContentUI, FocusUI } from './styles/Button.css.js'
+import { makeButtonUI, ButtonContentUI, FocusUI } from './Button.css.js'
 import { COMPONENT_KEY } from './utils'
 import { COMPONENT_KEY as ICON_KEY } from '../Icon/utils'
 
@@ -61,6 +62,8 @@ class Button extends Component<Props, State> {
   }
 
   static BlueComponentVersion = 2
+
+  makeButtonUI = memoize(makeButtonUI)
 
   constructor(props, context) {
     super(props, context)
@@ -140,6 +143,13 @@ class Button extends Component<Props, State> {
     })
   }
 
+  getButtonUI() {
+    const { href } = this.props
+    const selector = href ? 'a' : 'button'
+
+    return this.makeButtonUI(selector)
+  }
+
   render() {
     const {
       allowContentEventPropogation,
@@ -184,6 +194,7 @@ class Button extends Component<Props, State> {
     const focusMarkup = this.getFocusMarkup()
 
     const childrenMarkup = this.getChildrenMarkup()
+    const ButtonUI = this.getButtonUI()
 
     return (
       <ButtonUI

--- a/src/components/Button/__tests__/ButtonV2.test.js
+++ b/src/components/Button/__tests__/ButtonV2.test.js
@@ -299,3 +299,31 @@ describe('Content event propagation', () => {
     expect(spy).toHaveBeenCalled()
   })
 })
+
+describe('Link', () => {
+  test('Can render a link, if href is defined', () => {
+    const wrapper = mount(<Button href="/" />)
+
+    expect(wrapper.find('a').length).toBeTruthy()
+    expect(wrapper.find('button').length).toBeFalsy()
+  })
+
+  test('Can render a link based props', () => {
+    const wrapper = mount(<Button href="/" target="_blank" />)
+    const el = wrapper.find('a').first()
+
+    expect(el.length).toBeTruthy()
+    expect(el.prop('target')).toBe('_blank')
+  })
+
+  test('Changes back to <button>, if href is removed', () => {
+    const wrapper = mount(<Button href="/" />)
+
+    expect(wrapper.find('a').length).toBeTruthy()
+
+    wrapper.setProps({ href: null })
+
+    expect(wrapper.find('a').length).toBeFalsy()
+    expect(wrapper.find('button').length).toBeTruthy()
+  })
+})

--- a/src/components/Button/docs/ButtonV2.md
+++ b/src/components/Button/docs/ButtonV2.md
@@ -30,6 +30,7 @@ Alternatively, [PropProvider](../../PropProvider) can be used to set this prop a
 | className                    | `string`   | Custom class names to be added to the component.                                |
 | disabled                     | `bool`     | Disable the button so it can't be clicked.                                      |
 | fetch                        | `function` | function which returns a promise, will be invoked before routing the `to` route |
+| href                         | `string`   | Hyperlink for the button. This transforms the button to a `<a>` selector.       |
 | innerRef                     | `function` | Retrieves the `button` DOM node.                                                |
 | isFocused                    | `bool`     | Renders the focused style.                                                      |
 | isSuffix                     | `bool`     | Renders suffix styles.                                                          |

--- a/stories/ButtonV2.stories.js
+++ b/stories/ButtonV2.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { withKnobs, select } from '@storybook/addon-knobs'
 import {
   Button,
   ControlGroup,
@@ -11,6 +12,7 @@ import {
 import styled from '../src/components/styled'
 
 const stories = storiesOf('Button/V2', module)
+stories.addDecorator(withKnobs)
 
 const ContainerUI = styled('div')`
   background: #f1f3f5;
@@ -109,3 +111,22 @@ stories.add('icon', () => (
     </ContainerUI>
   </PropProvider>
 ))
+
+stories.add('selector', () => {
+  const props = {
+    href: select(
+      'selector',
+      {
+        button: '',
+        link: '#',
+      },
+      ''
+    ),
+  }
+
+  return (
+    <Button version={2} {...props} size="lg" kind="primary">
+      {props.href ? 'Link' : 'Button'}
+    </Button>
+  )
+})


### PR DESCRIPTION
## Button: Add support to render link (for href)

![screen recording 2019-02-06 at 03 36 pm](https://user-images.githubusercontent.com/2322354/52372364-01460280-2a26-11e9-8114-54c0825b2cef.gif)


This update enhances the Button (v2) component to allow for the render of
`<a>` selectors if `href` is defined.

For performance, `memoize-one` was added to help cache the (re)generation
of the `ButtonUI` styled component.