### PR TITLE
Button: Remove underline for link selector

### DIFF
--- a/.groovyrc.json
+++ b/.groovyrc.json
@@ -1,0 +1,1 @@
+{ "default_branch": "master" }

--- a/src/components/Button/Button.css.js
+++ b/src/components/Button/Button.css.js
@@ -236,12 +236,13 @@ export const makeButtonUI = (selector: 'button') => {
     text-align: center;
     text-decoration: none;
 
-    &:hover {
+    &:hover,
+    &:active,
+    &:focus {
       text-decoration: none;
     }
 
     &:focus {
-      text-decoration: none;
       z-index: 2;
     }
 

--- a/src/components/Button/Button.css.js
+++ b/src/components/Button/Button.css.js
@@ -236,7 +236,12 @@ export const makeButtonUI = (selector: 'button') => {
     text-align: center;
     text-decoration: none;
 
+    &:hover {
+      text-decoration: none;
+    }
+
     &:focus {
+      text-decoration: none;
       z-index: 2;
     }
 


### PR DESCRIPTION
## Button: Remove underline for link selector

<img width="808" alt="screen shot 2019-02-07 at 1 16 06 pm" src="https://user-images.githubusercontent.com/2322354/52433325-d5388900-2ada-11e9-867c-a4f520cf730a.png">


This update adjusts `Button` (v2) to not have an underline for `:hover`
and `:focus` by default. Note, these styles do appear if the `kind` of the
button happens to be a `link`.