### PR TITLE
DropdownV2: Better menu repositioning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
     '!src/components/Popper/**/*.{js,jsx}',
     '!src/tests/helpers/**/*.{js,jsx}',
     '!src/utilities/browser.{js,jsx,ts}',
+    '!src/utilities/env.{js,jsx,ts}',
     '!src/utilities/react-router/**/*.{js,jsx}',
     '!src/utilities/smoothScroll.{js,jsx}',
     '!src/utilities/closest.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.13.2",
+  "version": "2.13.3-dd-0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.13.2",
+  "version": "2.13.3-dd-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.13.3-dd-0",
+  "version": "2.13.3-dd-0.0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
+++ b/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
@@ -88,6 +88,7 @@ export class MenuContainer extends React.PureComponent<Props> {
   placementNode: HTMLElement
   wrapperNode: HTMLElement
   id: string = uniqueID()
+  RAF: any = null
 
   componentDidMount() {
     this.setPositionStylesOnNode()

--- a/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
+++ b/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
@@ -21,6 +21,7 @@ import {
   selectItem,
   onMenuMounted,
   onMenuUnmounted,
+  onMenuReposition,
 } from './Dropdown.actions'
 import { MenuContainerUI } from './Dropdown.css.js'
 import { classNames } from '../../../utilities/classNames'
@@ -44,6 +45,7 @@ export interface Props {
   menuOffsetTop: number
   onMenuMounted: () => void
   onMenuUnmounted: () => void
+  onMenuReposition: (props: any) => void
   innerRef: (node: HTMLElement) => void
   isOpen: boolean
   items: Array<any>
@@ -71,6 +73,7 @@ export class MenuContainer extends React.PureComponent<Props> {
     menuOffsetTop: 0,
     onMenuMounted: noop,
     onMenuUnmounted: noop,
+    onMenuReposition: noop,
     selectItem: noop,
     zIndex: 1080,
   }
@@ -82,12 +85,6 @@ export class MenuContainer extends React.PureComponent<Props> {
 
   componentDidMount() {
     this.setPositionStylesOnNode()
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.isOpen !== this.props.isOpen) {
-      this.setPositionStylesOnNode()
-    }
   }
 
   /* istanbul ignore next */
@@ -262,6 +259,16 @@ export class MenuContainer extends React.PureComponent<Props> {
       this.placementNode.style.left = `${Math.round(left)}px`
       this.placementNode.style.zIndex = `${zIndex}`
 
+      this.props.onMenuReposition({
+        top: `${Math.round(top)}px`,
+        left: `${Math.round(left)}px`,
+        position: 'fixed',
+        triggerNode,
+        placementNode: this.placementNode,
+        menuNode: this.node,
+        zIndex: `${zIndex}`,
+      })
+
       if (triggerNode) {
         this.placementNode.style.width = `${triggerNode.clientWidth}px`
       }
@@ -402,6 +409,7 @@ const ConnectedMenuContainer: any = connect(
     selectItem,
     onMenuMounted,
     onMenuUnmounted,
+    onMenuReposition,
   }
 )(
   // @ts-ignore

--- a/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
+++ b/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
@@ -248,8 +248,21 @@ export class MenuContainer extends React.PureComponent<Props> {
   }
 
   onPortalOpen = () => {
-    this.setPositionStylesOnNode()
+    /* this.setPositionStylesOnNode() */
     this.props.onMenuMounted()
+
+    const repeat = () => {
+      this.setPositionStylesOnNode()
+      requestAnimationFrame(repeat)
+    }
+
+    // FOLLOW TEST
+    this.RAF = requestAnimationFrame(repeat)
+  }
+
+  onPortalClose = () => {
+    this.props.onMenuUnmounted()
+    cancelAnimationFrame(this.RAF)
   }
 
   setPositionStylesOnNode = () => {
@@ -261,47 +274,45 @@ export class MenuContainer extends React.PureComponent<Props> {
       zIndex,
     } = this.props
 
-    requestAnimationFrame(() => {
-      if (!this.node || !this.placementNode) return
-      // ...then get the left.
-      const { top, left } = this.getStylePosition()
-      const positionType = positionFixed ? 'fixed' : 'absolute'
+    if (!this.node || !this.placementNode) return
+    // ...then get the left.
+    const { top, left } = this.getStylePosition()
+    const positionType = positionFixed ? 'fixed' : 'absolute'
 
-      this.placementNode.style.position = positionType
-      this.placementNode.style.top = `${Math.round(top)}px`
-      this.placementNode.style.left = `${Math.round(left)}px`
-      this.placementNode.style.zIndex = `${zIndex}`
+    this.placementNode.style.position = positionType
+    this.placementNode.style.top = `${Math.round(top)}px`
+    this.placementNode.style.left = `${Math.round(left)}px`
+    this.placementNode.style.zIndex = `${zIndex}`
 
-      onMenuReposition({
-        top: `${Math.round(top)}px`,
-        left: `${Math.round(left)}px`,
-        position: positionType,
-        triggerNode,
-        placementNode: this.placementNode,
-        menuNode: this.node,
-        zIndex: `${zIndex}`,
-      })
-
-      if (triggerNode) {
-        this.placementNode.style.width = `${triggerNode.clientWidth}px`
-      }
-
-      /* istanbul ignore next */
-      // Skipping coverage for this method as it does almost exclusively DOM
-      // calculations, which isn't a JSDOM's forte.
-      if (this.shouldDropUp()) {
-        this.node.classList.add('is-dropUp')
-        if (triggerNode) {
-          this.placementNode.style.marginTop = `-${triggerNode.clientHeight +
-            menuOffsetTop}px`
-        }
-      } else {
-        this.node.classList.remove('is-dropUp')
-        if (triggerNode) {
-          this.placementNode.style.marginTop = `${menuOffsetTop}px`
-        }
-      }
+    onMenuReposition({
+      top: `${Math.round(top)}px`,
+      left: `${Math.round(left)}px`,
+      position: positionType,
+      triggerNode,
+      placementNode: this.placementNode,
+      menuNode: this.node,
+      zIndex: `${zIndex}`,
     })
+
+    if (triggerNode) {
+      this.placementNode.style.width = `${triggerNode.clientWidth}px`
+    }
+
+    /* istanbul ignore next */
+    // Skipping coverage for this method as it does almost exclusively DOM
+    // calculations, which isn't a JSDOM's forte.
+    if (this.shouldDropUp()) {
+      this.node.classList.add('is-dropUp')
+      if (triggerNode) {
+        this.placementNode.style.marginTop = `-${triggerNode.clientHeight +
+          menuOffsetTop}px`
+      }
+    } else {
+      this.node.classList.remove('is-dropUp')
+      if (triggerNode) {
+        this.placementNode.style.marginTop = `${menuOffsetTop}px`
+      }
+    }
   }
 
   setNodeRef = node => {
@@ -325,7 +336,6 @@ export class MenuContainer extends React.PureComponent<Props> {
       dropRight,
       focusItem,
       isOpen,
-      onMenuUnmounted,
       selectItem,
     } = this.props
     const shouldDropUp = this.shouldDropUp()
@@ -344,7 +354,7 @@ export class MenuContainer extends React.PureComponent<Props> {
           <Portal
             id={this.id}
             onOpen={this.onPortalOpen}
-            onClose={onMenuUnmounted}
+            onClose={this.onPortalClose}
           >
             <div
               className="DropdownV2MenuContainerPlacementRoot"

--- a/src/components/Dropdown/V2/Dropdown.Trigger.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Trigger.tsx
@@ -100,12 +100,9 @@ export class Trigger extends React.PureComponent<Props> {
     const componentClassName = classNames(
       className,
       isOpen && 'is-open',
+      disabled && 'is-disabled',
       'c-DropdownV2Trigger'
     )
-
-    if (disabled) {
-      return <div {...getValidProps(rest)} className={componentClassName} />
-    }
 
     return (
       <TriggerUI
@@ -113,6 +110,7 @@ export class Trigger extends React.PureComponent<Props> {
         aria-haspopup="listbox"
         aria-expanded={isOpen}
         className={componentClassName}
+        disabled={disabled}
         innerRef={innerRef}
         onBlur={onBlur}
         onFocus={onFocus}

--- a/src/components/Dropdown/V2/Dropdown.actionTypes.ts
+++ b/src/components/Dropdown/V2/Dropdown.actionTypes.ts
@@ -6,6 +6,7 @@ const actionTypes = [
   'FOCUS_ITEM',
   'MENU_MOUNT',
   'MENU_UNMOUNT',
+  'MENU_REPOSITION',
   'OPEN_DROPDOWN',
   'SELECT_ITEM',
   'SET_MENU_NODE',

--- a/src/components/Dropdown/V2/Dropdown.actions.ts
+++ b/src/components/Dropdown/V2/Dropdown.actions.ts
@@ -66,6 +66,15 @@ export const onMenuUnmounted = state => {
   })
 }
 
+export const onMenuReposition = (state, position) => {
+  return dispatch(state, {
+    type: actionTypes.MENU_REPOSITION,
+    payload: {
+      position,
+    },
+  })
+}
+
 export const setTriggerNode = (state, triggerNode) => {
   return dispatch(state, {
     type: actionTypes.SET_TRIGGER_NODE,

--- a/src/components/Dropdown/V2/Dropdown.css.js
+++ b/src/components/Dropdown/V2/Dropdown.css.js
@@ -214,6 +214,11 @@ export const TriggerUI = styled('a')`
   display: inline-block;
   outline: none;
 
+  &.is-disabled {
+    color: ${getColor('charcoal.200')};
+    pointer-events: none;
+  }
+
   &.is-open {
     color: ${getColor('blue.700')};
   }

--- a/src/components/Dropdown/V2/Dropdown.store.js
+++ b/src/components/Dropdown/V2/Dropdown.store.js
@@ -35,6 +35,7 @@ export const initialState = {
   onOpen: noop,
   onSelect: noop,
   openClassName: 'is-open',
+  positionFixed: false,
   previousIndex: null,
   selectedItem: '',
   stateReducer: state => state,

--- a/src/components/Dropdown/V2/Dropdown.tsx
+++ b/src/components/Dropdown/V2/Dropdown.tsx
@@ -82,7 +82,7 @@ export class Dropdown extends React.PureComponent<DropdownProps, State> {
       disabled,
       onBlur,
       onFocus,
-      innerRef: this.setTriggerNodeRef,
+      innerRef: node => this.setTriggerNodeRef(node),
     }
   }
 
@@ -113,13 +113,14 @@ export class Dropdown extends React.PureComponent<DropdownProps, State> {
   }
 
   setTriggerNodeRef = (node: HTMLElement) => {
+    if (!node) return
     this.triggerNode = node
     this.props.triggerRef(node)
 
     /* istanbul ignore next */
     // Internally, for store
     // @ts-ignore
-    if (this.props.getState().triggerNode) return
+    /* if (this.props.getState().triggerNode === node) return */
     this.props.setTriggerNode(node)
   }
 

--- a/src/components/Dropdown/V2/Dropdown.tsx
+++ b/src/components/Dropdown/V2/Dropdown.tsx
@@ -120,7 +120,7 @@ export class Dropdown extends React.PureComponent<DropdownProps, State> {
     /* istanbul ignore next */
     // Internally, for store
     // @ts-ignore
-    /* if (this.props.getState().triggerNode === node) return */
+    if (this.props.getState().triggerNode === node) return
     this.props.setTriggerNode(node)
   }
 

--- a/src/components/Dropdown/V2/Dropdown.types.ts
+++ b/src/components/Dropdown/V2/Dropdown.types.ts
@@ -8,27 +8,27 @@ export interface DropdownMenuDimensions {
 
 export interface DropdownState extends DropdownMenuDimensions {
   closeOnSelect: boolean
-  id?: string
-  menuId?: string
-  triggerId?: string
-  isOpen: boolean
-  items: Array<any>
   direction: 'left' | 'right'
   dropUp: boolean
-  onOpen: () => void
+  id?: string
+  isOpen: boolean
+  items: Array<any>
+  menuId?: string
   onClose: () => void
+  onOpen: () => void
   onSelect: (item: Object, props: Object) => void
   renderItem?: any
   renderTrigger?: any
+  triggerId?: string
 }
 
 export interface DropdownProps extends DropdownMenuDimensions {
   activeClassName: string
   children?: (props: any) => void
   className?: string
-  closeOnSelect: boolean
   clearOnSelect: boolean
   closeDropdown: () => void
+  closeOnSelect: boolean
   direction: 'left' | 'right'
   disabled: boolean
   dropUp: boolean
@@ -44,8 +44,8 @@ export interface DropdownProps extends DropdownMenuDimensions {
   isOpen: boolean
   items: Array<any>
   menuId?: string
-  menuRef: (node: HTMLElement) => void
   menuOffsetTop: number
+  menuRef: (node: HTMLElement) => void
   onBlur: (...args: any[]) => void
   onClose: () => void
   onFocus: (...args: any[]) => void
@@ -54,6 +54,7 @@ export interface DropdownProps extends DropdownMenuDimensions {
   onOpen: () => void
   onSelect: (item: Object, props: Object) => void
   openClassName: string
+  positionFixed: boolean
   previousIndex?: null
   renderEmpty?: any
   renderItem?: any

--- a/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.test.tsx
+++ b/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.test.tsx
@@ -85,6 +85,8 @@ describe('Portal', () => {
   test('Fires onMenuMounted callback on mount', () => {
     const spy = jest.fn()
     const wrapper = mount(<MenuContainer isOpen={true} onMenuMounted={spy} />)
+    // @ts-ignore
+    wrapper.instance().repositionMenuNodeCycle = spy
     const portal = wrapper.find('Portal')
     // @ts-ignore
     portal.props().onOpen()
@@ -95,6 +97,8 @@ describe('Portal', () => {
   test('Fires onMenuUnmounted callback on mount', () => {
     const spy = jest.fn()
     const wrapper = mount(<MenuContainer isOpen={true} onMenuUnmounted={spy} />)
+    // @ts-ignore
+    wrapper.instance().repositionMenuNodeCycle = spy
     const portal = wrapper.find('Portal')
     // @ts-ignore
     portal.props().onClose()
@@ -107,6 +111,8 @@ describe('Portal', () => {
     const wrapper = mount(<MenuContainer isOpen={true} />)
     // @ts-ignore
     wrapper.instance().setPositionStylesOnNode = spy
+    // @ts-ignore
+    wrapper.instance().repositionMenuNodeCycle = spy
     const portal = wrapper.find('Portal')
     // @ts-ignore
     portal.props().onOpen()
@@ -442,5 +448,41 @@ describe('Empty', () => {
 
     expect(wrapper.find('Loading').length).toBeTruthy()
     expect(wrapper.find('Empty').length).toBeFalsy()
+  })
+})
+
+describe('Position', () => {
+  test('Renders position: absolute, by default', () => {
+    const wrapper = mount(<MenuContainer isOpen={true} positionFixed={false} />)
+    const inst = wrapper.instance()
+
+    // @ts-ignore
+    expect(inst.getPositionProps().position).toBe('absolute')
+  })
+
+  test('Renders position: fixed, if defined', () => {
+    const wrapper = mount(<MenuContainer isOpen={true} positionFixed={true} />)
+    const inst = wrapper.instance()
+
+    // @ts-ignore
+    expect(inst.getPositionProps().position).toBe('fixed')
+  })
+})
+
+describe('forceHideMenuNode', () => {
+  test('Forces the menu node to hide, on unmount', () => {
+    const wrapper = mount(<MenuContainer isOpen={true} />)
+    const placementNode = {
+      style: {
+        display: 'block',
+      },
+    }
+    const inst = wrapper.instance()
+    // @ts-ignore
+    inst.placementNode = placementNode
+
+    wrapper.unmount()
+
+    expect(placementNode.style.display).toBe('none')
   })
 })

--- a/src/components/Dropdown/V2/__tests__/Dropdown.Trigger.test.tsx
+++ b/src/components/Dropdown/V2/__tests__/Dropdown.Trigger.test.tsx
@@ -207,3 +207,19 @@ describe('mapStateToProps', () => {
     expect(props).toEqual(triggerProps)
   })
 })
+
+describe('Disable', () => {
+  test('Renders the disabled in the DOM node', () => {
+    const wrapper = mount(<Trigger disabled={true} />)
+    const el = wrapper.find('a.c-DropdownV2Trigger')
+
+    expect(el.prop('disabled')).toBe(true)
+  })
+
+  test('Renders disabled styles', () => {
+    const wrapper = mount(<Trigger disabled={true} />)
+    const el = wrapper.find('a.c-DropdownV2Trigger')
+
+    expect(el.hasClass('is-disabled')).toBe(true)
+  })
+})

--- a/src/components/Dropdown/V2/docs/Dropdown.md
+++ b/src/components/Dropdown/V2/docs/Dropdown.md
@@ -70,6 +70,7 @@ This component supports async rendering of items. Render the `Dropdown` as you w
 | minWidth            | `number`                 | `180`        | Minimum width for the menu.                                                     |
 | menuRef             | `Function`               |              | Retrieves the Dropdown Menu DOM node.                                           |
 | openClassName       | `string`                 | `is-open`    | ClassName for an open item (with a sub menu).                                   |
+| positionFixed       | `boolean`                | `false`      | Renders menu as position `fixed`. Otherwise, it's `absolute`.                   |
 | renderEmpty         | `Function`               |              | Callback to render the empty UI.                                                |
 | renderLoading       | `Function`               |              | Callback to render the loading UI.                                              |
 | renderItem          | `Function`               |              | Callback to customize how an item renders.                                      |

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -119,8 +119,14 @@ export class Portal extends React.Component {
     }
 
     this.node = document.createElement('div')
-    this.node.className = className
-    this.node.id = id
+
+    if (className) {
+      this.node.className = className
+    }
+    if (id) {
+      this.node.id = id
+    }
+
     // Render to specified target, instead of document
     this.state.mountSelector.appendChild(this.node)
     this.renderPortalContent(props)

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
 import propConnect from '../PropProvider/propConnect'
-import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import { classNames } from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
-
 import AutoDropDown from '../AutoDropdown'
 import Button from '../Button'
 import ControlGroup from '../ControlGroup'

--- a/src/utilities/__tests__/memoize.test.ts
+++ b/src/utilities/__tests__/memoize.test.ts
@@ -1,0 +1,44 @@
+import { shallowPropMemoizeIsEqual } from '../memoize'
+
+describe('shallowPropMemoizeIsEqual', () => {
+  test('Returns true for equal values', () => {
+    const a = {
+      one: 1,
+    }
+
+    const b = {
+      one: 1,
+    }
+
+    expect(shallowPropMemoizeIsEqual([a], [b])).toBe(true)
+  })
+
+  test('Returns true for multiple equal values', () => {
+    const a = {
+      one: 1,
+      two: 'two',
+      three: true,
+    }
+
+    const b = {
+      one: 1,
+      two: 'two',
+      three: true,
+    }
+
+    expect(shallowPropMemoizeIsEqual([a], [b])).toBe(true)
+  })
+
+  test('Returns false for non-matching values', () => {
+    const a = {
+      one: [],
+    }
+
+    const b = {
+      one: [],
+    }
+
+    // Returns false because the Array instance is different
+    expect(shallowPropMemoizeIsEqual([a], [b])).toBe(false)
+  })
+})

--- a/src/utilities/env.ts
+++ b/src/utilities/env.ts
@@ -1,0 +1,11 @@
+import { isDefined } from './is'
+import get from './get'
+
+export const isBrowserEnv = (): boolean => {
+  // @ts-ignore
+  if (!isDefined(process)) return true
+  // @ts-ignore
+  return get(process, 'browser') === true
+}
+
+export const isNodeEnv = (): boolean => !isBrowserEnv()

--- a/src/utilities/memoize.ts
+++ b/src/utilities/memoize.ts
@@ -1,0 +1,8 @@
+import * as memoize from 'memoize-one'
+import getShallowDiffs from '@helpscout/react-utils/dist/getShallowDiffs'
+
+export const shallowPropMemoizeIsEqual = (a: any, b: any): boolean => {
+  return !getShallowDiffs(a[0], b[0]).diffs.length
+}
+
+export const memoizeWithProps = fn => memoize(fn, shallowPropMemoizeIsEqual)

--- a/stories/DropdownV2.stories.js
+++ b/stories/DropdownV2.stories.js
@@ -7,6 +7,7 @@ import Button from '../src/components/Button'
 import Input from '../src/components/Input'
 import styled from '../src/components/styled'
 import store from '../src/components/Dropdown/V2/Dropdown.store'
+import { boolean } from '@storybook/addon-knobs'
 import { createSpec, faker } from '@helpscout/helix'
 
 const stories = storiesOf('DropdownV2', module)
@@ -33,9 +34,12 @@ const ItemSpec = createSpec({
 })
 
 stories.add('Dropdown/Default', () => {
-  const items = ItemSpec.generate(100)
+  const props = {
+    items: ItemSpec.generate(100),
+    disabled: boolean('disabled', false),
+  }
 
-  return <Dropdown items={items} />
+  return <Dropdown {...props} />
 })
 
 stories.add('Dropdown/Empty', () => {

--- a/stories/SplitButton.stories.js
+++ b/stories/SplitButton.stories.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import Flexy from '../src/components/Flexy'
+import Button from '../src/components/Button'
 import SplitButton from '../src/components/SplitButton'
+import Modal from '../src/components/Modal'
 
 import {
   withKnobs,
@@ -102,3 +104,39 @@ stories.add('Sizes and Colours', () => {
 stories.add('Colors', () => buildGrid())
 
 stories.add('Disabled', () => buildGrid({ disabled: true }))
+
+stories.add('Within Modal', () => {
+  const WordSpec = createSpec({
+    key: faker.random.uuid(),
+    children: faker.lorem.sentence(),
+  })
+
+  class Example extends React.Component {
+    state = { count: 0 }
+
+    increment = () => this.setState({ count: this.state.count + 1 })
+
+    render() {
+      return (
+        <Modal trigger={<Button>Open dis modal</Button>} isOpen={true}>
+          <Modal.Body>
+            <Button version={2} onClick={this.increment} kind="primaryAlt">
+              Update State
+            </Button>
+            <br />
+            {[...Array(this.state.count)].map(i => {
+              const content = WordSpec.generate()
+              return <p {...content} />
+            })}
+            <br />
+            <SplitButton dropdownProps={dropdownProps} kind="primary" size="lg">
+              Primary
+            </SplitButton>
+          </Modal.Body>
+        </Modal>
+      )
+    }
+  }
+
+  return <Example />
+})

--- a/stories/SplitButton.stories.js
+++ b/stories/SplitButton.stories.js
@@ -19,13 +19,11 @@ const stories = storiesOf('SplitButton', module)
 
 stories.addDecorator(
   withArtboard({
-    id: 'hsds-SplitButton',
     width: 500,
     height: 300,
     withCenterGuides: false,
   })
 )
-stories.addDecorator(withKnobs)
 
 const ItemSpec = createSpec({
   label: faker.lorem.words(),
@@ -118,7 +116,7 @@ stories.add('Within Modal', () => {
 
     render() {
       return (
-        <Modal trigger={<Button>Open dis modal</Button>} isOpen={true}>
+        <Modal trigger={<Button>Open dis modal</Button>}>
           <Modal.Body>
             <Button version={2} onClick={this.increment} kind="primaryAlt">
               Update State
@@ -129,7 +127,13 @@ stories.add('Within Modal', () => {
               return <p {...content} />
             })}
             <br />
-            <SplitButton dropdownProps={dropdownProps} kind="primary" size="lg">
+            <SplitButton
+              dropdownProps={{
+                ...dropdownProps,
+              }}
+              kind="primary"
+              size="lg"
+            >
               Primary
             </SplitButton>
           </Modal.Body>


### PR DESCRIPTION
## DropdownV2: Better menu repositioning

![screen recording 2019-02-28 at 12 24 pm](https://user-images.githubusercontent.com/2322354/53598344-72369100-3b72-11e9-9af7-0c6442ffb242.gif)

This update dramatically improves the menu positioning mechanisms for `DropdownV2`. The primary changes involved:

1. More frequent get/set for the `trigger` node
2. A `requestAnimationFrame` loop that performantly repositions the menu
3. A new `positionFixed` prop, which defaults to `false`.

## Screencast:

https://www.useloom.com/share/60d1873ad62e4498b00bd2024ee7c8b9

cc'ing @jmauerhan for x-team review