### PR TITLE
Input: Fixed Action + Error rendering

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -752,8 +752,8 @@ export class Input extends Component<Props, State> {
               {this.getInputMarkup(props)}
               {this.getInlineSuffixMarkup()}
               {this.getSuffixMarkup()}
-              {this.getActionMarkup()}
               {this.getErrorMarkup()}
+              {this.getActionMarkup()}
               <Backdrop
                 className="c-Input__backdrop"
                 disabled={disabled}

--- a/src/components/Input/styles/BackdropV2.css.js
+++ b/src/components/Input/styles/BackdropV2.css.js
@@ -16,7 +16,7 @@ export const config = {
   boxShadow: `0 0 0 0 rgba(${getColor('border')}, 0)`,
   boxShadowCheckbox: '0 0.5px 1px rgba(0, 0, 0, 0.2) inset',
   focusOutlineWidth: 2,
-  focusOutlineColor: getColor('blue.400'),
+  focusOutlineColor: getColor('blue.500'),
   focusOutlineOffset: 1,
   transition:
     'box-shadow 100ms ease, background-color 100ms ease, border-color 100ms ease',

--- a/src/components/Input/styles/Input.css.js
+++ b/src/components/Input/styles/Input.css.js
@@ -2,6 +2,7 @@ import styled from '../../styled/index'
 import baseStyles from '../../../styles/resets/baseStyles.css.js'
 import { STATES } from '../../../styles/configs/constants'
 import { getColor } from '../../../styles/utilities/color'
+import { makeFontFamilySystem } from '../../../styles/utilities/font'
 import forEach from '../../../styles/utilities/forEach'
 
 export const config = {
@@ -184,6 +185,7 @@ function makeStateStyles(): string {
 export function makeFieldStyles(): string {
   return `
     ${baseStyles};
+    ${makeFontFamilySystem()};
     appearance: none;
     background-color: transparent;
     border: none;

--- a/src/styles/utilities/__tests__/font.test.ts
+++ b/src/styles/utilities/__tests__/font.test.ts
@@ -5,6 +5,7 @@ import {
   makeFontFamilyFactory,
   makeFontFamily,
   makeFontFamilyMono,
+  makeFontFamilySystem,
 } from '../font'
 import { FONT_FAMILY, FONT_FAMILY_MONO } from '../../configs/constants'
 
@@ -54,5 +55,17 @@ describe('makeFontFamilyMono', () => {
     const fontFamily = makeFontFamilyMono('Roboto Mono')()
     expect(fontFamily).toContain(FONT_FAMILY_MONO)
     expect(fontFamily).toContain('Roboto Mono')
+  })
+})
+
+describe('makeFontFamilySystem', () => {
+  test('Sets system font family', () => {
+    const fontFamily = makeFontFamilySystem()
+    expect(fontFamily).toContain(FONT_FAMILY)
+  })
+
+  test('Does not use CSS var()', () => {
+    const fontFamily = makeFontFamilySystem()
+    expect(fontFamily).not.toContain('var')
   })
 })

--- a/src/styles/utilities/font.ts
+++ b/src/styles/utilities/font.ts
@@ -16,8 +16,8 @@ export const addFontSmoothing = (): string => {
 }
 
 export const makeFontFamilyFactory = (
-  fonts,
-  baseFont = FONT_FAMILY
+  fonts?: string,
+  baseFont: string = FONT_FAMILY
 ) => (): string => {
   if (!fonts) {
     return `font-family: ${baseFont};`
@@ -34,4 +34,8 @@ export const makeFontFamily = (fonts: string) => {
 
 export const makeFontFamilyMono = (fonts: string) => {
   return makeFontFamilyFactory(fonts, FONT_FAMILY_MONO)
+}
+
+export const makeFontFamilySystem = (): string => {
+  return `font-family: ${FONT_FAMILY};`
 }

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
+import { boolean } from '@storybook/addon-knobs'
 import { Button, Flexy, Icon, Input, styled } from '../src/index.js'
 
 const stories = storiesOf('Input', module)
@@ -246,6 +247,9 @@ const PaddedTextArea = styled('div')`
 `
 
 stories.add('Action', () => {
+  const error = boolean('error', false)
+  const state = error ? 'error' : null
+
   class Example extends React.Component {
     state = {
       isDisabled: true,
@@ -270,6 +274,7 @@ stories.add('Action', () => {
             type="text"
             onChange={this.onChange}
             value={this.state.value}
+            state={state}
             action={
               <Button
                 version={2}
@@ -291,6 +296,7 @@ stories.add('Action', () => {
             onChange={this.onChange}
             value={this.state.value}
             size="sm"
+            state={state}
             action={
               <Button
                 version={2}


### PR DESCRIPTION
## Input: Fixed Action + Error rendering

![Screen Shot 2019-03-15 at 12 25 29 PM](https://user-images.githubusercontent.com/2322354/54446549-9622d680-471d-11e9-8061-b784380d30f8.png)

### Action Alignment
This update improves the rendering of Input + Actions within an error state.
The solution was to re-arrange the UI to always have the actions on the
right-est side of the Input


### Focus Ring + System Font

![Screen Shot 2019-03-22 at 10 19 46 AM](https://user-images.githubusercontent.com/2322354/54829376-a93d2580-4c8c-11e9-9ee7-650ef3d21314.jpg)

This update also fixes the Input focus ring to use `blue.500`, and sets the `input`/`textarea` font-family to system.

Resolves:
https://github.com/helpscout/hsds-react/issues/520
#546 
#545 