### PR TITLE
Button: Fix mapping of props.theme.brandColor

### DIFF
--- a/src/components/Button/Button.css.js
+++ b/src/components/Button/Button.css.js
@@ -1,4 +1,5 @@
 // @flow
+import get from 'dash-get'
 import baseStyles from '../../styles/resets/baseStyles.css.js'
 import styled from '../styled'
 import { getColor } from '../../styles/utilities/color'
@@ -293,7 +294,7 @@ export const makeButtonUI = (selector: 'button') => {
 }
 
 function makePrimaryStyles(name = 'primary', props: Object = {}): string {
-  const { theme = {} } = props
+  const theme = get(props, 'theme.brandColor', {})
   const backgroundColor =
     theme.backgroundColorUI || theme.brandColor || config[name].backgroundColor
   const color =

--- a/stories/GreeterCard.stories.js
+++ b/stories/GreeterCard.stories.js
@@ -54,7 +54,7 @@ class Story extends React.Component {
       getColor('green.500')
     )
 
-    const theme = { ...makeBrandColors(brandColor) }
+    const theme = { brandColor: makeBrandColors(brandColor) }
 
     const props = {
       in: show,


### PR DESCRIPTION
## Button: Fix mapping of props.theme.brandColor

This update fixes the Button (V2) styles to ensure that it gets the correct
theme properties from the `<ThemeProvider />`.

The shape of the `theme` prop should be:

```
theme = {
  brandColor: {
    ...themeBrandColors
  }
}
```

vs

```
theme = {
  ...themeBrandColors
}
```

Resolves: https://github.com/helpscout/hsds-react/issues/522