### PR TITLE
Update the color of note chat message bubbles

### DIFF
--- a/src/components/Message/styles/Bubble.css.js
+++ b/src/components/Message/styles/Bubble.css.js
@@ -104,8 +104,8 @@ const css = `
   }
 
   &.is-note {
-    background-color: ${getColor('yellow.300')};
-    border-color: ${getColor('yellow.300')};
+    background-color: ${getColor('yellow.200')};
+    border-color: ${getColor('yellow.400')};
     color: ${getColor('yellow.900')};
 
     * {

--- a/src/components/Message/styles/Embed.css.js
+++ b/src/components/Message/styles/Embed.css.js
@@ -47,7 +47,7 @@ export const css = `
 
     &.is-note {
       ${noteBoxShadow()}
-      background-color: ${getColor('yellow.300')};
+      background-color: ${getColor('yellow.200')};
       color: ${getColor('yellow.800')};
     }
   }

--- a/src/components/Message/styles/Media.css.js
+++ b/src/components/Message/styles/Media.css.js
@@ -50,7 +50,7 @@ const css = `
 
     &.is-note {
       ${noteBoxShadow()}
-      background-color: ${getColor('yellow.300')};
+      background-color: ${getColor('yellow.200')};
       color: ${getColor('yellow.800')};
     }
 


### PR DESCRIPTION
https://trello.com/c/OXlQfWF7/960-update-note-styling-to-be-more-accessible

Changes the note message bubble to text `yellow-900`, background `yellow-200` and border `yellow-400` so that there is more contrast between text and background. This will become more noticeable when we change the color yellow to the new palette.

Storybook: https://deploy-preview-487--hsds-react.netlify.com/?selectedKind=Message&selectedStory=content&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel