### PR TITLE
Dropdown: Fix top/left position calculation with window.scroll values

### DIFF
--- a/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
+++ b/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
@@ -31,6 +31,7 @@ import { COMPONENT_KEY } from './Dropdown.utils'
 import { isBrowserEnv } from '../../../utilities/env'
 import { createUniqueIDFactory } from '../../../utilities/id'
 import { memoizeWithProps } from '../../../utilities/memoize'
+import { getComputedClientRect } from './Dropdown.MenuContainer.utils'
 
 const uniqueID = createUniqueIDFactory('DropdownMenuContainer')
 
@@ -269,12 +270,12 @@ export class MenuContainer extends React.PureComponent<Props> {
   getStylePosition = (): any => {
     const targetNode = this.getTargetNode()
 
-    const rect = targetNode.getBoundingClientRect()
-    const { height, top, left } = rect
+    const rect = getComputedClientRect(targetNode)
+    const { top, left } = rect
 
     return {
       left,
-      top: top + height,
+      top,
     }
   }
 

--- a/src/components/Dropdown/V2/Dropdown.MenuContainer.utils.ts
+++ b/src/components/Dropdown/V2/Dropdown.MenuContainer.utils.ts
@@ -1,0 +1,31 @@
+type ClientRect = {
+  height: number
+  left: number
+  top: number
+}
+
+export const getComputedClientRect = (node: HTMLElement): ClientRect => {
+  const defaultRect = {
+    height: 0,
+    left: 0,
+    top: 0,
+  }
+
+  if (!node) return defaultRect
+
+  const rect = node.getBoundingClientRect()
+  const { height, top, left } = rect
+
+  // window.scrollY / window.scrollX cannot be modified (or easily mocked)
+  // within JSDOM. Manually tested in the browser, and the calculations are
+  // correct.
+  /* istanbul ignore next */
+  const computedTop = top + height + window.scrollY
+  const computedLeft = left + window.scrollX
+
+  return {
+    left: computedLeft,
+    top: computedTop,
+    height,
+  }
+}

--- a/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.utils.test.ts
+++ b/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.utils.test.ts
@@ -1,0 +1,28 @@
+import { getComputedClientRect } from '../Dropdown.MenuContainer.utils'
+
+describe('getComputedClientRect', () => {
+  test('Returns zero values if invalid node', () => {
+    // @ts-ignore
+    const results = getComputedClientRect()
+
+    expect(results.height).toBe(0)
+    expect(results.left).toBe(0)
+    expect(results.top).toBe(0)
+  })
+
+  test('Returns getBoundingClientRect values', () => {
+    const node = {
+      getBoundingClientRect: () => ({
+        height: 42,
+        top: 332,
+        left: 21,
+      }),
+    } as HTMLElement
+
+    const results = getComputedClientRect(node)
+
+    expect(results.height).toBe(42)
+    expect(results.top).toBe(332 + 42)
+    expect(results.left).toBe(21)
+  })
+})


### PR DESCRIPTION
## Dropdown: Fix top/left position calculation with window.scroll values

![Screen Recording 2019-03-22 at 01 06 PM](https://user-images.githubusercontent.com/2322354/54840539-a3067380-4ca3-11e9-95dc-9a3a61078beb.gif)


This update fixes the issue with Dropdown (V2) where it did not factor in
`window.scrollY` and `window.scrollX` with it's `top` and `left`
calculations.

The fix involved creating a special util function to generated the computed
`top` and `left` values, which are used within the `Dropdown.MenuContainer`
position methods.