### PR TITLE
Avatar: Remove background when image is loaded

### DIFF
--- a/src/components/Avatar/Avatar.Crop.tsx
+++ b/src/components/Avatar/Avatar.Crop.tsx
@@ -1,9 +1,18 @@
 import * as React from 'react'
+import { getEasingTiming } from '../../utilities/easing'
 import { classNames } from '../../utilities/classNames'
 import { CropUI } from './Avatar.css'
 
 export const AvatarCrop = props => {
-  const { className, children, hasImage, isImageLoaded, withShadow } = props
+  const {
+    animationDuration,
+    animationEasing,
+    className,
+    children,
+    hasImage,
+    isImageLoaded,
+    withShadow,
+  } = props
 
   const componentClassName = classNames(
     'c-Avatar__crop',
@@ -13,7 +22,10 @@ export const AvatarCrop = props => {
   )
 
   const styles = {
-    backgroundColor: hasImage ? 'currentColor' : null,
+    backgroundColor: isImageLoaded ? 'transparent' : 'currentColor',
+    transition: `background-color ${animationDuration}ms ${getEasingTiming(
+      animationEasing
+    )}`,
   }
 
   return (
@@ -24,6 +36,8 @@ export const AvatarCrop = props => {
 }
 
 AvatarCrop.defaultProps = {
+  animationDuration: 160,
+  animationEasing: 'ease',
   hasImage: false,
   isImageLoaded: false,
   withShadow: false,

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -117,6 +117,8 @@ export class Avatar extends React.PureComponent<Props, State> {
 
     return (
       <AvatarCrop
+        animationDuration={animationDuration}
+        animationEasing={animationEasing}
         className={shapeClassnames}
         hasImage={hasImage}
         isImageLoaded={isImageLoaded}

--- a/stories/Avatar/AvatarV2.stories.js
+++ b/stories/Avatar/AvatarV2.stories.js
@@ -11,11 +11,9 @@ import { withArtboard, Guide, GuideContainer } from '@helpscout/artboard'
 import { Avatar } from '../../src/index.js'
 import AvatarSpec from './specs/Avatar'
 
-const guides = []
-
 const stories = storiesOf('Avatar', module)
 stories.addDecorator(
-  withArtboard({ id: 'hsds-avatar', guides, width: 300, height: 160 })
+  withArtboard({ width: 300, height: 160, withCenterGuides: false })
 )
 stories.addDecorator(withKnobs)
 
@@ -23,6 +21,7 @@ stories.add('V2/Default', () => {
   const animationDuration = number('animationDuration', 160)
   const animationEasing = text('animationEasing', 'ease')
 
+  const image = boolean('image')
   const size = select(
     'size',
     {
@@ -63,6 +62,7 @@ stories.add('V2/Default', () => {
     ...AvatarSpec.generate(),
     animationDuration,
     animationEasing,
+    image: image ? AvatarSpec.generate().image : null,
     shape,
     size,
     status,


### PR DESCRIPTION
## Avatar: Remove background when image is loaded

![Screen Recording 2019-04-30 at 04 14 PM](https://user-images.githubusercontent.com/2322354/56990483-306e9a80-6b63-11e9-9706-25c244266cdb.gif)

This update adjusts the `Avatar` component to remove the background color
once the Image is loaded in. This prevents unexpected cropping issues
around the edge of rounded/circular avatars.