### PR TITLE
Attachment: Fix error link (hover) colour

### DIFF
--- a/src/components/Attachment/Attachment.css.js
+++ b/src/components/Attachment/Attachment.css.js
@@ -49,6 +49,12 @@ const css = `
 
   &.is-error {
     color: ${getColor('red.500')};
+
+    &:hover,
+    &:active,
+    &:focus {
+      color: ${getColor('red.500')};
+    }
   }
 
   // Modifiers
@@ -82,7 +88,6 @@ const css = `
     text-decoration: none;
 
     ${bem.element('name')} {
-      color: ${getColor('blue.500')};
       text-decoration: underline;
     }
   }


### PR DESCRIPTION
## Attachment: Fix error link (hover) colour

![screen recording 2019-02-08 at 02 33 pm](https://user-images.githubusercontent.com/2322354/52501600-b5729500-2bae-11e9-8d30-e7bf8e585143.gif)


This update fixes the text color for `Attachment` when it is `:hover`,
specifically for the error state.

https://github.com/helpscout/hsds-react/issues/476