### PR TITLE
Updated GreeterCard Styles

### DIFF
--- a/src/components/GreeterCard/GreeterCard.css.ts
+++ b/src/components/GreeterCard/GreeterCard.css.ts
@@ -4,11 +4,7 @@ import Button from '../Button'
 import Heading from '../Heading'
 import Text from '../Text'
 import baseStyles from '../../styles/resets/baseStyles.css'
-import {
-  addFontSmoothing,
-  makeFontFamily,
-  setFontSize,
-} from '../../styles/utilities/font'
+import { makeFontFamily, setFontSize } from '../../styles/utilities/font'
 
 const fontFamily = makeFontFamily('Barlow')
 
@@ -31,18 +27,21 @@ export const GreeterCardUI = styled(Card)`
 
 export const TitleUI = styled(Heading)`
   ${fontFamily};
+  line-height: 22px !important;
   margin-top: 5px;
 `
 
 export const SubtitleUI = styled(Heading)`
   ${setFontSize(12)};
+  line-height: 18px !important;
   margin-top: 6px;
 `
 
 export const BodyUI = styled(Text)`
-  ${setFontSize(14)};
-  letter-spacing: 0.37px;
+  ${setFontSize(13)};
+  line-height: 20px;
   margin-top: ${({ withMargin }) => (withMargin ? '12px' : '0')};
+  white-space: pre-wrap;
 `
 
 export const ActionUI = styled('div')`

--- a/src/components/GreeterCard/GreeterCard.tsx
+++ b/src/components/GreeterCard/GreeterCard.tsx
@@ -103,6 +103,7 @@ export class GreeterCard extends React.PureComponent<Props> {
       children,
       innerRef,
       in: inProp,
+      title,
       ...rest
     } = this.props
 


### PR DESCRIPTION
## Trello Cards

- [Tighten line-height on the headings](https://trello.com/c/JlAwISd2/137-tighten-line-height-on-the-headings)
- [Tighten the typography of the body text](https://trello.com/c/q0kbZXt4/135-tighten-the-typography-of-the-body-text)
- [Line breaks are ignored in Embed](https://trello.com/c/ITC1nFSo/132-line-breaks-are-ignored-in-embed)
- [Greeter title text tooltip displayed on hover](https://trello.com/c/KWsmHYw2/138-greeter-title-text-tooltip-displayed-on-hover)

## Summary

This PR updates the styles of the `GreeterCard` component based on feedback from Buzz and Ryan. Updates include:

- Updated line-height of title and subtitle components.
- Updated line-height, font-size and letter-spacing of body text component.
- Added `white-space: pre-wrap;` to body component to respect new line characters.
- Removed `title` prop being passed to the main div to prevent the browser's tooltip from showing up.

## Demo

Before:

![Before](http://c.hlp.sc/37bd52d2d672/Image%202019-04-11%20at%2010.46.52%20AM.png)

After:

![After](http://c.hlp.sc/445808ec3ae2/Image%202019-04-11%20at%2010.58.49%20AM.png)

You can also check it out in the Storybook build for this branch.