### PR TITLE
Dropdown: Fix ComboBox positioning with shouldDropDirectionUpdate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,8 +22,8 @@
   "eslint.enable": true,
   "workbench.colorCustomizations": {
     "statusBar.foreground": "#ffffff",
-    "statusBar.background": "#3197D6",
-    "statusBar.noFolderBackground": "#3197D6",
-    "statusBar.debuggingBackground": "#3197D6"
+    "statusBar.background": "#1292EE",
+    "statusBar.noFolderBackground": "#1292EE",
+    "statusBar.debuggingBackground": "#1292EE"
   }
 }

--- a/src/components/ComboBox/ComboBox.tsx
+++ b/src/components/ComboBox/ComboBox.tsx
@@ -26,6 +26,7 @@ export interface ComboBoxProps extends DropdownProps {
   renderMenuEnd?: () => void
   renderFooter?: () => void
   showInput: boolean
+  shouldDropDirectionUpdate: (Position: any) => boolean
 }
 
 export interface ComboBoxState {
@@ -57,6 +58,7 @@ export class ComboBox extends React.Component<ComboBoxProps, ComboBoxState> {
     maxWidth: 222,
     noResultsLabel: 'No results',
     showInput: true,
+    shouldDropDirectionUpdate: () => false,
   }
 
   state = {

--- a/src/components/ComboBox/ComboBox.tsx
+++ b/src/components/ComboBox/ComboBox.tsx
@@ -15,6 +15,16 @@ import {
 import { HeaderUI, InputUI, MenuUI, EmptyItemUI } from './ComboBox.css'
 import { COMPONENT_KEY } from './ComboBox.utils'
 
+export const shouldDropDirectionUpdate = (positionProps: any = {}) => {
+  // Allow for the position to change, if ComboBox is set to dropUp
+  if (positionProps.dropUp) {
+    return true
+    // Otherwise, disable it
+  } else {
+    return false
+  }
+}
+
 export interface ComboBoxProps extends DropdownProps {
   closeOnInputTab: boolean
   customFilter?: (filterProps: Object, defaultFilter: any) => void
@@ -58,7 +68,7 @@ export class ComboBox extends React.Component<ComboBoxProps, ComboBoxState> {
     maxWidth: 222,
     noResultsLabel: 'No results',
     showInput: true,
-    shouldDropDirectionUpdate: () => false,
+    shouldDropDirectionUpdate,
   }
 
   state = {

--- a/src/components/ComboBox/__tests__/ComboBox.test.tsx
+++ b/src/components/ComboBox/__tests__/ComboBox.test.tsx
@@ -496,3 +496,29 @@ describe('onOpen/onClose', () => {
     expect(spy).toHaveBeenCalled()
   })
 })
+
+describe('shouldDropDirectionUpdate', () => {
+  test('Resolves to false, by default', () => {
+    const wrapper = mount(<ComboBox />)
+    const el = wrapper.find('Dropdown')
+
+    // @ts-ignore
+    expect(el.prop('shouldDropDirectionUpdate')()).toBe(false)
+  })
+
+  test('Can be customized', () => {
+    const spy = jest.fn()
+    const customShouldDropDirectionUpdate = () => {
+      spy()
+      return true
+    }
+    const wrapper = mount(
+      <ComboBox shouldDropDirectionUpdate={customShouldDropDirectionUpdate} />
+    )
+    const el = wrapper.find('Dropdown')
+
+    // @ts-ignore
+    expect(el.prop('shouldDropDirectionUpdate')()).toBe(true)
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/src/components/ComboBox/__tests__/ComboBox.test.tsx
+++ b/src/components/ComboBox/__tests__/ComboBox.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { mount } from 'enzyme'
-import { ComboBox } from '../ComboBox'
+import { ComboBox, shouldDropDirectionUpdate } from '../ComboBox'
 import { hasClass } from '../../../tests/helpers/enzyme'
 
 jest.mock('../../Dropdown/V2/Dropdown.Card', () => {
@@ -504,6 +504,7 @@ describe('shouldDropDirectionUpdate', () => {
 
     // @ts-ignore
     expect(el.prop('shouldDropDirectionUpdate')()).toBe(false)
+    expect(shouldDropDirectionUpdate({})).toBe(false)
   })
 
   test('Can be customized', () => {
@@ -520,5 +521,13 @@ describe('shouldDropDirectionUpdate', () => {
     // @ts-ignore
     expect(el.prop('shouldDropDirectionUpdate')()).toBe(true)
     expect(spy).toHaveBeenCalled()
+  })
+
+  test('Allows for dropUp, by default', () => {
+    const props = {
+      dropUp: true,
+    }
+
+    expect(shouldDropDirectionUpdate(props)).toBe(true)
   })
 })

--- a/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
+++ b/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
@@ -110,7 +110,9 @@ export class MenuContainer extends React.PureComponent<Props> {
   // Skipping coverage for this method as it does almost exclusively DOM
   // calculations, which isn't a JSDOM's forte.
   shouldDropUp(): boolean {
+    // Always return true, if dropUp
     if (this.props.dropUp) return true
+
     if (!this.node || !this.wrapperNode) return false
 
     const { top } = this.wrapperNode.getBoundingClientRect()
@@ -126,7 +128,13 @@ export class MenuContainer extends React.PureComponent<Props> {
   }
 
   shouldDropDirectionUpdate(positionProps): boolean {
-    return this.didOpen && this.props.shouldDropDirectionUpdate(positionProps)
+    return (
+      this.didOpen &&
+      this.props.shouldDropDirectionUpdate({
+        ...positionProps,
+        dropUp: this.props.dropUp,
+      })
+    )
   }
 
   getMenuProps() {

--- a/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
+++ b/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
@@ -57,6 +57,7 @@ export interface Props {
   renderEmpty?: any
   renderLoading?: any
   selectItem: (...args: any[]) => void
+  shouldDropDirectionUpdate: (Position: any) => boolean
   triggerId?: string
   triggerNode?: HTMLElement
   zIndex: number
@@ -80,11 +81,13 @@ export class MenuContainer extends React.PureComponent<Props> {
     onMenuReposition: noop,
     onMenuUnmounted: noop,
     positionFixed: false,
+    shouldDropDirectionUpdate: noop,
     selectItem: noop,
     zIndex: 1080,
   }
 
   id: string = uniqueID()
+  didOpen: boolean = false
   node: HTMLElement
   parentNode: HTMLElement
   placementNode: HTMLElement
@@ -120,6 +123,10 @@ export class MenuContainer extends React.PureComponent<Props> {
       return !hasWindowTopOverflow
     }
     return false
+  }
+
+  shouldDropDirectionUpdate(positionProps): boolean {
+    return this.didOpen && this.props.shouldDropDirectionUpdate(positionProps)
   }
 
   getMenuProps() {
@@ -272,6 +279,9 @@ export class MenuContainer extends React.PureComponent<Props> {
   /* istanbul ignore next */
   repositionMenuNodeCycle = () => {
     this.updateMenuNodePosition()
+    if (!this.didOpen) {
+      this.didOpen = true
+    }
     if (isBrowserEnv()) {
       requestAnimationFrame(this.repositionMenuNodeCycle)
     }
@@ -285,6 +295,7 @@ export class MenuContainer extends React.PureComponent<Props> {
 
   onPortalClose = () => {
     this.props.onMenuUnmounted()
+    this.didOpen = false
     // End the reposition cycle
     cancelAnimationFrame(this.positionRAF)
   }
@@ -310,12 +321,22 @@ export class MenuContainer extends React.PureComponent<Props> {
     }
   }
 
-  setPositionStylesOnNode = positionProps => {
+  setPositionStylesOnNode = positionData => {
     const { menuOffsetTop, onMenuReposition, triggerNode, zIndex } = this.props
 
     if (!this.node || !this.placementNode) return
 
-    const { top, left, position } = positionProps
+    const { top, left, position } = positionData
+
+    const positionProps = {
+      top: Math.round(top),
+      left: Math.round(left),
+      position,
+      triggerNode,
+      placementNode: this.placementNode,
+      menuNode: this.node,
+      zIndex,
+    }
 
     this.placementNode.style.position = position
     this.placementNode.style.top = `${Math.round(top)}px`
@@ -323,15 +344,7 @@ export class MenuContainer extends React.PureComponent<Props> {
     this.placementNode.style.zIndex = `${zIndex}`
 
     // Provide properties via stateReducer callback
-    onMenuReposition({
-      top: `${Math.round(top)}px`,
-      left: `${Math.round(left)}px`,
-      position,
-      triggerNode,
-      placementNode: this.placementNode,
-      menuNode: this.node,
-      zIndex: `${zIndex}`,
-    })
+    onMenuReposition(positionProps)
 
     /* istanbul ignore next */
     // Skipping coverage for this method as it does almost exclusively DOM
@@ -341,7 +354,7 @@ export class MenuContainer extends React.PureComponent<Props> {
     }
 
     /* istanbul ignore next */
-    if (this.shouldDropUp()) {
+    if (this.shouldDropUp() && this.shouldDropDirectionUpdate(positionProps)) {
       this.node.classList.add('is-dropUp')
       if (triggerNode) {
         this.placementNode.style.marginTop = `-${triggerNode.clientHeight +
@@ -448,6 +461,7 @@ const ConnectedMenuContainer: any = connect(
       positionFixed,
       renderEmpty,
       renderLoading,
+      shouldDropDirectionUpdate,
       triggerId,
       triggerNode,
       zIndex,
@@ -465,6 +479,7 @@ const ConnectedMenuContainer: any = connect(
       positionFixed,
       renderEmpty,
       renderLoading,
+      shouldDropDirectionUpdate,
       triggerId,
       triggerNode,
       zIndex,

--- a/src/components/Dropdown/V2/Dropdown.store.js
+++ b/src/components/Dropdown/V2/Dropdown.store.js
@@ -38,7 +38,7 @@ export const initialState = {
   positionFixed: false,
   previousIndex: null,
   selectedItem: '',
-  shouldDropDirectionUpdate: () => true,
+  shouldDropDirectionUpdate: noop,
   stateReducer: state => state,
   subscribe: noop,
   trigger: 'Dropdown',

--- a/src/components/Dropdown/V2/Dropdown.store.js
+++ b/src/components/Dropdown/V2/Dropdown.store.js
@@ -38,6 +38,7 @@ export const initialState = {
   positionFixed: false,
   previousIndex: null,
   selectedItem: '',
+  shouldDropDirectionUpdate: () => true,
   stateReducer: state => state,
   subscribe: noop,
   trigger: 'Dropdown',

--- a/src/components/Dropdown/V2/Dropdown.types.ts
+++ b/src/components/Dropdown/V2/Dropdown.types.ts
@@ -63,6 +63,7 @@ export interface DropdownProps extends DropdownMenuDimensions {
   selectedItem?: string | Object
   setMenuNode: (node: HTMLElement) => void
   setTriggerNode: (node: HTMLElement) => void
+  shouldDropDirectionUpdate: (Position: any) => boolean
   stateReducer: (...args: any[]) => void
   trigger: any
   triggerRef: (node: HTMLElement) => void

--- a/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.test.tsx
+++ b/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.test.tsx
@@ -496,7 +496,6 @@ describe('forceHideMenuNode', () => {
 describe('shouldDropDirectionUpdate', () => {
   test('Gets called when position is being calculated', () => {
     const spy = jest.fn()
-    const mockPositionProps = {}
 
     const shouldDropDirectionUpdate = props => {
       spy(props)
@@ -512,9 +511,9 @@ describe('shouldDropDirectionUpdate', () => {
 
     // Mock triggering
     // @ts-ignore
-    wrapper.instance().shouldDropDirectionUpdate(mockPositionProps)
+    wrapper.instance().shouldDropDirectionUpdate()
 
-    expect(spy).toHaveBeenCalledWith(mockPositionProps)
+    expect(spy).toHaveBeenCalled()
   })
 
   test('Does not get called on the first positionMenuNodeCycle run', () => {

--- a/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.test.tsx
+++ b/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.test.tsx
@@ -325,7 +325,13 @@ describe('Style/Direction', () => {
   })
 
   test('Renders dropUp styles, if defined', () => {
-    const wrapper = mount(<MenuContainer dropUp={true} />)
+    const wrapper = mount(<MenuContainer />)
+    // @ts-ignore
+    wrapper.instance().shouldDropDirectionUpdate = () => true
+
+    wrapper.setProps({ dropUp: true })
+    wrapper.update()
+
     const el = find(wrapper, baseSelector)
     const animate = wrapper.find('Animate')
 
@@ -484,5 +490,58 @@ describe('forceHideMenuNode', () => {
     wrapper.unmount()
 
     expect(placementNode.style.display).toBe('none')
+  })
+})
+
+describe('shouldDropDirectionUpdate', () => {
+  test('Gets called when position is being calculated', () => {
+    const spy = jest.fn()
+    const mockPositionProps = {}
+
+    const shouldDropDirectionUpdate = props => {
+      spy(props)
+      return true
+    }
+
+    const wrapper = mount(
+      <MenuContainer shouldDropDirectionUpdate={shouldDropDirectionUpdate} />
+    )
+    // Mocking Portal callbacks that open the Menu
+    // @ts-ignore
+    wrapper.instance().didOpen = true
+
+    // Mock triggering
+    // @ts-ignore
+    wrapper.instance().shouldDropDirectionUpdate(mockPositionProps)
+
+    expect(spy).toHaveBeenCalledWith(mockPositionProps)
+  })
+
+  test('Does not get called on the first positionMenuNodeCycle run', () => {
+    const spy = jest.fn()
+
+    const shouldDropDirectionUpdate = props => {
+      spy(props)
+      return true
+    }
+
+    const wrapper = mount(
+      <MenuContainer shouldDropDirectionUpdate={shouldDropDirectionUpdate} />
+    )
+    // Mocking Portal callbacks that open the Menu
+    // @ts-ignore
+    wrapper.instance().didOpen = false
+    // @ts-ignore
+    wrapper.instance().shouldDropDirectionUpdate()
+
+    expect(spy).not.toHaveBeenCalled()
+
+    // Mocking RAF loop, on the 2nd run
+    // @ts-ignore
+    wrapper.instance().didOpen = true
+    // @ts-ignore
+    wrapper.instance().shouldDropDirectionUpdate()
+
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/src/components/Dropdown/V2/docs/Dropdown.md
+++ b/src/components/Dropdown/V2/docs/Dropdown.md
@@ -41,51 +41,64 @@ This component supports async rendering of items. Render the `Dropdown` as you w
 
 ## Props
 
-| Prop                | Type                     | Default      | Description                                                                     |
-| ------------------- | ------------------------ | ------------ | ------------------------------------------------------------------------------- |
-| activeClassName     | `string`                 | `is-active`  | ClassName for an active item.                                                   |
-| clearOnSelect       | `boolean`                | `true`       | Removes selected item on select.                                                |
-| closeOnSelect       | `boolean`                | `true`       | Closes Dropdown on select.                                                      |
-| children            | `Function`               |              | Render prop to customize the Dropdown contents.                                 |
-| direction           | `string`                 | `down`       | Preferred for the menu to drop.                                                 |
-| disabled            | `bool`                   | false        | Disable the dropdown trigger so it can't be clicked.                            |
-| dropUp              | `boolean`                | `false`      | Changes the dropdown to drop upwards.                                           |
-| enableTabNavigation | `boolean`                | `true`       | Enables Tab keypresses to navigate through items.                               |
-| envNode             | `Document`/`HTMLElement` | `document`   | Node to bind global events.                                                     |
-| focusClassName      | `string`                 | `is-focused` | ClassName for a focused item.                                                   |
-| index               | `string`                 |              | Current selected item index.                                                    |
-| inputValue          | `string`                 |              |                                                                                 | Used when constructing a filterable Dropdown. |
-| id                  | `string`                 |              | ID of the component.                                                            |
-| innerRef            | `Function`               |              | Retrieves the Dropdown DOM node.                                                |
-| items               | `Array<Object>`          | `[]`         | Items to render.                                                                |
-| isLoading           | `boolean`                | `false`      | Renders the loading UI.                                                         |
-| onBlur              | `Function`               |              | Callback when the Trigger blurs.                                                |
-| onFocus             | `Function`               |              | Callback when the Trigger focuses.                                              |
-| onOpen              | `Function`               |              | Callback when the dropdown opens.                                               |
-| onClose             | `Function`               |              | Callback when the dropdown closes.                                              |
-| onSelect            | `Function`               |              | Callback an item is selected.                                                   |
-| maxHeight           | `number`                 | `320`        | Maximum height for the menu.                                                    |
-| maxWidth            | `number`                 | `360`        | Maximum width for the menu.                                                     |
-| minHeight           | `number`                 | `48`         | Minimum width for the menu.                                                     |
-| minWidth            | `number`                 | `180`        | Minimum width for the menu.                                                     |
-| menuRef             | `Function`               |              | Retrieves the Dropdown Menu DOM node.                                           |
-| openClassName       | `string`                 | `is-open`    | ClassName for an open item (with a sub menu).                                   |
-| positionFixed       | `boolean`                | `false`      | Renders menu as position `fixed`. Otherwise, it's `absolute`.                   |
-| renderEmpty         | `Function`               |              | Callback to render the empty UI.                                                |
-| renderLoading       | `Function`               |              | Callback to render the loading UI.                                              |
-| renderItem          | `Function`               |              | Callback to customize how an item renders.                                      |
-| renderTrigger       | `Function`               |              | Callback to customize how an trigger renders.                                   |
-| selectedItem        | `string`/`Object`        |              | Controls the dropdown and sets the "active" item.                               |
-| stateReducer        | `Function`               |              | Callback when the store state changes. Can be used to customize Dropdown state. |
-| subscribe           | `Function`               |              | Subscribes to internal Dropdown state changes.                                  |
-| trigger             | `string`                 | `Dropdown`   | The text to render into the trigger.                                            |
-| triggerRef          | `Function`               |              | Retrieves the Dropdown Trigger DOM node.                                        |
-| triggerStyle        | `Object`                 |              | Inline styles for the Trigger wrapper.                                          |
-| withScrollLock      | `boolean`                | `true`       | Scroll locks the Dropdown menu.                                                 |
-| zIndex              | `number`                 | `1080`       | CSS `z-index` for the menu.                                                     |
+| Prop                      | Type                     | Default      | Description                                                                                                  |
+| ------------------------- | ------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------ |
+| activeClassName           | `string`                 | `is-active`  | ClassName for an active item.                                                                                |
+| clearOnSelect             | `boolean`                | `true`       | Removes selected item on select.                                                                             |
+| closeOnSelect             | `boolean`                | `true`       | Closes Dropdown on select.                                                                                   |
+| children                  | `Function`               |              | Render prop to customize the Dropdown contents.                                                              |
+| direction                 | `string`                 | `right`      | Preferred horizontal drop direction for the menu.                                                            |
+| disabled                  | `bool`                   | `false`      | Disable the dropdown trigger so it can't be clicked.                                                         |
+| dropUp                    | `boolean`                | `false`      | Changes the dropdown to drop upwards.                                                                        |
+| enableTabNavigation       | `boolean`                | `true`       | Enables Tab keypresses to navigate through items.                                                            |
+| envNode                   | `Document`/`HTMLElement` | `document`   | Node to bind global events.                                                                                  |
+| focusClassName            | `string`                 | `is-focused` | ClassName for a focused item.                                                                                |
+| index                     | `string`                 |              | Current selected item index.                                                                                 |
+| inputValue                | `string`                 |              |                                                                                                              | Used when constructing a filterable Dropdown. |
+| id                        | `string`                 |              | ID of the component.                                                                                         |
+| innerRef                  | `Function`               |              | Retrieves the Dropdown DOM node.                                                                             |
+| items                     | `Array<Object>`          | `[]`         | Items to render.                                                                                             |
+| isLoading                 | `boolean`                | `false`      | Renders the loading UI.                                                                                      |
+| onBlur                    | `Function`               |              | Callback when the Trigger blurs.                                                                             |
+| onFocus                   | `Function`               |              | Callback when the Trigger focuses.                                                                           |
+| onOpen                    | `Function`               |              | Callback when the dropdown opens.                                                                            |
+| onClose                   | `Function`               |              | Callback when the dropdown closes.                                                                           |
+| onSelect                  | `Function`               |              | Callback an item is selected.                                                                                |
+| maxHeight                 | `number`                 | `320`        | Maximum height for the menu.                                                                                 |
+| maxWidth                  | `number`                 | `360`        | Maximum width for the menu.                                                                                  |
+| minHeight                 | `number`                 | `48`         | Minimum width for the menu.                                                                                  |
+| minWidth                  | `number`                 | `180`        | Minimum width for the menu.                                                                                  |
+| menuRef                   | `Function`               |              | Retrieves the Dropdown Menu DOM node.                                                                        |
+| openClassName             | `string`                 | `is-open`    | ClassName for an open item (with a sub menu).                                                                |
+| positionFixed             | `boolean`                | `false`      | Renders menu as position `fixed`. Otherwise, it's `absolute`.                                                |
+| renderEmpty               | `Function`               |              | Callback to render the empty UI.                                                                             |
+| renderLoading             | `Function`               |              | Callback to render the loading UI.                                                                           |
+| renderItem                | `Function`               |              | Callback to customize how an item renders.                                                                   |
+| renderTrigger             | `Function`               |              | Callback to customize how an trigger renders.                                                                |
+| selectedItem              | `string`/`Object`        |              | Controls the dropdown and sets the "active" item.                                                            |
+| shouldDropDirectionUpdate | `Function`               |              | Callback to determine if the dropdown should update it's `up`/`down` drop direction. Default returns `true`. |
+| stateReducer              | `Function`               |              | Callback when the store state changes. Can be used to customize Dropdown state.                              |
+| subscribe                 | `Function`               |              | Subscribes to internal Dropdown state changes.                                                               |
+| trigger                   | `string`                 | `Dropdown`   | The text to render into the trigger.                                                                         |
+| triggerRef                | `Function`               |              | Retrieves the Dropdown Trigger DOM node.                                                                     |
+| triggerStyle              | `Object`                 |              | Inline styles for the Trigger wrapper.                                                                       |
+| withScrollLock            | `boolean`                | `true`       | Scroll locks the Dropdown menu.                                                                              |
+| zIndex                    | `number`                 | `1080`       | CSS `z-index` for the menu.                                                                                  |
 
 ### Types
 
 | Prop      | Types         |
 | --------- | ------------- |
 | direction | `up` / `down` |
+
+### `shouldUpdateDirection(Position)`
+
+| Prop          | Type          | Description                                                |
+| ------------- | ------------- | ---------------------------------------------------------- |
+| top           | `number`      | The distance of the Menu node from the top of the window.  |
+| left          | `number`      | The distance of the Menu node from the left of the window. |
+| position      | `string`      | The position (e.g. `fixed`) defined in props.              |
+| triggerNode   | `HTMLElement` | The Trigger DOM node.                                      |
+| placementNode | `HTMLElement` | The wrapper DOM node for the Menu.                         |
+| menuNode      | `HTMLElement` | The Menu DOM node.                                         |
+| zIndex        | `number`      | The z-index value defined in props.                        |

--- a/stories/ComboBox.stories.js
+++ b/stories/ComboBox.stories.js
@@ -50,6 +50,12 @@ stories.add('Default', () => {
   return <ComboBox itemFilterKey="label" items={items} isOpen={true} />
 })
 
+stories.add('DropUp', () => {
+  return (
+    <ComboBox itemFilterKey="label" items={items} isOpen={true} dropUp={true} />
+  )
+})
+
 stories.add('StateReducer', () => {
   const stateReducer = (state, action) => {
     console.group('State update')


### PR DESCRIPTION
## Dropdown: Fix ComboBox positioning with shouldDropDirectionUpdate

![screen recording 2019-03-06 at 09 46 am](https://user-images.githubusercontent.com/2322354/53889885-2b72ec00-3ff5-11e9-8a42-d5b23cc138e7.gif)

(ComboBox, by default, should always drop down, if defined)

This update fixes the up/down menu position of `ComboBox` based dropdowns
that happens when the list size changes (during filtering).

The solution was to introduce a new prop called `shouldDropDirectionUpdate`.
By default, in `Dropdown`, it resolves to `true`. However, in `ComboBox`,
we'll resolve it to `false`.

The user can adjust this, if required.

`Dropdown` auto positioning works as before:
![screen recording 2019-03-06 at 09 45 am](https://user-images.githubusercontent.com/2322354/53889909-3c236200-3ff5-11e9-8712-382561f7fd26.gif)


#### Screencast

I recorded a screencast for additional details:

https://www.useloom.com/share/be89d280e6984512a707571e35e15cbc

---

Future enhancement idea:

Ideally, the menu position **should** auto calculate for `ComboBox`, but only on the initial render. Subsequent updates shouldn't change it's positioning. There are more edge cases with this, but I think this is the end-goal.

For now, this "hard coded" solution is simpler and more stable.