### PR TITLE
Add color yellow to tag colors

### DIFF
--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -36,3 +36,4 @@ A Tag component is a UI element that provide contextual labels for categories/ta
 | `orange` | Colors the tag orange. |
 | `purple` | Colors the tag purple. |
 | `red`    | Colors the tag red.    |
+| `yellow` | Colors the tag yellow. |

--- a/src/components/Tag/Tag.css.ts
+++ b/src/components/Tag/Tag.css.ts
@@ -16,6 +16,7 @@ export const config = {
     orange: getColor('orange.500'),
     purple: getColor('purple.500'),
     red: getColor('red.500'),
+    yellow: getColor('yellow.500'),
   },
   height: 18,
   padding: '1px 4px',

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -11,7 +11,15 @@ import { noop, promiseNoop } from '../../utilities/other'
 import { AnimateUI, TagWrapperUI, TagUI, BodyUI, SpinnerUI } from './Tag.css'
 import { COMPONENT_KEY } from './Tag.utils'
 
-type TagColor = 'blue' | 'green' | 'grey' | 'gray' | 'orange' | 'purple' | 'red'
+type TagColor =
+  | 'blue'
+  | 'green'
+  | 'grey'
+  | 'gray'
+  | 'orange'
+  | 'purple'
+  | 'red'
+  | 'yellow'
 
 export interface Props {
   animationDuration?: number

--- a/stories/Tag/Tag.stories.js
+++ b/stories/Tag/Tag.stories.js
@@ -25,6 +25,7 @@ stories.add('Default', () => {
         blue: 'blue',
         orange: 'orange',
         purple: 'purple',
+        yellow: 'yellow',
       },
       'grey'
     ),
@@ -57,6 +58,9 @@ stories.add('filled', () => (
     <Tag color="purple" filled>
       Ron
     </Tag>
+    <Tag color="yellow" filled>
+      Ron
+    </Tag>
   </div>
 ))
 
@@ -78,6 +82,9 @@ stories.add('pulsing', () => (
       Ron
     </Tag>
     <Tag color="purple" pulsing>
+      Ron
+    </Tag>
+    <Tag color="yellow" pulsing>
       Ron
     </Tag>
   </div>


### PR DESCRIPTION
https://trello.com/c/sanmmp8E/937-yellow-tag-not-supported-in-chat-ui-hsds

This fix adds the color yellow as a possible tag color.

<img width="299" alt="image 2019-02-07 at 10 15 06 am" src="https://user-images.githubusercontent.com/1704626/52433372-cb565c00-2ac1-11e9-933f-b30149a286da.png">

<img width="259" alt="image 2019-02-07 at 10 15 13 am" src="https://user-images.githubusercontent.com/1704626/52433377-cdb8b600-2ac1-11e9-826c-d2a3f4ab10ef.png">
