### PR TITLE
Icon: Adjust caret sizing + alignment

### DIFF
--- a/src/components/Icon/styles/Icon.css.js
+++ b/src/components/Icon/styles/Icon.css.js
@@ -10,8 +10,10 @@ const bem = BEM('.c-Icon')
 const ICON_SIZES = [8, 10, 12, 13, 14, 16, 18, 20, 24, 32, 48, 52]
 
 export const config = {
-  caretSize: 12,
-  offset: 4,
+  caretSize: 13,
+  marginOffset: 4,
+  offsetRight: '6px',
+  offsetTop: '1px',
   size: 20,
 }
 
@@ -41,11 +43,11 @@ const css = `
   }
 
   &.is-offsetLeft {
-    margin-right: ${config.offset}px;
+    margin-right: ${config.marginOffset}px;
   }
 
   &.is-offsetRight {
-    margin-left: ${config.offset}px;
+    margin-left: ${config.marginOffset}px;
   }
 
   ${makeShadeStyles()};
@@ -54,7 +56,7 @@ const css = `
 
   &.withCaret {
     ${bem.element('icon')} {
-      width: calc(100% - ${config.caretSize}px);
+      width: calc(100% - (${config.caretSize}px - ${config.offsetRight}));
     }
   }
 
@@ -81,7 +83,9 @@ const css = `
       height: ${config.caretSize}px;
       position: absolute;
       right: 0;
-      top: calc(50% - ${Math.round(config.caretSize / 2)}px);
+      top: calc(50% - ${Math.round(config.caretSize / 2)}px + ${
+  config.offsetTop
+});
       width: ${config.caretSize}px;
     }
   }

--- a/stories/Icon.stories.js
+++ b/stories/Icon.stories.js
@@ -74,7 +74,10 @@ stories.add('icons', () => {
 
 stories.add('sizes', () => {
   const icons = ['14', '16', '18', '24'].map(i => (
-    <div style={{ display: 'inline-block', margin: 12, textAlign: 'center' }}>
+    <div
+      key={i}
+      style={{ display: 'inline-block', margin: 12, textAlign: 'center' }}
+    >
       <Icon name="emoji" size={i} key={i} center />
       <Text muted size="sm">
         {i}
@@ -156,8 +159,11 @@ stories.add('shades', () => {
 
 stories.add('withCaret', () => {
   const icons = ['14', '16', '18', '24'].map(i => (
-    <div style={{ display: 'inline-block', margin: 12, textAlign: 'center' }}>
-      <Icon name="user" size={i} key={i} center withCaret />
+    <div
+      key={i}
+      style={{ display: 'inline-block', margin: 12, textAlign: 'center' }}
+    >
+      <Icon name="assign" size={i} key={i} center withCaret />
       <Text muted size="sm">
         {i}
       </Text>
@@ -169,7 +175,7 @@ stories.add('withCaret', () => {
     <div>
       <Flexy just="left">
         <Flexy.Item>
-          <Icon name="user" withCaret />
+          <Icon name="assign" withCaret />
         </Flexy.Item>
         <Flexy.Item>
           <Text muted size="sm">
@@ -180,7 +186,7 @@ stories.add('withCaret', () => {
 
       <Flexy just="left">
         <Flexy.Item>
-          <Icon name="user" withCaret muted />
+          <Icon name="assign" withCaret muted />
         </Flexy.Item>
         <Flexy.Item>
           <Text muted size="sm">
@@ -191,7 +197,7 @@ stories.add('withCaret', () => {
 
       <Flexy just="left" style={{ color: 'red' }}>
         <Flexy.Item>
-          <Icon name="user" withCaret />
+          <Icon name="assign" withCaret />
         </Flexy.Item>
         <Flexy.Item>
           <Text muted size="sm">


### PR DESCRIPTION
## Icon: Adjust caret sizing + alignment

![Screen Recording 2019-04-03 at 02 28 PM](https://user-images.githubusercontent.com/2322354/55503667-249fbf00-561d-11e9-90b1-4b2f71eed0ce.gif)

(GIF: Rendered Icon + caret overlaying latest mock from HSDS: Product UI)

This update adjusts the caret SVG sizing + alignment when used within
an `<Icon />` component via the `withCaret` prop.

https://github.com/helpscout/hsds-react/issues/555