### PR TITLE
Link: Refactor + add voidOnClick

### DIFF
--- a/src/components/Link/Link.css.ts
+++ b/src/components/Link/Link.css.ts
@@ -1,0 +1,28 @@
+import styled from '../styled'
+import baseStyles from '../../styles/resets/baseStyles.css'
+import linkStyles from '../../styles/mixins/linkStyles.css'
+
+export const LinkUI = styled('a')`
+  ${baseStyles};
+  ${linkStyles};
+
+  &:focus {
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px;
+  }
+
+  &.is-block {
+    display: block;
+  }
+
+  &.is-no-underline {
+    text-decoration: none;
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  &.is-word-wrap {
+    word-break: break-word;
+  }
+`

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,30 +1,31 @@
-// @flow
-import React, { PureComponent as Component } from 'react'
+import * as React from 'react'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
+import RouteWrapper from '../RouteWrapper'
 import { classNames } from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import { wordHasSpaces } from '../../utilities/strings'
-import RouteWrapper from '../RouteWrapper'
+import { LinkUI } from './Link.css'
 
-type Props = {
-  autoWordWrap: boolean,
-  block: boolean,
-  className?: string,
-  children?: any,
-  external: boolean,
-  href: string,
-  nodeRef: () => void,
-  onBlur: () => void,
-  onClick: () => void,
-  onFocus: () => void,
-  rel: string,
-  noUnderline: boolean,
-  target?: string,
-  to: string,
-  wordWrap: boolean,
+export interface Props {
+  autoWordWrap: boolean
+  block: boolean
+  className?: string
+  children?: any
+  external: boolean
+  href: string
+  nodeRef: (node: any) => void
+  onBlur: (event: Event) => void
+  onClick: (event: Event) => void
+  onFocus: (event: Event) => void
+  rel: string
+  noUnderline: boolean
+  target?: string
+  to: string
+  voidOnClick: boolean
+  wordWrap: boolean
 }
 
-class Link extends Component<Props> {
+export class Link extends React.PureComponent<Props> {
   static defaultProps = {
     autoWordWrap: true,
     block: false,
@@ -34,6 +35,17 @@ class Link extends Component<Props> {
     onBlur: noop,
     onClick: noop,
     onFocus: noop,
+    voidOnClick: false,
+  }
+
+  getHref() {
+    const { href, voidOnClick } = this.props
+
+    if (voidOnClick) {
+      return 'javascript:void(0);'
+    }
+
+    return href
   }
 
   render() {
@@ -43,7 +55,6 @@ class Link extends Component<Props> {
       children,
       className,
       external,
-      href,
       target,
       nodeRef,
       noUnderline,
@@ -67,16 +78,16 @@ class Link extends Component<Props> {
     const rel = isTargetExternal ? 'noopener noreferrer' : undefined
 
     return (
-      <a
+      <LinkUI
         {...getValidProps(rest)}
         className={componentClassName}
         target={linkTarget}
         rel={rel}
         ref={nodeRef}
-        href={href}
+        href={this.getHref()}
       >
         {children}
-      </a>
+      </LinkUI>
     )
   }
 }

--- a/src/components/Link/README.md
+++ b/src/components/Link/README.md
@@ -18,14 +18,15 @@ You're my boy, <Link fetch={fetchBlueData} to="/blue">Blue</Link>!
 
 ## Props
 
-| Prop      | Type       | Description                                                                     |
-| --------- | ---------- | ------------------------------------------------------------------------------- |
-| className | `string`   | Custom class names to be added to the component.                                |
-| external  | `bool`     | Opens link in a new tab.                                                        |
-| fetch     | `function` | function which returns a promise, will be invoked before routing the `to` route |
-| href      | `string`   | Address for the link. Default is `#`.                                           |
-| nodeRef   | `func`     | Callback function to retrieve the component's DOM node.                         |
-| onBlur    | `function` | Callback function when the component is blurred.                                |
-| onClick   | `function` | Callback function when the component is clicked.                                |
-| onFocus   | `function` | Callback function when the component is focused.                                |
-| to        | `string`   | React Router path to navigate on click.                                         |
+| Prop        | Type       | Description                                                                     |
+| ----------- | ---------- | ------------------------------------------------------------------------------- |
+| className   | `string`   | Custom class names to be added to the component.                                |
+| external    | `bool`     | Opens link in a new tab.                                                        |
+| fetch       | `function` | function which returns a promise, will be invoked before routing the `to` route |
+| href        | `string`   | Address for the link. Default is `#`.                                           |
+| nodeRef     | `func`     | Callback function to retrieve the component's DOM node.                         |
+| onBlur      | `function` | Callback function when the component is blurred.                                |
+| onClick     | `function` | Callback function when the component is clicked.                                |
+| onFocus     | `function` | Callback function when the component is focused.                                |
+| to          | `string`   | React Router path to navigate on click.                                         |
+| voidOnClick | `boolean`  | Disables click event.                                                           |

--- a/src/components/Link/__tests__/Link.test.js
+++ b/src/components/Link/__tests__/Link.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import Link from '..'
+import RouteLink, { Link } from '../Link'
 
 // Since we now wrap Link in a HOC, we have to use `.first.shallow()` to test.
 // See https://github.com/airbnb/enzyme/issues/539#issuecomment-239497107
@@ -92,9 +92,9 @@ describe('RouteWrapper', () => {
   test('Specifying a `to` sets up router navigation, overrides default click', done => {
     const route = '/some/route/'
     const wrapper = wrap(
-      <Link href="/gator" to={route}>
+      <RouteLink href="/gator" to={route}>
         Gator
-      </Link>,
+      </RouteLink>,
       options
     )
     wrapper.simulate('click', clickEvent)
@@ -143,9 +143,9 @@ describe('RouteWrapper', () => {
     const fetch = () => Promise.resolve()
     const to = 'some/route'
     const wrapper = wrap(
-      <Link fetch={fetch} to={to}>
+      <RouteLink fetch={fetch} to={to}>
         Gator
-      </Link>,
+      </RouteLink>,
       options
     )
     expect(wrapper.getElement().type).toBe('a')
@@ -163,5 +163,23 @@ describe('Styles', () => {
     const wrapper = wrap(<Link block />)
 
     expect(wrapper.hasClass('is-block')).toBeTruthy()
+  })
+})
+
+describe('voidOnClick', () => {
+  test('Is not void by default', () => {
+    const wrapper = wrap(<Link href="/gator">Gator</Link>)
+
+    expect(wrapper.prop('href')).not.toBe('javascript:void(0);')
+  })
+
+  test('Disables the href if voidOnClick is set', () => {
+    const wrapper = wrap(
+      <Link href="/gator" voidOnClick>
+        Gator
+      </Link>
+    )
+
+    expect(wrapper.prop('href')).toBe('javascript:void(0);')
   })
 })

--- a/src/components/Link/__tests__/Link.test.js
+++ b/src/components/Link/__tests__/Link.test.js
@@ -148,7 +148,6 @@ describe('RouteWrapper', () => {
       </RouteLink>,
       options
     )
-    expect(wrapper.getElement().type).toBe('a')
     wrapper.simulate('click', clickEvent)
     expect(preventDefault).toHaveBeenCalled()
     setTimeout(() => {

--- a/src/components/Link/index.ts
+++ b/src/components/Link/index.ts
@@ -1,0 +1,3 @@
+import Link from './Link'
+
+export default Link

--- a/src/styles/components/Link.scss
+++ b/src/styles/components/Link.scss
@@ -1,27 +1,2 @@
-@import '../mixins/linkStyles';
-
-.c-Link {
-  @import '../resets/base';
-  @include linkStyles();
-
-  &:focus {
-    outline: 5px auto -webkit-focus-ring-color;
-    outline-offset: -2px;
-  }
-
-  // Modifiers
-  &.is-block {
-    display: block;
-  }
-
-  &.is-no-underline {
-    text-decoration: none;
-    &:hover {
-      text-decoration: none;
-    }
-  }
-
-  &.is-word-wrap {
-    word-break: break-word;
-  }
-}
+// Is now being rendered by Fancy :)
+// File exists to preserve @import implementation.

--- a/stories/Link.stories.js
+++ b/stories/Link.stories.js
@@ -1,7 +1,21 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { withArtboard } from '@helpscout/artboard'
+import { boolean, text } from '@storybook/addon-knobs'
 import { Link } from '../src/index.js'
 
-storiesOf('Link', module).add('default', () => (
-  <Link href="https://github.com/helpscout/hsds-react">Linky</Link>
-))
+const stories = storiesOf('Link', module)
+
+stories.addDecorator(
+  withArtboard({ width: 300, height: 100, withCenterGuides: false })
+)
+
+stories.add('Default', () => {
+  const props = {
+    children: text('Content', 'Linky'),
+    href: text('href', 'https://github.com/helpscout/hsds-react'),
+    voidOnClick: boolean('voidOnClick', false),
+  }
+
+  return <Link {...props} />
+})


### PR DESCRIPTION
## Link: Refactor + add voidOnClick

![Screen Recording 2019-03-14 at 10 45 PM](https://user-images.githubusercontent.com/2322354/54405419-e01fa400-46ac-11e9-86d3-f4c18166fbaa.gif)

This update refactors the `Link` component to TypeScript and use `css.ts`.
The previous SCSS styles have been removed.

`Link` has also been enhanced with a new prop, `voidOnClick`. This disabled
the click interaction if set to `true`.

Resolves: https://github.com/helpscout/hsds-react/issues/532

