### PR TITLE
Add HSDS version to window

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,11 +73,12 @@
     "test:coverage": "npm run test:dev -- --coverage",
     "test:dev": "node scripts/test.js --env=jsdom",
     "test:coverage:fast": "npm run test:coverage -- --onlyChanged",
-    "version": "npm run build",
+    "version": "npm run make:version && npm run build",
     "prettier:base": "prettier \"src/**/*.js\" \"test/**/*.js\" \"stories/**/*.js\" --parser=flow",
     "prettier": "npm run prettier:base -- --write",
     "update:icons": "node ./scripts/update-icons.js",
-    "process:icons": "node ./scripts/process-icons.js"
+    "process:icons": "node ./scripts/process-icons.js",
+    "make:version": "node ./scripts/make-version.js"
   },
   "peerDependencies": {
     "react": "^16 || ^15",

--- a/scripts/make-version.js
+++ b/scripts/make-version.js
@@ -1,0 +1,18 @@
+const fs = require('fs')
+const path = require('path')
+const pkg = require('../package.json')
+
+const targetFilePath = path.resolve(__dirname, '../src/utilities/pkg.ts')
+
+const setVersion = () => {
+  const content = `
+export default {
+  version: '${pkg.version}'
+}
+  `.trim()
+
+  console.log(`Generating ${targetFilePath}...`)
+  fs.writeFileSync(targetFilePath, content)
+}
+
+setVersion()

--- a/src/components/PropProvider/propConnect.tsx
+++ b/src/components/PropProvider/propConnect.tsx
@@ -10,6 +10,7 @@ import {
   isStateless,
 } from './utils'
 import { classNames } from '../../utilities/classNames'
+import { setPackageVersionToGlobal } from '../../utilities/info'
 import {
   namespaceComponent,
   isComponentNamespaced,
@@ -39,6 +40,8 @@ function propConnect(name?: ConfigGetter, options: Object = {}) {
   const { pure, mapConnectedPropsAsProps } = { ...defaultOptions, ...options }
   // @ts-ignore
   let namespace: string = isString(name) ? name : ''
+
+  setPackageVersionToGlobal()
 
   return function wrapWithComponent(WrappedComponent: any) {
     if (!isDefined(name)) {

--- a/src/utilities/__tests__/info.test.ts
+++ b/src/utilities/__tests__/info.test.ts
@@ -1,0 +1,20 @@
+import { HSDS_REACT_NAMESPACE, setPackageVersionToGlobal } from '../info'
+
+beforeEach(() => {
+  window[HSDS_REACT_NAMESPACE] = undefined
+})
+
+afterEach(() => {
+  window[HSDS_REACT_NAMESPACE] = undefined
+})
+
+describe('setPackageVersionToGlobal', () => {
+  test('Sets the version to window', () => {
+    setPackageVersionToGlobal()
+
+    const info = window[HSDS_REACT_NAMESPACE]
+
+    expect(info).toBeTruthy()
+    expect(info.version).toBeTruthy()
+  })
+})

--- a/src/utilities/info.ts
+++ b/src/utilities/info.ts
@@ -1,0 +1,17 @@
+import pkg from './pkg'
+
+export const HSDS_REACT_NAMESPACE = 'HSDSReact'
+
+export const getPackageVersion = () => pkg.version
+
+export const setGlobalNamespace = () => {
+  if (window[HSDS_REACT_NAMESPACE]) return
+  window[HSDS_REACT_NAMESPACE] = {
+    url: 'https://github.com/helpscout/hsds-react/',
+  }
+}
+
+export const setPackageVersionToGlobal = () => {
+  setGlobalNamespace()
+  window[HSDS_REACT_NAMESPACE].version = getPackageVersion()
+}

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,0 +1,3 @@
+export default {
+  version: '2.17.1-0',
+}


### PR DESCRIPTION
## Add HSDS version to window

<img width="619" alt="Screen Shot 2019-03-14 at 10 17 41 PM" src="https://user-images.githubusercontent.com/2322354/54403956-448c3480-46a8-11e9-9357-c2f7eb231245.png">


This update adds some info about HSDS React to `window`, which would be helpful
for debugging.

A version generator script was added which runs right after a version bump
occurs during a release. This generates a file, which is used during the
build/compile step.

The mechanism that adds the info to `window` was snuck into `propConnect`, since
the chances of it instantiating is extremely high. We aren't able to add it to any entry file
(like the main `index.js`) since we don't use HSDS: React that way.

Resolves: https://github.com/helpscout/hsds-react/issues/529