### PR TITLE
Dropdown: Multi-select: Match active item (without id)

### DIFF
--- a/src/components/Dropdown/V2/Dropdown.Renderer.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Renderer.tsx
@@ -249,7 +249,11 @@ class Renderer extends React.PureComponent<any> {
     if (allowMultipleSelection) {
       const selectedNode = findItemDOMNode(index, envNode)
       const itemId = indexMap[index - 1]
-      const nodeIsSelected = itemIsActive(selectedItem, { id: itemId })
+      const nodeIsSelected = itemIsActive(selectedItem, {
+        id: itemId,
+        // Fallback matcher, for items without `id`
+        value: itemId,
+      })
 
       if (selectedNode) {
         if (nodeIsSelected) {

--- a/stories/AutoDropdown.stories.js
+++ b/stories/AutoDropdown.stories.js
@@ -9,7 +9,6 @@ const stories = storiesOf('AutoDropdown', module)
 stories.addDecorator(withKnobs)
 
 const ItemSpec = createSpec({
-  id: faker.random.uuid(),
   value: faker.name.firstName(),
 })
 const items = ItemSpec.generate(15)


### PR DESCRIPTION
## Dropdown: Multi-select: Match active item (without id)

![Screen Recording 2019-04-29 at 12 50 PM](https://user-images.githubusercontent.com/2322354/56912706-d647d980-6a7d-11e9-95cf-861cbf322888.gif)


This update fixes the Dropdown: Multi-select active rendering, specifically
for items without an `id` prop.

This update provides the matcher util with the `indexMap` id for both `id`
and `value` (as fallback) to determine the `is-active` UI state.