### PR TITLE
Clean up ArticleCard UI

### DIFF
--- a/src/components/ArticleCard/styles/ArticleCard.css.js
+++ b/src/components/ArticleCard/styles/ArticleCard.css.js
@@ -14,7 +14,7 @@ export const config = {
 }
 
 export const MetaHeaderUI = styled('header')`
-  margin-bottom: 7px;
+  margin-bottom: 10px;
 `
 
 export const ContentUI = styled('div')`
@@ -25,12 +25,12 @@ export const ContentUI = styled('div')`
 export const TitleUI = styled('div')`
   color: ${getColor('link.base')};
   line-height: 1.5;
-  margin-bottom: 4px;
+  margin-bottom: 7px;
   transition: all 200ms linear;
 `
 
 export const FooterUI = styled('footer')`
-  margin-top: 8px;
+  margin-top: 10px;
 `
 
 export const ArticleCardUI = styled(Card)`


### PR DESCRIPTION
This cleans up the ArticleCard UI.

Changes 
- adjust space between Meta data and Title to 10px
- adjust space between the content and the Title to 7px
- adjust the space between the Content and Avatars to 10px

### Before

<img width="616" alt="Screen Shot 2019-04-04 at 12 15 45 AM" src="https://user-images.githubusercontent.com/7111256/55519217-d2878980-566e-11e9-9571-caf891c59c7f.png">

### After
<img width="617" alt="Screen Shot 2019-04-04 at 12 07 30 AM" src="https://user-images.githubusercontent.com/7111256/55519159-9e13cd80-566e-11e9-8643-8487b8452339.png">
