### PR TITLE
Button: Add PrimaryAlt (purple) variant

### DIFF
--- a/src/components/Button/Button.css.js
+++ b/src/components/Button/Button.css.js
@@ -44,6 +44,41 @@ export const config = {
       colorActive: 'white',
     },
   },
+  primaryAlt: {
+    backgroundColor: getColor('purple.500'),
+    backgroundColorHover: getColor('purple.600'),
+    backgroundColorActive: getColor('purple.700'),
+    borderColor: getColor('purple.500'),
+    borderColorHover: getColor('purple.600'),
+    borderColorActive: getColor('purple.700'),
+    color: 'white',
+    disabledBackgroundColor: getColor('grey.500'),
+    disabledBorderColor: getColor('grey.500'),
+    disabledColor: 'white',
+    fontWeight: 500,
+    danger: {
+      backgroundColor: getColor('red.500'),
+      backgroundColorHover: getColor('red.600'),
+      backgroundColorActive: getColor('red.700'),
+      borderColor: getColor('red.500'),
+      borderColorHover: getColor('red.600'),
+      borderColorActive: getColor('red.700'),
+      color: 'white',
+      colorHover: 'white',
+      colorActive: 'white',
+    },
+    success: {
+      backgroundColor: getColor('green.500'),
+      backgroundColorHover: getColor('green.600'),
+      backgroundColorActive: getColor('green.700'),
+      borderColor: getColor('green.500'),
+      borderColorHover: getColor('green.600'),
+      borderColorActive: getColor('green.700'),
+      color: 'white',
+      colorHover: 'white',
+      colorActive: 'white',
+    },
+  },
   secondary: {
     backgroundColor: 'white',
     backgroundColorHover: 'white',
@@ -224,7 +259,8 @@ export const makeButtonUI = (selector: 'button') => {
 
     ${makeButtonSizeStyles()}
 
-    ${props => makePrimaryStyles(props)}
+    ${props => makePrimaryStyles('primary', props)}
+    ${props => makePrimaryStyles('primaryAlt', props)}
     ${makeButtonKindStyles('secondary', config.secondary)}
     ${makeButtonKindStyles('secondaryAlt', config.secondaryAlt)}
     ${makeButtonKindStyles('tertiary', config.tertiary)}
@@ -234,14 +270,14 @@ export const makeButtonUI = (selector: 'button') => {
   `
 }
 
-function makePrimaryStyles(props: Object = {}): string {
+function makePrimaryStyles(name = 'primary', props: Object = {}): string {
   const { theme } = props
   const backgroundColor =
-    (theme && theme.brandColor) || config.primary.backgroundColor
-  const color = (theme && theme.brandTextColor) || config.primary.color
+    (theme && theme.brandColor) || config[name].backgroundColor
+  const color = (theme && theme.brandTextColor) || config[name].color
 
-  return makeButtonKindStyles('primary', {
-    ...config.primary,
+  return makeButtonKindStyles(name, {
+    ...config[name],
     backgroundColor,
     color,
   })

--- a/src/components/Button/ButtonV2.js
+++ b/src/components/Button/ButtonV2.js
@@ -90,6 +90,7 @@ class Button extends Component<Props, State> {
   shouldShowFocus = () => {
     const paddedButtonKinds = [
       'primary',
+      'primaryAlt',
       'secondary',
       'secondaryAlt',
       'tertiary',

--- a/src/components/Button/docs/ButtonV2.md
+++ b/src/components/Button/docs/ButtonV2.md
@@ -50,6 +50,7 @@ Alternatively, [PropProvider](../../PropProvider) can be used to set this prop a
 | Value          | Description                                                                              |
 | -------------- | ---------------------------------------------------------------------------------------- |
 | `primary`      | Renders a blue button. Used for primary actions.                                         |
+| `primaryAlt`   | Renders a purple button. Used for primary actions.                                       |
 | `secondary`    | Renders a white button with a border. Used for secondary actions.                        |
 | `secondaryAlt` | Renders a white button with a green border. Used for secondary actions.                  |
 | `default`      | Renders a borderless button. Used for subtle/tertiary actions.                           |

--- a/src/components/Button/types.js
+++ b/src/components/Button/types.js
@@ -1,5 +1,6 @@
 export type ButtonKind =
 | 'primary'
+| 'primaryAlt'
 | 'secondary'
 | 'secondaryAlt'
 | 'tertiary'

--- a/stories/ButtonV2.stories.js
+++ b/stories/ButtonV2.stories.js
@@ -66,6 +66,7 @@ stories.add('everything', () => (
   <PropProvider value={{ Button: { version: 2 } }}>
     <ContainerUI>
       {makeButtonVariations({ kind: 'primary' })}
+      {makeButtonVariations({ kind: 'primaryAlt' })}
       {makeButtonVariations({ kind: 'secondary' })}
       {makeButtonVariations({ kind: 'secondaryAlt' })}
       {makeButtonVariations({ kind: 'default' })}


### PR DESCRIPTION
## Button: Add PrimaryAlt (purple) variant

![screen recording 2019-02-06 at 05 09 pm](https://user-images.githubusercontent.com/2322354/52377268-5e47b580-2a32-11e9-963f-7a3c55e14d62.gif)


This update adds a new primary alt (purple) variant to `Button` (version 2).

This can be rendered by:

```jsx
<Button version={2} kind="primaryAlt" />
```