### PR TITLE
PropProvider: Fix rendering for empty array

### DIFF
--- a/src/components/PropProvider/PropProvider.tsx
+++ b/src/components/PropProvider/PropProvider.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { PropProviderProps } from './types'
 import Context from './Context'
 import { ThemeProvider } from '../styled'
+import { renderAsSingleChild } from '../../utilities/component'
 import { setGlobalApp, shallowMergeProps, propProviderDataAttr } from './utils'
 
 export interface Props {
@@ -16,16 +17,10 @@ class PropProvider extends React.Component<Props> {
     value: {},
   }
 
-  getChildren = () => {
+  renderChildren = () => {
     const { children } = this.props
 
-    if (!children) return null
-
-    if (React.Children.count(children) > 1) {
-      return <div className="c-PropProvider">{children}</div>
-    }
-
-    return React.Children.only(children)
+    return renderAsSingleChild(children, 'div', { className: 'c-PropProvider' })
   }
 
   enhanceContextProps = (contextProps: PropProviderProps) => {
@@ -48,7 +43,7 @@ class PropProvider extends React.Component<Props> {
             )}
           >
             <ThemeProvider theme={this.getThemeProviderProps(contextProps)}>
-              {this.getChildren()}
+              {this.renderChildren()}
             </ThemeProvider>
           </Context.Provider>
         )}

--- a/src/components/PropProvider/__tests__/PropProvider.test.js
+++ b/src/components/PropProvider/__tests__/PropProvider.test.js
@@ -11,6 +11,36 @@ describe('PropProvider', () => {
 
       expect(wrapper.html()).toBeFalsy()
     })
