### PR TITLE
Data Cy: Fix namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1646,6 +1646,28 @@
         "react-resizable": "^1.7.5",
         "redux": "^4.0.1",
         "resize-observer-polyfill": "^1.5.0"
+      },
+      "dependencies": {
+        "@helpscout/react-utils": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@helpscout/react-utils/-/react-utils-1.0.6.tgz",
+          "integrity": "sha512-7nwK14rKFvCX37z/4DbOoFum61V4PLNWB9sN9k/hNlUd7ORepCa5MKq8qv0Ozneb6TYie+u9Y/QQi2Txi8Puog==",
+          "dev": true,
+          "requires": {
+            "create-react-context": "0.2.2",
+            "dash-get": "1.0.2",
+            "hoist-non-react-statics": "3.0.1"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz",
+          "integrity": "sha512-1kXwPsOi0OGQIZNVMPvgWJ9tSnGMiMfJdihqEzrPEXlHOBh9AAHXX/QYmAJTXztnz/K+PQ8ryCb4eGaN6HlGbQ==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.3.2"
+          }
+        }
       }
     },
     "@helpscout/colorway": {
@@ -1684,35 +1706,63 @@
       }
     },
     "@helpscout/fancy": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.2.6.tgz",
-      "integrity": "sha512-TsX7CP5VHpzoyF1tbjPf+V+2ePzjD9qC3L0MXPi8+y2pC5jWe9lnUsnLhnoIYRSY8ZJqUxsdpurjiLnudfo4hg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.4.1.tgz",
+      "integrity": "sha512-4FcrSVXz2Q03qrAxL9SFqNGr9o19cOXiTpfSsAK0Pf5waRviQXnD1kYf/bt/h9S3dAVlXzC+uG/3J/G7ENxE1A==",
       "requires": {
         "@emotion/hash": "0.6.6",
         "@emotion/memoize": "0.6.6",
         "@emotion/stylis": "0.7.1",
         "@emotion/unitless": "0.6.7",
-        "@helpscout/react-utils": "1.0.6",
+        "@helpscout/react-utils": "2.2.0",
         "create-emotion": "9.2.12",
         "create-emotion-styled": "9.2.8",
-        "csstype": "2.5.7",
         "emotion-theming": "9.2.9",
         "stylis": "3.5.3",
         "stylis-rule-sheet": "0.0.10"
       },
       "dependencies": {
+        "@helpscout/react-utils": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@helpscout/react-utils/-/react-utils-2.2.0.tgz",
+          "integrity": "sha512-30/SdeaWJmzTpr47c9TycCrOfrpdTqZLtI99xn59ce2mBwPLW543lFNuxNj/FvEy0GCPvwCRcxdyAruggETdfQ==",
+          "requires": {
+            "create-react-context": "0.2.3",
+            "dash-get": "1.0.2",
+            "hoist-non-react-statics": "3.2.1"
+          }
+        },
+        "create-react-context": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+          "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+          "requires": {
+            "fbjs": "^0.8.0",
+            "gud": "^1.0.0"
+          }
+        },
         "emotion-theming": {
           "version": "9.2.9",
           "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-9.2.9.tgz",
           "integrity": "sha512-Ncyr1WocmDDrTbuYAzklIUC5iKiGtHy3e5ymoFXcka6SuvZl/EDMawegk4wVp72Agrcm1xemab3QOHfnOkpoMA==",
           "requires": {
             "hoist-non-react-statics": "^2.3.1"
+          },
+          "dependencies": {
+            "hoist-non-react-statics": {
+              "version": "2.5.5",
+              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+            }
           }
         },
         "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz",
+          "integrity": "sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==",
+          "requires": {
+            "react-is": "^16.3.2"
+          }
         }
       }
     },
@@ -1754,13 +1804,24 @@
       }
     },
     "@helpscout/react-utils": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@helpscout/react-utils/-/react-utils-1.0.6.tgz",
