### PR TITLE
Fix: Opening Autodropdown causes scroll to bottom

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -665,7 +665,8 @@ export class Input extends Component<Props, State> {
 
     const componentProps = {
       ...getValidProps(rest),
-      autoFocus,
+      /* We manually set autoFocus after component mounts. */
+      autoFocus: false,
       className: fieldClassName,
       id,
       onChange: this.handleOnChange,

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -216,15 +216,15 @@ export class Input extends Component<Props, State> {
   forceAutoFocus() {
     const { forceAutoFocusTimeout } = this.props
 
-    this.setState({
-      isFocused: true,
-    })
-
     setTimeout(() => {
       /* istanbul ignore else */
       if (this.inputNode) {
         this.inputNode.focus()
       }
+
+      this.setState({
+        isFocused: true,
+      })
     }, forceAutoFocusTimeout)
   }
 
@@ -662,11 +662,10 @@ export class Input extends Component<Props, State> {
     const id = props.id || this.state.id
 
     const BaseFieldComponent = multiline ? FieldTextAreaUI : FieldUI
-
     const componentProps = {
       ...getValidProps(rest),
       /* We manually set autoFocus after component mounts. */
-      autoFocus: false,
+      autoFocus: this.state.isFocused,
       className: fieldClassName,
       id,
       onChange: this.handleOnChange,

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -55,10 +55,11 @@ describe('Autofocus', () => {
   })
 
   test('Autofocuses if specified', () => {
+    jest.useFakeTimers()
     const wrapper = mount(<Input autoFocus />)
     const input = wrapper.find('input')
-
-    expect(input.prop('autoFocus')).toBeTruthy()
+    jest.runAllTimers()
+    expect(wrapper.state('isFocused')).toBeTruthy()
   })
 })
 

--- a/stories/AutoDropdown.stories.js
+++ b/stories/AutoDropdown.stories.js
@@ -10,17 +10,15 @@ import {
 import { action } from '@storybook/addon-actions'
 import { createSpec, faker } from '@helpscout/helix'
 import { storiesOf } from '@storybook/react'
-import { withArtboard } from '@helpscout/artboard'
 
 const stories = storiesOf('AutoDropdown', module)
-stories.addDecorator(withArtboard({ withCenterGuides: false }))
 stories.addDecorator(withKnobs)
 
 const ItemSpec = createSpec({
   id: faker.random.uuid(),
   value: faker.name.firstName(),
 })
-const items = ItemSpec.generate(15)
+const items = ItemSpec.generate(100)
 
 stories.add('Default', () => {
   const props = {
@@ -84,4 +82,18 @@ stories.add('Stateful', () => {
   }
 
   return <Example />
+})
+
+stories.add('Multiple instances', () => {
+  const renderTrigger = index => <span>{`Click ${index}`}</span>
+
+  return (
+    <ul>
+      {[...Array(100).keys()].map(i => (
+        <li key={i}>
+          <AutoDropdown items={items} renderTrigger={renderTrigger(i)} />
+        </li>
+      ))}
+    </ul>
+  )
 })


### PR DESCRIPTION
This update addresses an issue where opening an autodropdown would cause the page to scroll to the bottom.

This issue impacted the autodropdown when the number of items exceeded the threshold that has us render a filterable dropdown menu. That is 15 items by default. It also was only a noticeable issue on pages with a scrollbar. However, when those conditions were met, the dropdown was unusable.

Here is a demo of the problem:

![Problem](http://c.hlp.sc/e7c08738a95b/Screen%252520Recording%2525202019-02-26%252520at%25252003.19%252520PM.gif)

Here is a demo of how things are looking after the fix:

![Fix](http://c.hlp.sc/485dee667f67/Screen%252520Recording%2525202019-02-26%252520at%25252003.16%252520PM.gif)