### PR TITLE
Attachment: Adding Error state

### DIFF
--- a/src/components/Attachment/Attachment.css.js
+++ b/src/components/Attachment/Attachment.css.js
@@ -47,6 +47,10 @@ const css = `
   position: relative;
   text-decoration: none;
 
+  &.is-error {
+    color: ${getColor('red.500')};
+  }
+
   // Modifiers
   &.is-action {
     ${bem.element('name')} {

--- a/src/components/Attachment/Attachment.css.js
+++ b/src/components/Attachment/Attachment.css.js
@@ -1,10 +1,11 @@
-import { BEM } from '../../../utilities/classNames'
-import baseStyles from '../../../styles/resets/baseStyles.css'
+import styled from '../styled'
+import { BEM } from '../../utilities/classNames'
+import baseStyles from '../../styles/resets/baseStyles.css'
 import cardStyles, {
   cardSubtleStyles,
-} from '../../../styles/mixins/cardStyles.css'
-import linkStyles from '../../../styles/mixins/linkStyles.css'
-import { getColor } from '../../../styles/utilities/color'
+} from '../../styles/mixins/cardStyles.css'
+import linkStyles from '../../styles/mixins/linkStyles.css'
+import { getColor } from '../../styles/utilities/color'
 
 const bem = BEM('.c-Attachment')
 
@@ -12,6 +13,27 @@ const config = {
   imageSize: '37px',
   imageMaxWidth: '80px',
 }
+
+export const ErrorBorderUI = styled('div')`
+  border-radius: 99999px;
+  border: 1px solid ${getColor('red.500')};
+  bottom: -1px;
+  left: -1px;
+  pointer-events: none;
+  position: absolute;
+  right: -1px;
+  top: -1px;
+
+  ${({ isCard }) =>
+    isCard &&
+    `
+    border-radius: 3px;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: 0;
+  `};
+`
 
 const css = `
   ${linkStyles()}

--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -1,5 +1,6 @@
 import { AttachmentProp } from './types'
 import * as React from 'react'
+import { UIState } from '../../constants/types.js'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import AttachmentProvider from './Provider'
 import CloseButton from '../CloseButton'
@@ -11,7 +12,7 @@ import { classNames } from '../../utilities/classNames'
 import { namespaceComponent } from '../../utilities/component'
 import { noop } from '../../utilities/other'
 import { COMPONENT_KEY } from './utils'
-import css from './styles/Attachment.css.js'
+import css, { ErrorBorderUI } from './Attachment.css.js'
 
 export const Provider = AttachmentProvider
 
