### PR TITLE
Refactor input error-state outline color to Red

### DIFF
--- a/src/components/Input/BackdropV2.js
+++ b/src/components/Input/BackdropV2.js
@@ -3,7 +3,7 @@ import type { UIState } from '../../constants/types'
 import React, { PureComponent as Component } from 'react'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import { classNames } from '../../utilities/classNames'
-import { isStateful } from './utils'
+import { hasErrorState, isStateful } from './utils'
 import { BackdropUI, FocusUI } from './styles/BackdropV2.css.js'
 
 type Props = {
@@ -75,7 +75,8 @@ class Backdrop extends Component<Props> {
       isNotOnly && 'is-notOnly',
       isLast && 'is-last',
       isRadio && 'is-radio',
-      isStateful(this.props) && 'is-stateful'
+      isStateful(this.props) && 'is-stateful',
+      hasErrorState(this.props) && `is-error`
     )
   }
 

--- a/src/components/Input/__tests__/BackdropV2.test.js
+++ b/src/components/Input/__tests__/BackdropV2.test.js
@@ -122,4 +122,11 @@ describe('Focus', () => {
     expect(o.getDOMNode().classList.contains('is-notOnly')).toBe(false)
     expect(o.getDOMNode().classList.contains('is-last')).toBe(true)
   })
+
+  test('Can render error state styles', () => {
+    const wrapper = mount(<Backdrop isFocused state="error" />)
+    const o = wrapper.find('.c-InputBackdropV2__focus').first()
+
+    expect(o.getDOMNode().classList.contains('is-error')).toBe(true)
+  })
 })

--- a/src/components/Input/styles/BackdropV2.css.js
+++ b/src/components/Input/styles/BackdropV2.css.js
@@ -16,6 +16,7 @@ export const config = {
   boxShadow: `0 0 0 0 rgba(${getColor('border')}, 0)`,
   boxShadowCheckbox: '0 0.5px 1px rgba(0, 0, 0, 0.2) inset',
   focusOutlineWidth: 2,
+  focusErrorOutlineWidth: 1,
   focusErrorOutlineColor: getColor('red.500'),
   focusOutlineColor: getColor('blue.500'),
   focusOutlineOffset: 1,
@@ -152,12 +153,12 @@ export const FocusUI = styled('div')`
   }
 
   &.is-error {
-    box-shadow: 0 0 0 ${config.focusOutlineWidth}px
+    box-shadow: 0 0 0 ${config.focusErrorOutlineWidth}px
       ${config.focusErrorOutlineColor};
   }
 `
 
-function makeStateStyles(): string {
+function makeStateStyles() {
   return forEach(
     STATES,
     state => `

--- a/src/components/Input/styles/BackdropV2.css.js
+++ b/src/components/Input/styles/BackdropV2.css.js
@@ -16,6 +16,7 @@ export const config = {
   boxShadow: `0 0 0 0 rgba(${getColor('border')}, 0)`,
   boxShadowCheckbox: '0 0.5px 1px rgba(0, 0, 0, 0.2) inset',
   focusOutlineWidth: 2,
+  focusErrorOutlineColor: getColor('red.500'),
   focusOutlineColor: getColor('blue.500'),
   focusOutlineOffset: 1,
   transition:
@@ -148,6 +149,11 @@ export const FocusUI = styled('div')`
     left: -1px;
     right: -1px;
     top: -1px;
+  }
+
+  &.is-error {
+    box-shadow: 0 0 0 ${config.focusOutlineWidth}px
+      ${config.focusErrorOutlineColor};
   }
 `
 

--- a/src/components/Input/utils.js
+++ b/src/components/Input/utils.js
@@ -66,3 +66,8 @@ export function isTextArea(node: HTMLElement): boolean {
 export function isStateful(props: Object): boolean {
   return props.state && includes(['error', 'success', 'warning'], props.state)
 }
+
+export function hasErrorState(props: Object): boolean {
+  const state = props.state
+  return state && state === 'error'
+}


### PR DESCRIPTION
[Trello Card](https://trello.com/c/YhkkvCSD/1152-focus-state-for-inputs-with-errors-should-be-red)

This refactors the outline color of an input with an error. 

### Before

<img width="2284" alt="Screen Shot 2019-04-23 at 4 48 20 PM" src="https://user-images.githubusercontent.com/7111256/56623146-e7a96580-65e7-11e9-90b3-758b62cd4ac4.png">

### After
<img width="2303" alt="Screen Shot 2019-04-23 at 3 52 25 PM" src="https://user-images.githubusercontent.com/7111256/56623155-ebd58300-65e7-11e9-9aa1-685b105c895b.png">
