### PR TITLE
Message.Media: Remove caption from modal

### DIFF
--- a/src/components/Message/Media.js
+++ b/src/components/Message/Media.js
@@ -269,10 +269,7 @@ export class Media extends Component<Props> {
             )}
           >
             <Modal.Body scrollFade={false} isSeamless>
-              <Modal.Content>
-                {modalMediaMarkup}
-                {captionMarkup}
-              </Modal.Content>
+              <Modal.Content>{modalMediaMarkup}</Modal.Content>
             </Modal.Body>
           </Modal>
         </div>


### PR DESCRIPTION
## Message.Media: Remove caption from modal

![screen recording 2019-02-11 at 05 20 pm](https://user-images.githubusercontent.com/2322354/52597728-c0812b80-2e21-11e9-9183-c80b65b1bb24.gif)


This update removes the caption from the preview modal.