### PR TITLE
Input: Fix multiline size calculations + add default maxHeight

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -127,6 +127,7 @@ export class Input extends Component<Props, State> {
     isLast: false,
     isNotOnly: false,
     isSubtleReadOnly: false,
+    maxHeight: 320,
     moveCursorToEnd: false,
     multiline: null,
     offsetAmount: 0,

--- a/src/components/Input/Resizer.tsx
+++ b/src/components/Input/Resizer.tsx
@@ -129,8 +129,8 @@ export class Resizer extends React.PureComponent<Props> {
     if (!minimumLines) return
 
     return (
-      <div
-        ref={this.setMinimumLinesNode}
+      <GhostUI
+        innerRef={this.setMinimumLinesNode}
         className={this.getContentClassName()}
         dangerouslySetInnerHTML={{
           __html: this.getContentsForMinimumLines(minimumLines),

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -370,11 +370,11 @@ describe('Multiline', () => {
     expect(wrapper.state()).not.toBe(null)
   })
 
-  test('Does not set maxHeight on multiline by default', () => {
+  test('Has a maxHeight by default', () => {
     const wrapper = mount(<Input multiline={3} />)
     const el = wrapper.find('textarea')
 
-    expect(el.prop('style').maxHeight).toBeFalsy()
+    expect(el.prop('style').maxHeight).toBeTruthy()
   })
 
   test('Sets maxHeight on multiline, if specified', () => {


### PR DESCRIPTION
## Input: Fix multiline size calculations + add default maxHeight

![Screen Recording 2019-04-10 at 04 45 PM](https://user-images.githubusercontent.com/2322354/55912385-8f6a7080-5bb0-11e9-9571-37623696d3f3.gif)


This update resolves the `multiline` based size calculation for the
`Input` component. The solution was to provide one of the "ghost" inputs
with the correct `GhostUI` styled component to help account for
padding/line-height.

For context, the Input uses a ghost `textarea` to help recalculate the
height for auto-resizing.

Additionally, a default `maxHeight` of `320` was added for `Input`.

![Screen Recording 2019-04-10 at 04 46 PM](https://user-images.githubusercontent.com/2322354/55912395-92fdf780-5bb0-11e9-8abd-ea52b24b0488.gif)