@@ -27,6 +28,7 @@ export interface Props {
   name: string
   onClick: (event: MouseClickEvent, attachmentProp: AttachmentProp) => void
   onRemoveClick: (event: Event, attachmentProp: AttachmentProp) => void
+  state: UIState
   size: number | string
   target?: string
   truncateLimit: number
@@ -41,6 +43,7 @@ export class Attachment extends React.PureComponent<Props> {
     onClick: noop,
     onRemoveClick: noop,
     truncateLimit: 20,
+    state: 'default',
     type: 'link',
   }
   static contextTypes = {
@@ -61,12 +64,31 @@ export class Attachment extends React.PureComponent<Props> {
     }
   }
 
+  isError() {
+    return this.props.state === 'error'
+  }
+
+  isThemePreview() {
+    return this.context.theme === 'preview'
+  }
+
   handleOnClick = (event: MouseClickEvent) => {
     this.props.onClick(event, this.getAttachmentProps())
   }
 
   handleOnRemoveClick = (event: Event) => {
     this.props.onRemoveClick(event, this.getAttachmentProps())
+  }
+
+  renderErrorBorder() {
+    return (
+      this.isError() && (
+        <ErrorBorderUI
+          className="c-Attachment__errorBorder"
+          isCard={this.isThemePreview()}
+        />
+      )
+    )
   }
 
   render() {
@@ -81,6 +103,7 @@ export class Attachment extends React.PureComponent<Props> {
       onClick,
       onRemoveClick,
       size,
+      state,
       target,
       truncateLimit,
       type,
@@ -89,11 +112,12 @@ export class Attachment extends React.PureComponent<Props> {
     } = this.props
     const { theme } = this.context
 
-    const isThemePreview = theme === 'preview'
+    const isThemePreview = this.isThemePreview()
 
     const componentClassName = classNames(
       'c-Attachment',
       imageUrl && 'has-image',
+      state && `is-${state}`,
       type && `is-${type}`,
       theme && `is-theme-${theme}`,
       className
@@ -150,6 +174,7 @@ export class Attachment extends React.PureComponent<Props> {
       >
         {contentMarkup}
         {closeMarkup}
+        {this.renderErrorBorder()}
       </a>
     )
   }

--- a/src/components/Attachment/__tests__/Attachment.test.js
+++ b/src/components/Attachment/__tests__/Attachment.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { mount, shallow, render } from 'enzyme'
 import { Attachment } from '../Attachment'
 import { Provider } from '../index'
 
@@ -251,5 +251,20 @@ describe('Download', () => {
     const link = wrapper.find('a')
 
     expect(link.prop('target')).toBe('_self')
+  })
+})
+
+describe('State', () => {
+  test('Renders state className', () => {
+    const wrapper = render(<Attachment url="file.pdf" state="error" />)
+
+    expect(wrapper.hasClass('is-error')).toBeTruthy()
+  })
+
+  test('Renders state UI', () => {
+    const wrapper = render(<Attachment url="file.pdf" state="error" />)
+    const el = wrapper.find('.c-Attachment__errorBorder')
+
+    expect(el.length).toBeTruthy()
   })
 })

--- a/src/components/Attachment/docs/Attachment.md
+++ b/src/components/Attachment/docs/Attachment.md
@@ -2,46 +2,43 @@
 
 An Attachment component provides UI for file attachments, typically found in [Chat-based](../ChatTranscript) components.
 
-
 ## Example
 
 ```jsx
-<Attachment name='file.png' size='52KB' />
+<Attachment name="file.png" size="52KB" />
 ```
-
 
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| className | `string` | Custom class names to be added to the component. |
-| download | `bool`/`string` | Enables file downloaded. Allowed by default if `url` is provided. |
-| id | `number`/`string` | The id of the attachment. |
-| imageUrl | `string` | The URL of the an image attachment to render. |
-| mime | `string` | The file type of the attachment. |
-| name | `string` | The name of the attachment. |
-| onClick | `function` | The callback when the component is clicked. |
-| onRemoveClick | `function` | The callback when the component's [CloseButton](../../CloseButton) UI is clicked. |
-| size | `string` | The size of the attachment. |
-| target | `string` | Determines the link target. Set to `_blank` by default if `url` is provided. |
-| truncateLimit | `number` | The amount of characters to truncate the file name. |
-| type | `string` | The type of UI for the component. |
-| url | `string` | The URL of the attachment. |
-
+| Prop          | Type              | Description                                                                       |
+| ------------- | ----------------- | --------------------------------------------------------------------------------- |
+| className     | `string`          | Custom class names to be added to the component.                                  |
+| download      | `bool`/`string`   | Enables file downloaded. Allowed by default if `url` is provided.                 |
+| id            | `number`/`string` | The id of the attachment.                                                         |
+| imageUrl      | `string`          | The URL of the an image attachment to render.                                     |
+| mime          | `string`          | The file type of the attachment.                                                  |
+| name          | `string`          | The name of the attachment.                                                       |
+| onClick       | `function`        | The callback when the component is clicked.                                       |
+| onRemoveClick | `function`        | The callback when the component's [CloseButton](../../CloseButton) UI is clicked. |
+| size          | `string`          | The size of the attachment.                                                       |
+| state         | `string`          | The state of the attachment.                                                      |
+| target        | `string`          | Determines the link target. Set to `_blank` by default if `url` is provided.      |
+| truncateLimit | `number`          | The amount of characters to truncate the file name.                               |
+| type          | `string`          | The type of UI for the component.                                                 |
+| url           | `string`          | The URL of the attachment.                                                        |
 
 ### Types
 
-| Prop | Description |
-| --- | --- |
-| `action` | Provides a button-based UI. |
-| `link` | Provides a link-based UI. Default. |
-
+| Prop     | Description                        |
+| -------- | ---------------------------------- |
+| `action` | Provides a button-based UI.        |
+| `link`   | Provides a link-based UI. Default. |
 
 ### Callbacks
 
 #### `onClick(event, props)`
 
-| Argument | Type | Description |
-| --- | --- | --- |
-| `event` | `object` | The (React) event object. |
-| `props` | `object` | Data object with all of the component's props. |
+| Argument | Type     | Description                                    |
+| -------- | -------- | ---------------------------------------------- |
+| `event`  | `object` | The (React) event object.                      |
+| `props`  | `object` | Data object with all of the component's props. |

--- a/stories/Attachment.stories.js
+++ b/stories/Attachment.stories.js
@@ -1,25 +1,47 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Attachment } from '../src/index.js'
+import { withKnobs, select, text } from '@storybook/addon-knobs'
+import { withArtboard } from '@helpscout/artboard'
 
 const stories = storiesOf('Attachment', module)
