### PR TITLE
Icon: Fix rendering sizes within Input and OptionIcon

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -569,9 +569,10 @@ export class Input extends Component<Props, State> {
           title={errorMessage}
         >
           <Icon
-            name={errorIcon}
-            state={STATES.error}
             className="c-Input__errorIcon"
+            name={errorIcon}
+            size={24}
+            state={STATES.error}
           />
         </Tooltip>
       </InlinePrefixSuffixUI>

--- a/src/components/OptionIcon/OptionIcon.js
+++ b/src/components/OptionIcon/OptionIcon.js
@@ -25,7 +25,12 @@ class OptionIcon extends Component<Props> {
 
     return (
       <OptionIconUI {...getValidProps(rest)} className={componentClassName}>
-        <Icon className="c-OptionIcon__icon" name={icon} title={title} />
+        <Icon
+          className="c-OptionIcon__icon"
+          name={icon}
+          title={title}
+          size={24}
+        />
       </OptionIconUI>
     )
   }


### PR DESCRIPTION
## Icon: Fix rendering sizes within Input and OptionIcon

![Screen Shot 2019-04-02 at 12 33 22 PM](https://user-images.githubusercontent.com/2322354/55424711-dd4afd00-554e-11e9-8b34-fd272d67afd6.png)

This update fixes the 20->24 Icon rescale for usage within `Input` and
`OptionIcon`.

![Screen Shot 2019-04-02 at 12 33 40 PM](https://user-images.githubusercontent.com/2322354/55424742-ecca4600-554e-11e9-9a73-55a57a4ccd37.png)
