### PR TITLE
Fix the padding of chat preview cards

### DIFF
--- a/src/components/Message/styles/Content.css.js
+++ b/src/components/Message/styles/Content.css.js
@@ -14,6 +14,11 @@ const css = `
       direction: rtl;
       text-align: right;
     }
+
+    .c-Card {
+      border-radius: 5px;
+      padding: 20px;
+    }
   }
 `
 

--- a/src/components/Message/styles/Content.css.js
+++ b/src/components/Message/styles/Content.css.js
@@ -14,11 +14,6 @@ const css = `
       direction: rtl;
       text-align: right;
     }
-
-    .c-Card {
-      border-radius: 5px;
-      padding: 20px;
-    }
   }
 `
 

--- a/src/components/PreviewCard/styles/PreviewCard.css.js
+++ b/src/components/PreviewCard/styles/PreviewCard.css.js
@@ -7,8 +7,9 @@ import { BEM } from '../../../utilities/classNames'
 const bem = BEM('.c-PreviewCard')
 
 const css = `
-  ${baseStyles}
-  ${shadowlessBoxShadowWithHover()}
+  ${baseStyles};
+  ${shadowlessBoxShadowWithHover()};
+  padding: 20px;
   text-decoration: none;
 
   &:hover {
@@ -23,6 +24,10 @@ const css = `
     ${bem.element('title')} {
       color: ${getColor('link.base')};
     }
+  }
+
+  &.is-hoverable {
+    border-radius: 5px;
   }
 
   &.is-note {

--- a/src/components/PreviewCard/styles/PreviewCard.css.js
+++ b/src/components/PreviewCard/styles/PreviewCard.css.js
@@ -1,4 +1,5 @@
 import { getColor } from '../../../styles/utilities/color'
+import { shadowlessBoxShadowWithHover } from '../../../styles/mixins/cardStyles.css'
 import { noteBoxShadowWithHover } from '../../../styles/mixins/noteStyles.css'
 import baseStyles from '../../../styles/resets/baseStyles.css'
 import { BEM } from '../../../utilities/classNames'
@@ -7,7 +8,9 @@ const bem = BEM('.c-PreviewCard')
 
 const css = `
   ${baseStyles}
+  ${shadowlessBoxShadowWithHover()}
   text-decoration: none;
+
   &:hover {
     text-decoration: none;
   }
@@ -16,7 +19,6 @@ const css = `
     margin-bottom: 4px;
   }
 
-  // Modifiers
   &.is-link {
     ${bem.element('title')} {
       color: ${getColor('link.base')};

--- a/src/styles/mixins/cardStyles.css.js
+++ b/src/styles/mixins/cardStyles.css.js
@@ -35,4 +35,27 @@ export const cardSubtleStyles = () => {
   return cardBaseStyles(subtle)
 }
 
+export const shadowlessCardBoxShadow = () => `
+  box-shadow:
+    0 1px 3px 0 rgba(0, 0, 0, 0),
+    inset 0 0 0 1px ${rgba(getColor('grey.600'), 0.7)},
+    inset 0 -1px 0 0 ${getColor('grey.700')};
+`
+
+export const shadowlessBoxShadowHover = () => `
+  box-shadow:
+    0 3px 12px 0 rgba(0, 0, 0, 0.1),
+    inset 0 0 0 1px ${getColor('grey.600')},
+    inset 0 -1px 0 0 ${getColor('grey.700')};
+`
+
+export const shadowlessBoxShadowWithHover = () => `
+  &.is-hoverable {
+    ${shadowlessCardBoxShadow()}
+    &:hover {
+      ${shadowlessBoxShadowHover()}
+    }
+  }
+`
+
 export default cardStyles

--- a/src/styles/mixins/noteStyles.css.js
+++ b/src/styles/mixins/noteStyles.css.js
@@ -2,7 +2,7 @@ import { getColor } from '../utilities/color'
 
 export const noteBoxShadow = () => `
   box-shadow:
-    0px 1px 3px 0px rgba(179, 113, 0, 0.2),
+    0px 1px 3px 0px rgba(0, 0, 0, 0),
     inset 0px 0px 0px 1px ${getColor('yellow.400')};
 `
 

--- a/stories/Message/Message.stories.js
+++ b/stories/Message/Message.stories.js
@@ -43,6 +43,19 @@ stories.add('content', () => (
             and Bob Newhart...
           </PreviewCard>
         </Message.Content>
+        <Message.Chat read timestamp="9:42.am">
+          Nam accumsan ex mi, nec ullamcorper lectus pulvinar mollis. In quis
+          ligula quis mauris ultrices consectetur in non tortor. Ut ac ligula
+          quam. Nulla vel eros nec augue consequat consequat ac non ex. Nam
+          ultrices elementum congue. Maecenas id elementum diam. Integer ipsum
+          lacus, iaculis id mi eget, ornare gravida mauris. Curabitur
+          consectetur pharetra diam. Mauris vel sodales massa. Etiam eget
+          eleifend sapien, vel vestibulum metus. Etiam varius mauris ipsum, non
+          vestibulum eros imperdiet ac. Maecenas velit urna, varius nec
+          vestibulum eu, vehicula id enim. Sed feugiat erat sit amet orci
+          tincidunt malesuada eget eget nunc. Mauris quis vestibulum justo.
+          Curabitur id commodo nisl.
+        </Message.Chat>
       </Message>
       <Message to avatar={<Avatar name="Buddy" />}>
         <Message.Chat read timestamp="9:41am" isNote>
@@ -62,6 +75,19 @@ stories.add('content', () => (
             and Bob Newhart...
           </PreviewCard>
         </Message.Content>
+        <Message.Chat read timestamp="9:42.am" isNote>
+          Nam accumsan ex mi, nec ullamcorper lectus pulvinar mollis. In quis
+          ligula quis mauris ultrices consectetur in non tortor. Ut ac ligula
+          quam. Nulla vel eros nec augue consequat consequat ac non ex. Nam
+          ultrices elementum congue. Maecenas id elementum diam. Integer ipsum
+          lacus, iaculis id mi eget, ornare gravida mauris. Curabitur
+          consectetur pharetra diam. Mauris vel sodales massa. Etiam eget
+          eleifend sapien, vel vestibulum metus. Etiam varius mauris ipsum, non
+          vestibulum eros imperdiet ac. Maecenas velit urna, varius nec
+          vestibulum eu, vehicula id enim. Sed feugiat erat sit amet orci
+          tincidunt malesuada eget eget nunc. Mauris quis vestibulum justo.
+          Curabitur id commodo nisl.
+        </Message.Chat>
       </Message>
     </div>
   </ScopeProvider>


### PR DESCRIPTION
## Fix the padding of chat preview cards

https://trello.com/c/sX3XeCBX/1075-docs-embed-cards-could-be-visually-improved

The style of the chat preview card for unfurled links did not match the padding of other chat bubbles. This PR addresses this by tweaking the default card styling when in the scope of a chat content component.

Before:

![Screen Shot 2019-04-01 at 15 12 00](https://user-images.githubusercontent.com/6132043/55334257-c9d95c80-5490-11e9-8fc6-c8c6f9ff8be7.png)

After:

![Screen Shot 2019-04-01 at 15 11 10](https://user-images.githubusercontent.com/6132043/55334254-c7770280-5490-11e9-8bda-7d7d7b731454.png)
