### PR TITLE
Remove unicode modifier from auto linking regex

### DIFF
--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -277,10 +277,10 @@ export const convertLinksToHTML = (string: string): string => {
   }
 
   return string
-    .split(new RegExp(`(${urlPattern}|${emailPattern})`, 'giu'))
+    .split(new RegExp('(' + urlPattern + '|' + emailPattern + ')', 'gi'))
     .reduce((accumulator: string, value: string, index: number): string => {
       if (index % 2) {
-        if (value.match(new RegExp(`^${emailPattern}$`, 'ui'))) {
+        if (value.match(new RegExp('^' + emailPattern + '$', 'i'))) {
           // Matched an email
           return (
             accumulator +
@@ -291,7 +291,7 @@ export const convertLinksToHTML = (string: string): string => {
         // Matched a URL
         let url = value
 
-        if (url.match(new RegExp(`^${domainPattern}$`, 'ui'))) {
+        if (url.match(new RegExp(`^${domainPattern}$`, 'i'))) {
           // Only matched a domain name (without subdomain)
           // Skip this as it could be the end/start of a sentence without whitespace.
           // For example with "Hello Tom.how are you?" we should not match "Tom.how"

--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -277,10 +277,10 @@ export const convertLinksToHTML = (string: string): string => {
   }
 
   return string
-    .split(new RegExp('(' + urlPattern + '|' + emailPattern + ')', 'gi'))
+    .split(new RegExp(`(${urlPattern}|${emailPattern})`, 'gi'))
     .reduce((accumulator: string, value: string, index: number): string => {
       if (index % 2) {
-        if (value.match(new RegExp('^' + emailPattern + '$', 'i'))) {
+        if (value.match(new RegExp(`^${emailPattern}$`, 'i'))) {
           // Matched an email
           return (
             accumulator +


### PR DESCRIPTION
We had issues with the regex in IE11 that resulted in syntax errors.

![Screen Shot 2019-05-02 at 14 59 49](https://user-images.githubusercontent.com/6132043/57080924-925a0c00-6ceb-11e9-98e7-52a9a31a1baf.png)

After removing the modifier the story loads and the URL is converted to a link.

![Screen Shot 2019-05-02 at 14 59 10](https://user-images.githubusercontent.com/6132043/57080930-971ec000-6ceb-11e9-9b6a-20d32505aef0.png)