### PR TITLE
DropdownV2: Resolve item render updates

### DIFF
--- a/src/components/AnimateGroup/__tests__/AnimateGroup.test.js
+++ b/src/components/AnimateGroup/__tests__/AnimateGroup.test.js
@@ -225,23 +225,7 @@ describe('Staggering', () => {
 })
 
 describe('Children', () => {
-  test('Can render non-Animate children, with stagger', () => {
-    const wrapper = mount(
-      <AnimateGroup stagger>
-        <Animate duration={30}>
-          <div className="champ">Champ</div>
-        </Animate>
-        <div className="ron">Ron</div>
-      </AnimateGroup>
-    )
-    const o = wrapper.find('.champ')
-    const p = wrapper.find('.ron')
-
-    expect(o.length).toBeTruthy()
-    expect(p.length).toBeTruthy()
-  })
-
-  test('Filters out null children', () => {
+  test('Can render Animate children', () => {
     const children = [
       <Animate duration={30} key={11}>
         <div className="champ">Champ</div>

--- a/src/components/Dropdown/V2/Dropdown.Container.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Container.tsx
@@ -28,6 +28,7 @@ import {
 import Trigger from './Dropdown.Trigger'
 import { createUniqueIDFactory } from '../../../utilities/id'
 import { noop } from '../../../utilities/other'
+import { isDefined } from '../../../utilities/is'
 
 export interface Props extends DropdownProps {
   // Secret prop to pass in a custom store
@@ -115,7 +116,10 @@ export class DropdownContainer extends React.PureComponent<Props, State> {
 
     // Update items + regenerate the indexMap if items chage
     if (nextProps.items !== state.items) {
-      nextState = { ...updateItems(state, nextProps.items) }
+      nextState = {
+        ...nextState,
+        ...updateItems(state, nextProps.items),
+      }
     }
 
     // Adjust open state, if changed
@@ -127,20 +131,29 @@ export class DropdownContainer extends React.PureComponent<Props, State> {
     }
 
     // Adjust index, if changed
-    if (nextProps.index !== state.index) {
-      nextState = { ...updateIndex(state, nextProps.index) }
+    if (isDefined(nextProps.index) && nextProps.index !== state.index) {
+      nextState = {
+        ...nextState,
+        ...updateIndex(state, nextProps.index),
+      }
     }
 
     // Adjust dropUp, if changed
     if (nextProps.dropUp !== state.dropUp) {
-      nextState = { ...updateDropUp(state, nextProps.dropUp) }
+      nextState = {
+        ...nextState,
+        ...updateDropUp(state, nextProps.dropUp),
+      }
     }
 
     // This is to handle filterable dropdowns. We need to adjust the internally
     // tracked inputValue and reset the `index` value for a filterable
     // experience.
     if (nextProps.inputValue !== state.inputValue) {
-      nextState = { ...updateInputValue(state, nextProps.inputValue) }
+      nextState = {
+        ...nextState,
+        ...updateInputValue(state, nextProps.inputValue),
+      }
     }
 
     const diffs = getShallowDiffs(this.props, nextProps)
@@ -157,7 +170,7 @@ export class DropdownContainer extends React.PureComponent<Props, State> {
       } = diffs.next
 
       if (Object.keys(changedProps).length) {
-        nextState = { ...changedProps }
+        nextState = { ...nextState, ...changedProps }
       }
     }
 

--- a/stories/DropdownV2.stories.js
+++ b/stories/DropdownV2.stories.js
@@ -270,12 +270,20 @@ stories.add('Stateful', () => {
     }
 
     render() {
+      const getItems = () => this.state.items
+      // Forces' Dropdown diff'ing
+      const nonCachedStateReducer = state => state
+
       return (
         <div>
           <button onClick={this.add}>Add Item</button>
           <button onClick={this.remove}>Remove Item</button>
           <hr />
-          <Dropdown {...this.state} />
+          <Dropdown
+            {...this.state}
+            items={getItems()}
+            stateReducer={nonCachedStateReducer}
+          />
         </div>
       )
     }


### PR DESCRIPTION
## DropdownV2: Resolve item render updates

![screen recording 2019-02-08 at 09 34 am](https://user-images.githubusercontent.com/2322354/52485322-99f39400-2b86-11e9-8172-e34519dfad46.gif)


This update resolves the issue for `DropdownV2` where new items being passed
may (or may not) re-render correctly.

The issue was `Dropdown.Container`, which handles the diff'ing + state
updating process from external props.

The `nextState` that was building was being clobbered over as it trickles
down the conditional logic tree.

---

Unrelated, I fixed the `AnimatedGroup` test so that it stops spitting out
errors during the test run.

Resolves: https://github.com/helpscout/hsds-react/issues/474