### PR TITLE
Tag: Close icon fix

### DIFF
--- a/src/components/Icon/icons.all.js
+++ b/src/components/Icon/icons.all.js
@@ -275,6 +275,7 @@ const ICONS = {
   'cross-medium': crossMedium,
   'cross-small': crossSmall,
   crossLarge,
+  cross: crossLarge,
   cursor,
   dashboard,
   'document-in': documentIn,

--- a/src/components/Icon/icons.embed.js
+++ b/src/components/Icon/icons.embed.js
@@ -34,6 +34,7 @@ const ICONS = {
   copy,
   'cross-large': crossLarge,
   'cross-small': crossSmall,
+  cross: crossLarge,
   fullscreen,
   'helpscout-logo': hsLogo,
   'hs-logo': hsLogo,

--- a/stories/Toolbar.stories.js
+++ b/stories/Toolbar.stories.js
@@ -14,7 +14,7 @@ stories.add('default', () => (
 ))
 
 stories.add('example', () => (
-  <Toolbar size="lg">
+  <Toolbar>
     <Toolbar.Item>
       <TagListSampleComponent />
     </Toolbar.Item>


### PR DESCRIPTION
## Tag: Close icon fix

![Screen Shot 2019-04-01 at 8 59 44 AM](https://user-images.githubusercontent.com/2322354/55329531-d04de100-545c-11e9-93ce-475d142031fa.png)


This update fixes the close icon within the Tag component. The solution
was to provide the alias for `cross`, which was removed during the icon
refactor.

The Toolbar component story was updated for improved rendering.