### PR TITLE
Fix renderAsSingleChild handling of Array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.17.0",
+  "version": "2.17.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.17.0",
+  "version": "2.17.1-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/utilities/__tests__/component.test.js
+++ b/src/utilities/__tests__/component.test.js
@@ -401,4 +401,48 @@ describe('renderAsSingleChild', () => {
     expect(wrapper.find('section.Hello').length).toBe(1)
     expect(wrapper.find('p').length).toBe(3)
   })
+
+  test('Can render a mapped Array of a single child', () => {
+    const InnerComponent = props => <p />
+    const data = [
+      {
+        id: 1,
+        key: 1,
+      },
+    ]
+    const Comp = ({ children }) =>
+      renderAsSingleChild(children, 'section', { className: 'Hello' })
+
+    const wrapper = mount(
+      <Comp>{data.map(d => <InnerComponent {...d} />)}</Comp>
+    )
+
+    expect(wrapper.find('p').length).toBe(1)
+  })
+
+  test('Can render a mapped Array of a multiple children', () => {
+    const InnerComponent = props => <p />
+    const data = [
+      {
+        id: 1,
+        key: 1,
+      },
+      {
+        id: 2,
+        key: 2,
+      },
+      {
+        id: 3,
+        key: 3,
+      },
+    ]
+    const Comp = ({ children }) =>
+      renderAsSingleChild(children, 'section', { className: 'Hello' })
+
+    const wrapper = mount(
+      <Comp>{data.map(d => <InnerComponent {...d} />)}</Comp>
+    )
+
+    expect(wrapper.find('p').length).toBe(3)
+  })
 })

--- a/src/utilities/component.ts
+++ b/src/utilities/component.ts
@@ -206,15 +206,16 @@ export const renderAsSingleChild = (
   baseTag: 'div',
   props: any = {}
 ) => {
-  if (!React.isValidElement(children) && !isArray(children)) return null
+  const _isArray = isArray(children)
+  if (!React.isValidElement(children) && !_isArray) return null
 
   const count = React.Children.count(children)
   if (!count) return null
 
   const tag = baseTag || 'div'
 
-  // Render multiple children
-  if (count > 1) {
+  // Render multiple children, or an array
+  if (count > 1 || _isArray) {
     return React.createElement(tag, props, children)
   }
 


### PR DESCRIPTION
## Fix renderAsSingleChild handling of Array

This update fixes the `renderAsSingleChild` util function to handle the
rendering of Arrays, of zero, singular, or multiple items.