+stories.addDecorator(withKnobs)
+stories.addDecorator(
+  withArtboard({ width: 400, height: 200, withCenterGuides: false })
+)
 
-stories.add('default', () => {
-  return (
-    <Attachment
-      name="parrot.png"
-      size="5kb"
-      url="https://github.com/helpscout/hsds-react/raw/master/images/Blue.png"
-    />
+stories.add('Default', () => {
+  const theme = select(
+    'theme',
+    {
+      default: 'default',
+      preview: 'preview',
+    },
+    'default'
   )
-})
 
-stories.add('long file name', () => {
+  const props = {
+    name: text('name', 'derek.png'),
+    size: text('size', '5kb'),
+    state: select(
+      'state',
+      {
+        default: 'default',
+        error: 'error',
+      },
+      'default'
+    ),
+    url: text(
+      'url',
+      'https://github.com/helpscout/hsds-react/raw/master/images/Blue.png'
+    ),
+  }
+
+  const isPreview = theme === 'preview'
+
   return (
-    <Attachment
-      name="parrot-with-a-super-long-name.png"
-      size="5kb"
-      url="https://github.com/helpscout/hsds-react/raw/master/images/Blue.png"
-    />
+    <Attachment.Provider theme={theme}>
+      <Attachment {...props} size={!isPreview && props.size} />
+    </Attachment.Provider>
   )
 })

--- a/stories/AttachmentList.stories.js
+++ b/stories/AttachmentList.stories.js
@@ -52,7 +52,10 @@ class ThemePreviewDemo extends React.Component {
         <button onClick={this.add}>Add</button>
         <Attachment.Provider theme="preview">
           <AttachmentList>
-            <Attachment imageUrl="https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto" />
+            <Attachment
+              imageUrl="https://img.buzzfeed.com/buzzfeed-static/static/2014-12/5/11/enhanced/webdr06/longform-original-7538-1417798667-22.jpg?downsize=715:*&output-format=auto&output-quality=auto"
+              state="error"
+            />
             <Attachment imageUrl="http://matthewjamestaylor.com/img/illustrations/large/how-to-convert-a-liquid-layout-to-fixed-width.jpg" />
             <Attachment name="attachment-coming-soon.md" />
             <Attachment name="attachment-coming-soon.md" />


### PR DESCRIPTION
## Attachment: Adding Error state

![screen recording 2019-02-07 at 04 05 pm](https://user-images.githubusercontent.com/2322354/52444609-d37cbe80-2af6-11e9-8b4d-c0868b88100f.gif)


This update adds an state support for `Attachment`, allowing for a state
of `error` to render a red border.

---

Testing:

https://deploy-preview-473--hsds-react.netlify.com/?selectedKind=Attachment&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs