### PR TITLE
Add Cypress tests for Pagination component

### DIFF
--- a/cypress/integration/Pagination.js
+++ b/cypress/integration/Pagination.js
@@ -1,0 +1,94 @@
+beforeEach(() => {
+  cy.visitStory('Pagination', 'in action')
+})
+
+describe('Pagination / range', () => {
+  it('Should display total of items', () => {
+    cy.get('[data-cy="Pagination-totalItems"]').should('be', '255')
+  })
+
+  it('End range and total should be the same on last page', () => {
+    cy.get('[data-cy="Pagination-totalItems"]').should('be', '255')
+    cy.get('[data-cy="Pagination-endRange"]').should('be', '255')
+  })
+})
+
+describe('Pagination / navigation', () => {
+  it('Prev/First should be hidden on first page', () => {
+    cy.get('[data-cy="Pagination-prevButton"]').should('not.exist')
+    cy.get('[data-cy="Pagination-firstButton"]').should('not.exist')
+  })
+  it('Prev/First should be visible on second page', () => {
+    cy.get('[data-cy="Pagination-nextButton"]:first').click()
+    cy.get('[data-cy="Pagination-prevButton"]').should('exist')
+    cy.get('[data-cy="Pagination-firstButton"]').should('exist')
+  })
+
+  it('Last/Next should be disabled on last page', () => {
+    cy.get('[data-cy="Pagination-lastButton"]:first').click()
+    cy.get('[data-cy="Pagination-lastButton"]').should('be.disabled')
+    cy.get('[data-cy="Pagination-nextButton"]').should('be.disabled')
+  })
+
+  it('Can increase current page', () => {
+    const startRange = cy.get('[data-cy="Pagination-startRange"]')
+    startRange.should('be', '1')
+    startRange.invoke('text').then(originalValue => {
+      originalValue = parseInt(originalValue, 10)
+      const nextValue = originalValue + 50
+
+      cy.get('[data-cy="Pagination-nextButton"]:first').click()
+      cy
+        .get('[data-cy="Pagination-startRange"]')
+        .should('be', nextValue.toString())
+    })
+  })
+
+  it('Can decrease current page', () => {
+    const startRange = cy.get('[data-cy="Pagination-startRange"]')
+    cy.get('[data-cy="Pagination-nextButton"]:first').click()
+    startRange.should('be', '51')
+
+    startRange.invoke('text').then(originalValue => {
+      originalValue = parseInt(originalValue, 10)
+      const nextValue = originalValue - 50
+
+      cy.get('[data-cy="Pagination-prevButton"]:first').click()
+      cy
+        .get('[data-cy="Pagination-startRange"]')
+        .should('be', nextValue.toString())
+    })
+  })
+})
+
+describe('Pagination / keyboard', () => {
+  it('Typing K should increase the current page', () => {
+    cy.get('body').trigger('keydown', { keyCode: 75, which: 75 })
+
+    const startRange = cy.get('[data-cy="Pagination-startRange"]')
+    startRange.invoke('text').then(originalValue => {
+      originalValue = parseInt(originalValue, 10)
+      const nextValue = originalValue + 50
+
+      cy
+        .get('[data-cy="Pagination-startRange"]')
+        .should('be', nextValue.toString())
+    })
+  })
+
+  it('Typing J should decrease the current page', () => {
+    cy.get('[data-cy="Pagination-nextButton"]:first').click()
+
+    const startRange = cy.get('[data-cy="Pagination-startRange"]')
+    startRange.invoke('text').then(originalValue => {
+      originalValue = parseInt(originalValue, 10)
+      const nextValue = originalValue - 50
+
+      cy.get('body').trigger('keydown', { keyCode: 74, which: 74 })
+
+      cy
+        .get('[data-cy="Pagination-startRange"]')
+        .should('be', nextValue.toString())
+    })
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -16,5 +16,5 @@ Cypress.Commands.add('visitStory', (kind = '', name = '') => {
  * @param {string} name The name of the Story
  */
 function getStoryBookUrl(kind = 'ArticleCard', name = 'Content') {
-  return `iframe.html?selectedKind=${kind}%2FV2&selectedStory=${name}`
+  return `iframe.html?selectedKind=${kind}&selectedStory=${name}`
 }

--- a/src/components/Pagination/Pagination.css.js
+++ b/src/components/Pagination/Pagination.css.js
@@ -33,6 +33,7 @@ export const RangeUI = styled('span')`
 `
 
 export const ButtonIconUI = styled(Button)`
+  &.is-default:focus,
   &.is-default.is-focused {
     color: ${config.default.colorActive};
   }

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -126,7 +126,9 @@ export class Pagination extends React.PureComponent<Props> {
     const { separator, subject } = this.props
     const totalItems = this.getTotalItems()
     const totalNode = (
-      <span className="c-Pagination__total">{formatNumber(totalItems)}</span>
+      <span className="c-Pagination__total" data-cy="Pagination-totalItems">
+        {formatNumber(totalItems)}
+      </span>
     )
 
     if (!totalItems) {
@@ -135,9 +137,13 @@ export class Pagination extends React.PureComponent<Props> {
 
     return (
       <Text className="c-Pagination__range">
-        <RangeUI>{formatNumber(this.getStartRange())}</RangeUI>
+        <RangeUI data-cy="Pagination-startRange">
+          {formatNumber(this.getStartRange())}
+        </RangeUI>
         {` `}-{` `}
-        <RangeUI>{formatNumber(this.getEndRange())}</RangeUI>
+        <RangeUI data-cy="Pagination-endRange">
+          {formatNumber(this.getEndRange())}
+        </RangeUI>
         {` `}
         {separator}
         {` `}
@@ -174,6 +180,7 @@ export class Pagination extends React.PureComponent<Props> {
             className="c-Pagination__firstButton"
             disabled={isLoading}
             title="First page"
+            data-cy="Pagination-firstButton"
           >
             <Icon name="arrow-left-double-large" size="24" center />
           </ButtonIconUI>,
@@ -184,6 +191,7 @@ export class Pagination extends React.PureComponent<Props> {
             className="c-Pagination__prevButton"
             disabled={isLoading}
             title="Previous page (j)"
+            data-cy="Pagination-prevButton"
           >
             <Icon name="arrow-left-single-large" size="24" center />
           </ButtonIconUI>,
@@ -195,6 +203,7 @@ export class Pagination extends React.PureComponent<Props> {
           onClick={this.handleNextClick}
           className="c-Pagination__nextButton"
           title="Next page (k)"
+          data-cy="Pagination-nextButton"
         >
           <Icon name="arrow-right-single-large" size="24" center />
         </ButtonIconUI>
@@ -204,6 +213,7 @@ export class Pagination extends React.PureComponent<Props> {
           onClick={this.handleEndClick}
           className="c-Pagination__lastButton"
           title="Last page"
+          data-cy="Pagination-lastButton"
         >
           <Icon name="arrow-right-double-large" size="24" center />
         </ButtonIconUI>

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -8,6 +8,11 @@ import styled from '../src/components/styled'
 
 import { Pagination } from '../src/components'
 
+export const config = {
+  TOTAL_ITEMS: 255,
+  RANGE_PER_PAGE: 50,
+}
+
 const PaginationWrapperUI = styled('div')`
   min-width: 400px;
   max-width: 800px;
@@ -28,8 +33,8 @@ const activePage = (cPage = 1) => number('activePage', cPage)
 
 const getKnobsProps = otherKnobs => {
   return {
-    totalItems: number('totalItems', 255),
-    rangePerPage: number('rangePerPage', 50),
+    totalItems: number('totalItems', config.TOTAL_ITEMS),
+    rangePerPage: number('rangePerPage', config.RANGE_PER_PAGE),
     ...otherKnobs,
   }
 }


### PR DESCRIPTION
This update adds a list of cypress tests for the Pagination component

<img width="451" alt="Image 2019-04-12 at 4 19 10 PM" src="https://user-images.githubusercontent.com/203992/56064077-fb7adf00-5d3e-11e9-9261-f385d7c1f5dd.png">

### Notes
This is the first time I am working with Cypress. Feel free to give advice or request some changes to this PR

Next step would be to add cypress to travis-ci, and then add Percy to the integration suite