### PR TITLE
Update ArticleCard to handle title prop as component

### DIFF
--- a/src/components/ArticleCard/ArticleCard.tsx
+++ b/src/components/ArticleCard/ArticleCard.tsx
@@ -39,8 +39,10 @@ export class ArticleCard extends React.PureComponent<Props> {
   renderTitle = () => {
     const { title, titleLimit, titleSize } = this.props
 
-    return (
-      !!title && (
+    if (!title) return
+
+    if (isString(title)) {
+      return (
         <TitleUI className="c-ArticleCard__title">
           <Text size={titleSize} weight="500">
             <Truncate limit={titleLimit} type="end">
@@ -49,7 +51,9 @@ export class ArticleCard extends React.PureComponent<Props> {
           </Text>
         </TitleUI>
       )
-    )
+    }
+
+    return <div className="c-ArticleCard__titleMarkup">{title}</div>
   }
 
   renderContentMarkup() {

--- a/stories/ArticleCard.stories.js
+++ b/stories/ArticleCard.stories.js
@@ -88,18 +88,19 @@ const ArticleSpec = createSpec({
 const article = ArticleSpec.generate()
 
 stories.add('Default', () => {
-  const { content, title } = article
+  const { content, title: articleTitle } = article
 
   const metaHeaderConfig = boolean('metaHeader', false)
+  const titleConfig = boolean('title', false)
   const footerConfig = boolean('footer', false)
   const consecutive = boolean('Multiple Cards', false)
 
   const props = {
     content: text('content', content),
     href: text('href', '#'),
-    title: text('title', title),
     isHovered: boolean('isHovered', false),
     metaHeader: metaHeaderConfig && metaHeader(),
+    title: titleConfig && title(articleTitle),
     footer: footerConfig && footer(),
   }
 
@@ -144,6 +145,15 @@ function metaHeader() {
       </Flexy.Item>
     </Flexy>
   )
+}
+
+function title(title) {
+  console.log(title)
+  const TitleUI = styled('div')`
+    margin-bottom: 10px;
+    color: red;
+  `
+  return <TitleUI>{title}</TitleUI>
 }
 
 function footer() {


### PR DESCRIPTION
Refactor `ArticleCard` to allow for passing a React component for the `title` prop. 

This change is needed to clean up the PreviousMessage card UI as mentioned here https://trello.com/c/gw1FUzW2/139-previousmessages-screen#