+
+    test('Can render single child', () => {
+      const wrapper = mount(
+        <PropProvider>
+          <p>One</p>
+        </PropProvider>
+      )
+
+      expect(wrapper.html()).toBeTruthy()
+      expect(wrapper.find('p').length).toBe(1)
+    })
+
+    test('Can render multiple children', () => {
+      const wrapper = mount(
+        <PropProvider>
+          <p>One</p>
+          <p>Two</p>
+          <p>Three</p>
+        </PropProvider>
+      )
+
+      expect(wrapper.html()).toBeTruthy()
+      expect(wrapper.find('p').length).toBe(3)
+    })
+
+    test('Can handle rendering of an empty array', () => {
+      const wrapper = mount(<PropProvider>{[]}</PropProvider>)
+
+      expect(wrapper.html()).toBeFalsy()
+    })
   })
 
   describe('Nesting/Scope', () => {

--- a/src/utilities/__tests__/component.test.js
+++ b/src/utilities/__tests__/component.test.js
@@ -8,6 +8,7 @@ import {
   namespaceComponent,
   renderRenderPropComponent,
   renderChildrenSafely,
+  renderAsSingleChild,
   __clearRegisteredComponents,
 } from '../component'
 
@@ -271,5 +272,133 @@ describe('renderChildrenSafely', () => {
 
     expect(el.text()).toContain('Hello')
     expect(el.prop('data-cy')).toBe('Hello')
+  })
+})
+
+describe('renderAsSingleChild', () => {
+  const Comp = ({ children }) => renderAsSingleChild(children)
+
+  test('Can handle undefined children', () => {
+    const wrapper = mount(<Comp>{undefined}</Comp>)
+
+    expect(wrapper.html()).toBeFalsy()
+  })
+
+  test('Can handle null children', () => {
+    const wrapper = mount(<Comp>{null}</Comp>)
+
+    expect(wrapper.html()).toBeFalsy()
+  })
+
+  test('Can handle false children', () => {
+    const wrapper = mount(<Comp>{false}</Comp>)
+
+    expect(wrapper.html()).toBeFalsy()
+  })
+
+  test('Can handle 0 children', () => {
+    const wrapper = mount(<Comp>{0}</Comp>)
+
+    expect(wrapper.html()).toBeFalsy()
+  })
+
+  test('Can handle true children', () => {
+    const wrapper = mount(<Comp>{true}</Comp>)
+
+    expect(wrapper.html()).toBeFalsy()
+  })
+
+  test('Can handle empty array of children', () => {
+    const wrapper = mount(<Comp>{[]}</Comp>)
+
+    expect(wrapper.html()).toBeFalsy()
+  })
+
+  test('Can handle empty Object of children', () => {
+    const wrapper = mount(<Comp>{{}}</Comp>)
+
+    expect(wrapper.html()).toBeFalsy()
+  })
+
+  test('Can handle single child component', () => {
+    const wrapper = mount(
+      <Comp>
+        <p />
+      </Comp>
+    )
+
+    expect(wrapper.html()).toBeTruthy()
+    expect(wrapper.find('p').length).toBe(1)
+  })
+
+  test('Can handle multiple child components', () => {
+    const wrapper = mount(
+      <Comp>
+        <p />
+        <p />
+        <p />
+      </Comp>
+    )
+
+    expect(wrapper.html()).toBeTruthy()
+    expect(wrapper.find('p').length).toBe(3)
+  })
+
+  test('Can handle multiple child components', () => {
+    const wrapper = mount(
+      <Comp>
+        <p />
+        <p />
+        <p />
+      </Comp>
+    )
+
+    expect(wrapper.html()).toBeTruthy()
+    expect(wrapper.find('p').length).toBe(3)
+  })
+
+  test('Creates a wrapper for multiple child components', () => {
+    const wrapper = mount(
+      <Comp>
+        <p />
+        <p />
+        <p />
+      </Comp>
+    )
+
+    expect(wrapper.html()).toBeTruthy()
+    expect(wrapper.find('div').length).toBe(1)
+    expect(wrapper.find('p').length).toBe(3)
+  })
+
+  test('Can customize the wrapper baseTag', () => {
+    const Comp = ({ children }) => renderAsSingleChild(children, 'section')
+    const wrapper = mount(
+      <Comp>
+        <p />
+        <p />
+        <p />
+      </Comp>
+    )
+
+    expect(wrapper.html()).toBeTruthy()
+    expect(wrapper.find('section').length).toBe(1)
+    expect(wrapper.find('p').length).toBe(3)
+  })
+
+  test('Can customize the wrapper props', () => {
+    const Comp = ({ children }) =>
+      renderAsSingleChild(children, 'section', { className: 'Hello' })
+    const wrapper = mount(
+      <Comp>
+        <p />
+        <p />
+        <p />
+      </Comp>
+    )
+
+    expect(wrapper.html()).toBeTruthy()
+    expect(wrapper.find('section.Hello').length).toBe(1)
+    expect(wrapper.find('p').length).toBe(3)
   })
 })

--- a/src/utilities/component.ts
+++ b/src/utilities/component.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { includes } from './arrays'
-import { isFunction, isObject, isDefined, isString } from './is'
+import { isArray, isFunction, isObject, isDefined, isString } from './is'
 
 let REGISTERED_COMPONENTS = {}
 export const COMPONENT_NAMESPACE_KEY = '__BlueComponent__'
@@ -199,4 +199,25 @@ export const renderChildrenSafely = (
   } else {
     return React.createElement(baseTag, rest, children)
   }
+}
+
+export const renderAsSingleChild = (
+  children: any,
+  baseTag: 'div',
+  props: any = {}
+) => {
+  if (!React.isValidElement(children) && !isArray(children)) return null
+
+  const count = React.Children.count(children)
+  if (!count) return null
+
+  const tag = baseTag || 'div'
+
+  // Render multiple children
+  if (count > 1) {
+    return React.createElement(tag, props, children)
+  }
+
+  // Render single child
+  return React.Children.only(children)
 }


### PR DESCRIPTION
## PropProvider: Fix rendering for empty array

This update improves the rendering stability for PropProvider, allowing it
to handle `props.children` of varying types, including booleans,
empty objects, and empty arrays.

The solution involved creating a new `renderAsSingleChild` utility which
encapsulates all that logic.

Resolves: https://github.com/helpscout/hsds-react/issues/523