### PR TITLE
Fix appearance of disabled SplitButtons and SplitButtons with state

### DIFF
--- a/src/components/SplitButton/SplitButton.css.ts
+++ b/src/components/SplitButton/SplitButton.css.ts
@@ -1,6 +1,5 @@
 import styled from '../styled'
 import Button from '../Button'
-import { config } from '../Button/Button.css.js'
 import { getColor } from '../../styles/utilities/color'
 
 export const OptionsTriggerButtonUI = styled(Button)`
@@ -17,7 +16,7 @@ export const OptionsTriggerButtonUI = styled(Button)`
       box-shadow: -1px 0 0 ${getColor('red.600')};
     }
     &[disabled] {
-      box-shadow: -1px 0 0 ${config.primary.disabledBorderColor};
+      box-shadow: -1px 0 0 ${getColor('grey.600')};
     }
   }
 
@@ -25,7 +24,7 @@ export const OptionsTriggerButtonUI = styled(Button)`
     box-shadow: -1px 0 0 ${getColor('purple.600')};
 
     &[disabled] {
-      box-shadow: -1px 0 0 ${config.primaryAlt.disabledBorderColor};
+      box-shadow: -1px 0 0 ${getColor('grey.600')};
     }
   }
 

--- a/src/components/SplitButton/SplitButton.css.ts
+++ b/src/components/SplitButton/SplitButton.css.ts
@@ -1,5 +1,6 @@
 import styled from '../styled'
 import Button from '../Button'
+import { config } from '../Button/Button.css.js'
 import { getColor } from '../../styles/utilities/color'
 
 export const OptionsTriggerButtonUI = styled(Button)`
@@ -12,13 +13,20 @@ export const OptionsTriggerButtonUI = styled(Button)`
     &.is-success {
       box-shadow: -1px 0 0 ${getColor('green.600')};
     }
-    &.is-error {
+    &.is-danger {
       box-shadow: -1px 0 0 ${getColor('red.600')};
+    }
+    &[disabled] {
+      box-shadow: -1px 0 0 ${config.primary.disabledBorderColor};
     }
   }
 
   &.is-primaryAlt {
     box-shadow: -1px 0 0 ${getColor('purple.600')};
+
+    &[disabled] {
+      box-shadow: -1px 0 0 ${config.primaryAlt.disabledBorderColor};
+    }
   }
 
   .c-ButtonV2__content {

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -21,6 +21,7 @@ export interface Props {
   kind?: string
   onClick?: (event: Event) => void
   size?: string
+  state?: string
 }
 
 const defaultDropdownProps = {
@@ -53,6 +54,7 @@ export class SplitButton extends React.PureComponent<Props> {
       dropdownProps: { onTriggerClick },
       kind,
       size,
+      state,
     } = this.props
 
     return (
@@ -63,6 +65,7 @@ export class SplitButton extends React.PureComponent<Props> {
         kind={kind}
         onClick={onTriggerClick}
         size={size}
+        state={state}
         version={2}
       >
         <Icon name="caret-down" size="16" />

--- a/stories/SplitButton.stories.js
+++ b/stories/SplitButton.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import Flexy from '../src/components/Flexy'
 import SplitButton from '../src/components/SplitButton'
 
 import {
@@ -35,6 +36,40 @@ const dropdownProps = {
   onSelect: value => console.log(value),
 }
 
+const buildGrid = ({ disabled = false } = {}) => {
+  const style = { marginBottom: '3px' }
+
+  return (
+    <Flexy>
+      <Flexy.Item>
+        {['tertiary', 'primary', 'primaryAlt'].map(kind => (
+          <SplitButton
+            disabled={disabled}
+            dropdownProps={dropdownProps}
+            kind={kind}
+            style={style}
+          >
+            Click Me
+          </SplitButton>
+        ))}
+      </Flexy.Item>
+      <Flexy.Item>
+        {['success', 'danger'].map(state => (
+          <SplitButton
+            disabled={disabled}
+            dropdownProps={dropdownProps}
+            kind="primary"
+            state={state}
+            style={style}
+          >
+            Click Me
+          </SplitButton>
+        ))}
+      </Flexy.Item>
+    </Flexy>
+  )
+}
+
 stories.add('Default', () => {
   return (
     <SplitButton
@@ -64,15 +99,6 @@ stories.add('Sizes and Colours', () => {
   )
 })
 
-stories.add('Disabled', () => {
-  return (
-    <SplitButton
-      disabled
-      dropdownProps={dropdownProps}
-      kind="secondary"
-      size="lg"
-    >
-      Submit
-    </SplitButton>
-  )
-})
+stories.add('Colors', () => buildGrid())
+
+stories.add('Disabled', () => buildGrid({ disabled: true }))


### PR DESCRIPTION
Nice job on the SplitButton component @TerrenceLJones! Soon as it went out I scooped it up to use in app :)

This update improves the styles for the primary button with success + error state as well as the disabled states.

Here are some screenshots of before:

![Screenshot 1: Before](http://c.hlp.sc/59a8a9ab7898/Image%2525202019-02-27%252520at%25252010.55.15%252520AM.png)

![Screenshot 2: Before](http://c.hlp.sc/2be01ee1c1fe/%255B82931dd26979acd8812163d793af22eb%255D_Image%2525202019-02-27%252520at%25252010.55.29%252520AM.png)

Here are some screenshots of after:

![Screenshot 3: After](http://c.hlp.sc/9dc6d4d23601/Image%2525202019-02-27%252520at%25252010.53.07%252520AM.png)

![Screenshot 4: After](http://c.hlp.sc/640de1982fb6/Image%2525202019-02-27%252520at%25252010.53.20%252520AM.png)
