### PR TITLE
Popover/Tooltip: Improve left/right placement

### DIFF
--- a/src/components/Pop/Popper.js
+++ b/src/components/Pop/Popper.js
@@ -167,13 +167,13 @@ export const enhancePopperStyles = (props: PopperStyles = {}) => {
   if (placement.indexOf('left') >= 0) {
     return {
       ...style,
-      left: `${(arrowSize * 2 + offset) * -1}px`,
+      left: `${arrowSize / 2 * -1}px`,
     }
   }
   if (placement.indexOf('right') >= 0) {
     return {
       ...style,
-      left: `${(arrowSize * 2 + offset) * 1}px`,
+      left: `${arrowSize / 2 * 1}px`,
     }
   }
 

--- a/src/components/Pop/__tests__/Popper.test.js
+++ b/src/components/Pop/__tests__/Popper.test.js
@@ -55,8 +55,8 @@ describe('enhancePopperStyles', () => {
   test('Adjusts placement styles', () => {
     expect(enhancePopperStyles({ placement: 'top' }).top).toBe('-5px')
     expect(enhancePopperStyles({ placement: 'bottom' }).top).toBe('5px')
-    expect(enhancePopperStyles({ placement: 'left' }).left).toBe('-10px')
-    expect(enhancePopperStyles({ placement: 'right' }).left).toBe('10px')
+    expect(enhancePopperStyles({ placement: 'left' }).left).toBe('-2.5px')
+    expect(enhancePopperStyles({ placement: 'right' }).left).toBe('2.5px')
     expect(enhancePopperStyles({ placement: 'drrrr' }).left).toBe(undefined)
   })
 

--- a/stories/Popover.stories.js
+++ b/stories/Popover.stories.js
@@ -12,7 +12,7 @@ import { withArtboard } from '@helpscout/artboard'
 import { action } from '@storybook/addon-actions'
 
 const stories = storiesOf('Popover', module)
-stories.addDecorator(withArtboard())
+stories.addDecorator(withArtboard({ width: 300, height: 100 }))
 stories.addDecorator(withKnobs)
 
 const actionLoggerProps = {


### PR DESCRIPTION
## Popover/Tooltip: Improve left/right placement

![Screen Recording 2019-03-15 at 11 32 AM](https://user-images.githubusercontent.com/2322354/54443308-c0bd6100-4716-11e9-823d-4ebf0ce2a946.gif)

This update improves the positioning of the Popover/Tooltip element in
relation to the trigger. The spacing on the left/right sides have been
reduced, to bring the elements closer together.

Resolve: https://github.com/helpscout/hsds-react/issues/535