-      "integrity": "sha512-7nwK14rKFvCX37z/4DbOoFum61V4PLNWB9sN9k/hNlUd7ORepCa5MKq8qv0Ozneb6TYie+u9Y/QQi2Txi8Puog==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@helpscout/react-utils/-/react-utils-2.2.0.tgz",
+      "integrity": "sha512-30/SdeaWJmzTpr47c9TycCrOfrpdTqZLtI99xn59ce2mBwPLW543lFNuxNj/FvEy0GCPvwCRcxdyAruggETdfQ==",
       "requires": {
-        "create-react-context": "0.2.2",
+        "create-react-context": "0.2.3",
         "dash-get": "1.0.2",
-        "hoist-non-react-statics": "3.0.1"
+        "hoist-non-react-statics": "3.2.1"
+      },
+      "dependencies": {
+        "create-react-context": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+          "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+          "requires": {
+            "fbjs": "^0.8.0",
+            "gud": "^1.0.0"
+          }
+        }
       }
     },
     "@helpscout/stats": {
@@ -1770,9 +1831,9 @@
       "dev": true
     },
     "@helpscout/wedux": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@helpscout/wedux/-/wedux-0.0.11.tgz",
-      "integrity": "sha512-7k3G0zKKLAS1oQKY4yRtRqyQODCFbOaj//4eaotUSRP4P6J7jpwhOptrZODYQmjr5XZx4DWQxZW40Ddlv7bGyQ=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@helpscout/wedux/-/wedux-0.1.0.tgz",
+      "integrity": "sha512-jkB9bCZIxkmt2RbpKLCoefFK/sfZtdxDgZlFoZCs1yIvyP1MuHp20S7oZEwdwfrr2MIvp8kl3zeTl0hmcjF7uw=="
     },
     "@icons/material": {
       "version": "0.2.4",
@@ -8666,6 +8727,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
       "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
+      "dev": true,
       "requires": {
         "fbjs": "^0.8.0",
         "gud": "^1.0.0"
@@ -12611,9 +12673,9 @@
       "dev": true
     },
     "hoist-non-react-statics": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz",
-      "integrity": "sha512-1kXwPsOi0OGQIZNVMPvgWJ9tSnGMiMfJdihqEzrPEXlHOBh9AAHXX/QYmAJTXztnz/K+PQ8ryCb4eGaN6HlGbQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz",
+      "integrity": "sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==",
       "requires": {
         "react-is": "^16.3.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.33.0",
+  "version": "2.33.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.33.0",
+  "version": "2.33.1-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -88,9 +88,9 @@
     "react-router-dom": "4.0.0 - 4.3.1"
   },
   "dependencies": {
-    "@helpscout/fancy": "2.2.6",
-    "@helpscout/react-utils": "1.0.6",
-    "@helpscout/wedux": "0.0.11",
+    "@helpscout/fancy": "2.4.1",
+    "@helpscout/react-utils": "2.2.0",
+    "@helpscout/wedux": "0.1.0",
     "@seedcss/seed-button": "0.0.6",
     "@seedcss/seed-color-scheme": "0.0.6",
     "@seedcss/seed-control": "0.0.6",

--- a/src/components/PropProvider/propConnect.tsx
+++ b/src/components/PropProvider/propConnect.tsx
@@ -61,6 +61,7 @@ function propConnect(name?: ConfigGetter, options: Object = {}) {
         wrappedRef: noop,
       }
       static displayName = displayName
+      static displayLabel = namespace
 
       wrappedInstance: any = null
 

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.33.0',
+  version: '2.33.1-0',
 }


### PR DESCRIPTION
## Data Cy: Fix namespace

This update fixes the autogenerated `data-cy` namespace for HSDS: React
components. The solution was to adjust how Fancy compiled the namespace to
make it more compatible with HSDS: React integration.

This required an update to Fancy to the latest v2.4.1

React Utils and Wedux were also updated to their latest versions

Fixes: https://github.com/helpscout/hsds-react/issues/595