### PR TITLE
RateAction: Fix active circle sizing

### DIFF
--- a/src/components/RateAction/RateAction.css.ts
+++ b/src/components/RateAction/RateAction.css.ts
@@ -32,16 +32,17 @@ export const RateActionUI = styled('button')`
   z-index: 0;
 
   &:after {
+    ${baseStyles};
     content: '';
     border-radius: 50%;
     border: 2px solid ${config.outlineColor};
     display: none;
-    height: 28px;
+    height: calc(${config.size.default} + 4px);
     left: -4px;
     pointer-events: none;
     position: absolute;
     top: -4px;
-    width: 28px;
+    width: calc(${config.size.default} + 4px);
     will-change: transform;
 
     @keyframes HSDSRateActionSelected {
@@ -81,5 +82,10 @@ export const RateActionUI = styled('button')`
   &.is-sm {
     width: ${config.size.sm};
     height: ${config.size.sm};
+
+    &:after {
+      height: calc(${config.size.sm} + 4px);
+      width: calc(${config.size.sm} + 4px);
+    }
   }
 `


### PR DESCRIPTION
## RateAction: Fix active circle sizing

![screen recording 2019-02-14 at 03 50 pm](https://user-images.githubusercontent.com/2322354/52817014-95d8e200-3070-11e9-9960-df4fb997383b.gif)

This update fixes the green active circle rendering for RateAction buttons.
The issue came from a lack of CSS `box-sizing`, resulting in inconsitent size
rendering depending on the environment.