### PR TITLE
Storybook: Lock React Treebeard at v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29576,15 +29576,31 @@
         "velocity-react": "^1.4.1"
       },
       "dependencies": {
-        "prop-types": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "dev": true,
           "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
+            "js-tokens": "^3.0.0 || ^4.0.0"
           }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "react-frame-component": "^1.1.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
+    "react-treebeard": "3.1.0",
     "remake-cli": "0.0.7",
     "rgb-hex": "2.1.0",
     "rimraf": "2.6.2",


### PR DESCRIPTION
## Storybook: Lock React Treebeard at v3.1.0

This update locks React Treebeard at 3.1.0. This dependency comes from
`@storybook/ui`. There is a chance npm will install `react-treebeard@3.2.0`,
which uses `@emotion/core@10`. This breaks Storybook! Haha.