### PR TITLE
Button: Add new size and state to V2

### DIFF
--- a/src/components/Button/Button.css.js
+++ b/src/components/Button/Button.css.js
@@ -44,6 +44,17 @@ export const config = {
       colorHover: 'white',
       colorActive: 'white',
     },
+    warning: {
+      backgroundColor: getColor('yellow.600'),
+      backgroundColorHover: getColor('yellow.700'),
+      backgroundColorActive: getColor('yellow.800'),
+      borderColor: getColor('yellow.600'),
+      borderColorHover: getColor('yellow.700'),
+      borderColorActive: getColor('yellow.800'),
+      color: 'white',
+      colorHover: 'white',
+      colorActive: 'white',
+    },
   },
   primaryAlt: {
     backgroundColor: getColor('purple.500'),
@@ -177,6 +188,12 @@ export const config = {
     xl: {
       fontSize: 14,
       height: 54,
+      minWidth: '120px',
+      padding: 20,
+    },
+    lgxl: {
+      fontSize: 14,
+      height: 50,
       minWidth: '120px',
       padding: 20,
     },
@@ -354,6 +371,7 @@ function makeButtonKindStyles(kind: string, config: Object): string {
 
       ${makeDangerStyles(config)}
       ${makeSuccessStyles(config)}
+      ${makeWarningStyles(config)}
 
       ${makeDisabledStyles(`
         background: ${config.disabledBackgroundColor} !important;
@@ -393,6 +411,10 @@ function makeDangerStyles(config: Object): string {
 
 function makeSuccessStyles(config: Object): string {
   return makeButtonStateStyles(config, 'success')
+}
+
+function makeWarningStyles(config: Object): string {
+  return makeButtonStateStyles(config, 'warning')
 }
 
 function makeDisabledStyles(content: string): string {

--- a/src/components/Button/types.js
+++ b/src/components/Button/types.js
@@ -14,6 +14,8 @@ export type ButtonState =
 | 'success'
 
 export type ButtonSize =
+| 'xl'
+| 'lgxl'
 | 'lg'
 | 'md'
 | 'sm'

--- a/stories/ButtonV2.stories.js
+++ b/stories/ButtonV2.stories.js
@@ -38,6 +38,12 @@ const makeButtonVariations = (props = {}) => {
         </Flexy>
         <h5>Sizes</h5>
         <Flexy just="left">
+          <Button {...props} size="xl">
+            Button
+          </Button>
+          <Button {...props} size="lgxl">
+            Button
+          </Button>
           <Button {...props} size="lg">
             Button
           </Button>
@@ -74,6 +80,7 @@ stories.add('everything', () => (
       {makeButtonVariations({ kind: 'default', state: 'danger' })}
       {makeButtonVariations({ kind: 'primary', state: 'danger' })}
       {makeButtonVariations({ kind: 'primary', state: 'success' })}
+      {makeButtonVariations({ kind: 'primary', state: 'warning' })}
     </ContainerUI>
   </PropProvider>
 ))


### PR DESCRIPTION
## Button: Add new size and state to V2

This update adds a new size and primary state to the V2 Button.

![](https://user-images.githubusercontent.com/7111256/55411963-7a616200-555e-11e9-9403-a9f2eb0fc31e.png)

For contrast reasons, the button color for the new `warning` state uses a base of `600` instead of `500`. 

A new size was added to Button. Size `lgxl`. This enables the button to render with a height of `50px`, which matches the requirements for the Beacon Embed design.