### PR TITLE
Avatars: Make shape default to circles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.29.0",
+  "version": "2.30.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.30.0-beta",
+  "version": "2.30.1-avatars-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.30.0-beta",
+  "version": "2.30.1-avatars-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.29.0",
+  "version": "2.30.0-beta",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/AvatarGrid/AvatarGrid.js
+++ b/src/components/AvatarGrid/AvatarGrid.js
@@ -38,7 +38,7 @@ class AvatarGrid extends Component<Props> {
     borderColor: 'transparent',
     center: true,
     max: 9,
-    shape: 'rounded',
+    shape: 'circle',
     showStatusBorderColor: true,
     size: 'md',
   }

--- a/src/components/Message/Message.js
+++ b/src/components/Message/Message.js
@@ -66,7 +66,7 @@ export class Message extends Component<Props> {
 
     const avatarMarkup = avatar
       ? React.cloneElement(avatar, {
-          shape: isThemeEmbed ? 'circle' : 'rounded',
+          shape: 'circle',
           size: isThemeEmbed ? 'xxs' : 'xs',
         })
       : null

--- a/src/components/Message/__tests__/Message.test.js
+++ b/src/components/Message/__tests__/Message.test.js
@@ -208,7 +208,20 @@ describe('Context', () => {
       expect(o.length).toBe(0)
     })
 
-    test('Always render Circle avatars for embed', () => {
+    test('Always render Circle avatars', () => {
+      const a = <Avatar name="Mugatu" shape="square" />
+      const wrapper = mount(
+        <Message.Provider>
+          <Message avatar={a} showAvatar from />
+        </Message.Provider>
+      )
+
+      const o = wrapper.find(Avatar)
+
+      expect(o.prop('shape')).toBe('circle')
+    })
+
+    test('Always render size xxs for embed', () => {
       const a = <Avatar name="Mugatu" shape="square" />
       const wrapper = mount(
         <Message.Provider theme="embed">
@@ -218,7 +231,7 @@ describe('Context', () => {
 
       const o = wrapper.find(Avatar)
 
-      expect(o.prop('shape')).toBe('circle')
+      expect(o.prop('size')).toBe('xxs')
     })
   })
 })

--- a/src/components/StatusAvatar/StatusAvatar.js
+++ b/src/components/StatusAvatar/StatusAvatar.js
@@ -20,7 +20,7 @@ type Props = {
 class StatusAvatar extends Component<Props> {
   static defaultProps = {
     isOnline: true,
-    shape: 'rounded',
+    shape: 'circle',
     size: 'smmd',
   }
 

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.30.0-beta',
+  version: '2.30.1-avatars-0',
 }

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.29.0',
+  version: '2.30.0-beta',
 }


### PR DESCRIPTION
## Avatars: Make shape default to circles

@jaredmcdaniel has a [PR](https://github.com/helpscout/hs-app/pull/6653) in play to make all Avatars in `hs-app` circles. In order to make this happen, we need to change the `<Message>` component in HSDS to stop enforcing `rounded`. 

This PR changes the logic to enforce `shape="circle"` on all `Message` component `Avatar`s regardless of theme. (Embed was already circles)

### Before:
![image](https://user-images.githubusercontent.com/2163045/56613887-54563d00-65b3-11e9-8363-65f4802c9241.png)

### After: 
![image](https://user-images.githubusercontent.com/2163045/56613894-5ae4b480-65b3-11e9-9785-21cb5f1a5411.png)
