### PR TITLE
Dropdown: Fix label rendering in multi select 

### DIFF
--- a/src/components/Dropdown/V2/Dropdown.ItemSelectedCheck.tsx
+++ b/src/components/Dropdown/V2/Dropdown.ItemSelectedCheck.tsx
@@ -28,9 +28,11 @@ const ItemSelectedCheck = (props: any = defaultProps) => {
     isClearerActive && 'is-selectionClearer-active'
   )
 
+  const content = props.label || props.value
+
   return (
     <ItemSelectedCheckUI className={componentClassnames}>
-      <span className="c-ItemSelectedCheck__value">{props.value}</span>
+      <span className="c-ItemSelectedCheck__value">{content}</span>
       {props.isActive || isClearerActive ? <Icon name="check" /> : null}
     </ItemSelectedCheckUI>
   )


### PR DESCRIPTION
## Dropdown: Fix label rendering in multi select 

This update fix an issue where the label was not render inside a multi select dropdown. The component `ItemSelectedCheck` will now render the label if available. 