### PR TITLE
Page.Card: Add additional bottom margin

### DIFF
--- a/src/components/Page/styles/Card.css.ts
+++ b/src/components/Page/styles/Card.css.ts
@@ -20,7 +20,7 @@ export const config = {
     default: 'column',
     superWidescreen: 'row',
   },
-  marginBottom: '20px',
+  marginBottom: '40px',
   padding: {
     default: '50px 50px',
     widescreen: '50px 100px',


### PR DESCRIPTION
## Page.Card: Add additional bottom margin

[Trello Card](https://trello.com/c/aAVMc6Sz/1151-additional-20px-padding-required-on-the-bottom-of-greeter-settings-blocks)

Add extra margin to the bottom of Page.Card component.

### Before 
![](https://user-images.githubusercontent.com/7111256/56835326-b9669880-6828-11e9-82e8-649da4541cc0.png)

### After
![](https://user-images.githubusercontent.com/7111256/56835334-c08da680-6828-11e9-9e34-bcf35d516890.png)
