### PR TITLE
Improve pagination component

### DIFF
--- a/src/components/KeypressListener/__tests__/KeypressListener.test.js
+++ b/src/components/KeypressListener/__tests__/KeypressListener.test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme'
 import KeypressListener from '..'
 import Keys from '../../../constants/Keys'
 
-const simulateKeyPress = (keyCode, modifier) => {
+export const simulateKeyPress = (keyCode, modifier) => {
   const event = new Event('keyup')
   event.keyCode = keyCode
   if (modifier) {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -6,6 +6,8 @@ import { namespaceComponent } from '../../utilities/component'
 import { noop } from '../../utilities/other'
 import { COMPONENT_KEY } from './Pagination.utils'
 import pluralize from '../../utilities/pluralize'
+import KeypressListener from '../KeypressListener'
+import Keys from '../../constants/Keys'
 
 import {
   PaginationUI,
@@ -149,6 +151,18 @@ export class Pagination extends React.PureComponent<Props> {
 
     return (
       <NavigationUI>
+        <KeypressListener
+          keyCode={Keys.KEY_J}
+          handler={this.handlePrevClick}
+          noModifier
+          type="keyup"
+        />
+        <KeypressListener
+          keyCode={Keys.KEY_K}
+          handler={this.handleNextClick}
+          noModifier
+          type="keyup"
+        />
         {isNotFirstPage && [
           <ButtonIconUI
             key="firstButton"
@@ -156,6 +170,7 @@ export class Pagination extends React.PureComponent<Props> {
             onClick={this.handleFirstClick}
             className="c-Pagination__firstButton"
             disabled={isLoading}
+            title="First page"
           >
             <Icon name="arrow-left-double-large" size="24" center />
           </ButtonIconUI>,
@@ -165,6 +180,7 @@ export class Pagination extends React.PureComponent<Props> {
             onClick={this.handlePrevClick}
             className="c-Pagination__prevButton"
             disabled={isLoading}
+            title="Previous page (j)"
           >
             <Icon name="arrow-left-single-large" size="24" center />
           </ButtonIconUI>,
@@ -175,6 +191,7 @@ export class Pagination extends React.PureComponent<Props> {
           disabled={isLastPage || isLoading}
           onClick={this.handleNextClick}
           className="c-Pagination__nextButton"
+          title="Next page (k)"
         >
           <Icon name="arrow-right-single-large" size="24" center />
         </ButtonIconUI>
@@ -183,6 +200,7 @@ export class Pagination extends React.PureComponent<Props> {
           disabled={isLastPage || isLoading}
           onClick={this.handleEndClick}
           className="c-Pagination__lastButton"
+          title="Last page"
         >
           <Icon name="arrow-right-double-large" size="24" center />
         </ButtonIconUI>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -20,6 +20,7 @@ import Icon from '../Icon'
 export interface Props {
   activePage: number
   className?: string
+  isLoading?: boolean
   innerRef: (node: HTMLElement) => void
   onChange: (nextPageNumber: number) => void
   rangePerPage: number
@@ -33,6 +34,7 @@ export interface Props {
 export class Pagination extends React.PureComponent<Props> {
   static defaultProps = {
     activePage: 1,
+    isLoading: false,
     innerRef: noop,
     onChange: noop,
     rangePerPage: 50,
@@ -140,6 +142,7 @@ export class Pagination extends React.PureComponent<Props> {
   }
 
   renderNavigation() {
+    const { isLoading } = this.props
     const currentPage = this.getCurrentPage()
     const isNotFirstPage = currentPage > 1
     const isLastPage = currentPage >= this.getNumberOfPages()
@@ -152,6 +155,7 @@ export class Pagination extends React.PureComponent<Props> {
             version={2}
             onClick={this.handleFirstClick}
             className="c-Pagination__firstButton"
+            disabled={isLoading}
           >
             <Icon name="arrow-left-double-large" size="24" center />
           </ButtonIconUI>,
@@ -160,6 +164,7 @@ export class Pagination extends React.PureComponent<Props> {
             version={2}
             onClick={this.handlePrevClick}
             className="c-Pagination__prevButton"
+            disabled={isLoading}
           >
             <Icon name="arrow-left-single-large" size="24" center />
           </ButtonIconUI>,
@@ -167,7 +172,7 @@ export class Pagination extends React.PureComponent<Props> {
 
         <ButtonIconUI
           version={2}
-          disabled={isLastPage}
+          disabled={isLastPage || isLoading}
           onClick={this.handleNextClick}
           className="c-Pagination__nextButton"
         >
@@ -175,7 +180,7 @@ export class Pagination extends React.PureComponent<Props> {
         </ButtonIconUI>
         <ButtonIconUI
           version={2}
-          disabled={isLastPage}
+          disabled={isLastPage || isLoading}
           onClick={this.handleEndClick}
           className="c-Pagination__lastButton"
         >

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -8,6 +8,7 @@ import { COMPONENT_KEY } from './Pagination.utils'
 import pluralize from '../../utilities/pluralize'
 import KeypressListener from '../KeypressListener'
 import Keys from '../../constants/Keys'
+import { formatNumber } from '../../utilities/number'
 
 import {
   PaginationUI,
@@ -124,7 +125,9 @@ export class Pagination extends React.PureComponent<Props> {
   renderRange() {
     const { separator, subject } = this.props
     const totalItems = this.getTotalItems()
-    const totalNode = <span className="c-Pagination__total">{totalItems}</span>
+    const totalNode = (
+      <span className="c-Pagination__total">{formatNumber(totalItems)}</span>
+    )
 
     if (!totalItems) {
       return subject ? totalNode : null
@@ -132,9 +135,9 @@ export class Pagination extends React.PureComponent<Props> {
 
     return (
       <Text className="c-Pagination__range">
-        <RangeUI>{this.getStartRange()}</RangeUI>
+        <RangeUI>{formatNumber(this.getStartRange())}</RangeUI>
         {` `}-{` `}
-        <RangeUI>{this.getEndRange()}</RangeUI>
+        <RangeUI>{formatNumber(this.getEndRange())}</RangeUI>
         {` `}
         {separator}
         {` `}

--- a/src/components/Pagination/__tests__/Pagination.test.js
+++ b/src/components/Pagination/__tests__/Pagination.test.js
@@ -155,6 +155,28 @@ describe('Navigation', () => {
     expect(last.props('disabled')).toBeTruthy()
   })
 
+  test('Disables all buttons when loading', () => {
+    const wrapper = mount(
+      <Pagination
+        isLoading={true}
+        showNavigation={true}
+        totalItems={15}
+        rangePerPage={5}
+        activePage={3}
+      />
+    )
+
+    const first = wrapper.find('Button.c-Pagination__firstButton').first()
+    const prev = wrapper.find('Button.c-Pagination__prevButton').first()
+    const next = wrapper.find('Button.c-Pagination__nextButton').first()
+    const last = wrapper.find('Button.c-Pagination__lastButton').first()
+
+    expect(first.props('disabled')).toBeTruthy()
+    expect(prev.props('disabled')).toBeTruthy()
+    expect(next.props('disabled')).toBeTruthy()
+    expect(last.props('disabled')).toBeTruthy()
+  })
+
   test('Sets 1 as the minimum for currentPage', () => {
     const wrapper = mount(
       <Pagination

--- a/src/components/Pagination/__tests__/Pagination.test.js
+++ b/src/components/Pagination/__tests__/Pagination.test.js
@@ -3,7 +3,8 @@ import { mount } from 'enzyme'
 import { Pagination } from '../Pagination'
 import { NavigationUI } from '../Pagination.css'
 import { hasClass } from '../../../tests/helpers/enzyme'
-
+import { simulateKeyPress } from '../../KeypressListener/__tests__/KeypressListener.test'
+import Keys from '../../../constants/Keys'
 describe('className', () => {
   test('Has a default className', () => {
     const wrapper = mount(<Pagination />)
@@ -404,5 +405,43 @@ describe('Clicks', () => {
     )
     wrapper.instance().handleNextClick({ preventDefault: jest.fn() })
     expect(changeWatcher).not.toHaveBeenCalled()
+  })
+})
+
+describe('Keyboard', () => {
+  test('Pressing j navigate to previous page', () => {
+    const totalItems = 17
+    const rangePerPage = 5
+    const changeWatcher = jest.fn()
+
+    mount(
+      <Pagination
+        showNavigation={true}
+        totalItems={totalItems}
+        rangePerPage={rangePerPage}
+        activePage={2}
+        onChange={changeWatcher}
+      />
+    )
+    simulateKeyPress(Keys.KEY_J)
+    expect(changeWatcher).toHaveBeenCalledWith(1)
+  })
+
+  test('Pressing k navigate to next page', () => {
+    const totalItems = 17
+    const rangePerPage = 5
+    const changeWatcher = jest.fn()
+
+    mount(
+      <Pagination
+        showNavigation={true}
+        totalItems={totalItems}
+        rangePerPage={rangePerPage}
+        activePage={1}
+        onChange={changeWatcher}
+      />
+    )
+    simulateKeyPress(Keys.KEY_K)
+    expect(changeWatcher).toHaveBeenCalledWith(2)
   })
 })

--- a/src/utilities/__tests__/number.test.js
+++ b/src/utilities/__tests__/number.test.js
@@ -1,4 +1,4 @@
-import { isEven, isOdd, getMiddleIndex } from '../number'
+import { isEven, isOdd, getMiddleIndex, formatNumber } from '../number'
 
 describe('isEven', () => {
   test('Should detect even numbers', () => {
@@ -37,5 +37,17 @@ describe('getMiddleIndex', () => {
     expect(getMiddleIndex(9)).toBe(4)
     expect(getMiddleIndex(99)).toBe(49)
     expect(getMiddleIndex(100)).toBe(49)
+  })
+})
+
+describe('formatNumber', () => {
+  test('Should format number', () => {
+    expect(formatNumber(4)).toBe('4')
+    expect(formatNumber(5000)).toBe('5,000')
+    expect(formatNumber(4500.23)).toBe('4,500.23')
+    expect(formatNumber(0)).toBe('0')
+    expect(formatNumber(null)).toBe(null)
+    expect(formatNumber(-10028.444)).toBe('-10,028.444')
+    expect(formatNumber(1032234234028.4)).toBe('1,032,234,234,028.4')
   })
 })

--- a/src/utilities/__tests__/number.test.js
+++ b/src/utilities/__tests__/number.test.js
@@ -49,5 +49,6 @@ describe('formatNumber', () => {
     expect(formatNumber(null)).toBe(null)
     expect(formatNumber(-10028.444)).toBe('-10,028.444')
     expect(formatNumber(1032234234028.4)).toBe('1,032,234,234,028.4')
+    expect(formatNumber('test')).toBe('test')
   })
 })

--- a/src/utilities/number.js
+++ b/src/utilities/number.js
@@ -7,3 +7,10 @@ export const getMiddleIndex = (number: string): number => {
 
   return isOdd(number) ? middle : middle - 1
 }
+
+export const formatNumber = num => {
+  if (num === null || num === undefined) {
+    return num
+  }
+  return num.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')
+}

--- a/src/utilities/number.js
+++ b/src/utilities/number.js
@@ -1,3 +1,5 @@
+import { isDefined, isNumber } from './is'
+
 export const isEven = (number: string): boolean => number % 2 === 0
 
 export const isOdd = (number: string): boolean => !isEven(number)
@@ -9,8 +11,8 @@ export const getMiddleIndex = (number: string): number => {
 }
 
 export const formatNumber = num => {
-  if (num === null || num === undefined) {
-    return num
-  }
+  if (!isDefined(num)) return num
+  if (!isNumber(num)) return num
+
   return num.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')
 }

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -94,6 +94,20 @@ stories.add('end of navigation', () => {
   )
 })
 
+stories.add('isLoading', () => {
+  return (
+    <Pagination
+      {...getKnobsProps({
+        subject: subject(),
+        activePage: activePage(10),
+        isLoading: boolean('isLoading', true),
+      })}
+      showNavigation={true}
+      onChange={action('changePage')}
+    />
+  )
+})
+
 class PaginationWrapper extends React.Component {
   state = {
     activePage: 1,


### PR DESCRIPTION
This update add 3 small improvements to the Pagination component

### Keyboard shortcut
Pressing `j` or `k` will update the current page
![Screen Recording 2019-04-05 at 01 57 PM](https://user-images.githubusercontent.com/203992/55647193-0d8ed780-57ab-11e9-8efc-51b6b60e7e87.gif)

### Formatting number
Current range and total of items are now formatted with the us format: 111,111.00
<img width="866" alt="Image 2019-04-05 at 1 47 18 PM" src="https://user-images.githubusercontent.com/203992/55647238-2dbe9680-57ab-11e9-898b-d437feadd69e.png">

### isLoading state
If the prop isLoading is active, all navigations button will be disabled
![Screen Recording 2019-04-05 at 01 58 PM](https://user-images.githubusercontent.com/203992/55647264-4464ed80-57ab-11e9-98fc-d49b9b00442f.gif)
