### PR TITLE
Fix smoothScrollTo function to work in IE/Edge

### DIFF
--- a/src/utilities/smoothScroll.js
+++ b/src/utilities/smoothScroll.js
@@ -59,6 +59,12 @@ export const smoothScrollTo = ({
       } else {
         node.scrollTo(0, scrollToPosition)
       }
+    } else {
+      if (isHorizontalScroll) {
+        node.scrollLeft = scrollToPosition
+      } else {
+        node.scrollTop = scrollToPosition
+      }
     }
 
     // Proceed with animation as long as we wanted it to.


### PR DESCRIPTION
**[Trello Card](https://trello.com/c/mHLEw62a/180-beacon-chat-doesnt-auto-scroll-on-microsoft-edge)**

This PR fixes the `smoothScrollTo` function, used by `ChatScroller` and other components so that it works in IE/Edge where the `scrollTo` method is not available.

Here's a demo of the auto-scrolling working correctly in Beacon chat:

![Demo](http://c.hlp.sc/b7bcefbc41e2/Screen%20Recording%202019-04-15%20at%2004.20%20PM.gif)