### PR TITLE
Button V2: Remove outline for hover, active, focus

### DIFF
--- a/src/components/Button/Button.css.js
+++ b/src/components/Button/Button.css.js
@@ -263,6 +263,7 @@ export const makeButtonUI = (selector: 'button') => {
     &:hover,
     &:active,
     &:focus {
+      outline: none;
       text-decoration: none;
     }
 


### PR DESCRIPTION
## Button V2: Remove outline for hover, active, focus

<img width="393" alt="Screen Shot 2019-04-03 at 2 04 27 PM" src="https://user-images.githubusercontent.com/2322354/55502016-ac83ca00-5619-11e9-8e8c-10f39681a9e1.png">


This update adds CSS to nullify the outline styles which may occur during
integration.

These outline styles are typically defined within reset/normalize
styles. Adding `outline: none` directly to the Button helps ensure that outline
removal is prioritized.

https://github.com/helpscout/hsds-react/issues/559