### PR TITLE
Pop (Tooltip/Popover): Fix closeOnBodyClick

### DIFF
--- a/src/components/EventListener/EventListener.tsx
+++ b/src/components/EventListener/EventListener.tsx
@@ -49,7 +49,19 @@ class EventListener extends React.Component<Props> {
 
   setInternalScopeFromProps = (props: Props) => {
     const { scope } = props
-    this.scope = scope === document ? getClosestDocument(this.node) : scope
+
+    let _document = document
+    let internalScope = scope
+
+    if (scope === document) {
+      _document = getClosestDocument(this.node)
+      internalScope = _document
+    }
+    if (scope === document.body) {
+      internalScope = _document.body
+    }
+
+    this.scope = internalScope
   }
 
   attachListener = () => {

--- a/src/components/Pop/Arrow.tsx
+++ b/src/components/Pop/Arrow.tsx
@@ -20,6 +20,7 @@ export interface Props {
 
 export class Arrow extends React.PureComponent<Props> {
   static defaultProps = {
+    'data-cy': 'PopArrow',
     innerRef: noop,
     offset: 0,
     placement: 'top',

--- a/src/components/Pop/Pop.types.ts
+++ b/src/components/Pop/Pop.types.ts
@@ -46,3 +46,8 @@ export type PopperStyles = {
   placement: Placements
   style: Object
 }
+
+export type PopInteraction = {
+  type: string
+  props?: any
+}

--- a/src/components/Pop/Pop.utils.ts
+++ b/src/components/Pop/Pop.utils.ts
@@ -1,0 +1,10 @@
+export const INTERACTION_TYPE = {
+  BODY_CLICK: 'bodyClick',
+  CONTENT_CLICK: 'contentClick',
+  MOUNT: 'mount',
+  MOUSE_LEAVE: 'mouseLeave',
+  MOUSE_MOVE: 'mouseMove',
+  POPPER_MOUSE_LEAVE: 'popperMouseLeave',
+  TOGGLE: 'toggle',
+  UPDATE_IS_OPEN: 'updatedIsOpen',
+}

--- a/src/components/Pop/Popper.tsx
+++ b/src/components/Pop/Popper.tsx
@@ -110,6 +110,7 @@ export class Popper extends React.Component<Props> {
 
     return (
       <ReactPopper
+        data-cy="PopPopper"
         modifiers={modifiers}
         placement={placement}
         positionFixed={positionFixed}

--- a/src/components/Pop/README.md
+++ b/src/components/Pop/README.md
@@ -8,6 +8,7 @@ This component is powered by [Popper.js](https://popper.js.org/) the evolution o
 
 The Toolbar component is comprised of smaller components:
 
+* [Pop](./docs/Pop.md)
 * [Arrow](./docs/Arrow.md)
 * [Manager](./docs/Manager.md)
 * [Popper](./docs/Popper.md)

--- a/src/components/Pop/docs/Pop.md
+++ b/src/components/Pop/docs/Pop.md
@@ -25,15 +25,17 @@ This component is powered by [Popper.js](https://popper.js.org/) the evolution o
 | className           | `string`   | Custom class names to be added to the component.                   |
 | closeOnBodyClick    | `boolean`  | Closes component on `body` click. Default `false`.                 |
 | closeOnContentClick | `boolean`  | Closes component on inner content click. Default `false`.          |
-| closeOnMouseLeave   | `boolean`  | Closes component when the mouse leaves component . Default `true`. |
 | closeOnEscPress     | `boolean`  | Closes component on `ESC` key press. Default `true`.               |
+| closeOnMouseLeave   | `boolean`  | Closes component when the mouse leaves component . Default `true`. |
 | display             | `string`   | The CSS `display` of the component.                                |
 | isOpen              | `boolean`  | Open/close the component.                                          |
 | onBeforeClose       | `Function` | Callback before component opens. Returns a `Promise`.              |
 | onBeforeOpen        | `Function` | Callback before component opens. Returns a `Promise`.              |
 | onClose             | `Function` | Callback when component closes.                                    |
-| onOpen              | `Function` | Callback when component opens.                                     |
 | onContentClick      | `Function` | Callback when inner content is clicked.                            |
+| onOpen              | `Function` | Callback when component opens.                                     |
 | placement           | `string`   | Determines the alignment of the component's content.               |
-| triggerOn           | `string`   | Determines how to engage the component.                            |
+| shouldClose         | `Function` | Determines if the component should close. Returns `boolean`.       |
+| shouldOpen          | `Function` | Determines if the component should open. Returns `boolean`.        |
 | showArrow           | `boolean`  | Renders the [Arrow component](./Arrow.md). Default `true`.         |
+| triggerOn           | `string`   | Determines how to engage the component.                            |

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -109,6 +109,8 @@ export class Popover extends React.PureComponent<Props> {
         contentClassName="c-PopoverContent"
         className={this.getClassName()}
         closeOnMouseLeave={false}
+        data-cy="Popover"
+        dataCyPopper="PopoverContent"
         innerRef={innerRef}
         renderContent={this.renderContent}
       />

--- a/src/components/Popover/__tests__/Popover.integration.test.tsx
+++ b/src/components/Popover/__tests__/Popover.integration.test.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react'
+import { cy, promiseQueue } from '@helpscout/cyan'
+import Popover from '../index'
+
+cy.useFakeTimers()
+cy.useFakePromises()
+
+const fastForwardTimers = () => {
+  cy.runAllPromises()
+  jest.runAllTimers()
+}
+
+describe('Interactions', () => {
+  test('Can be closed on body click', () => {
+    cy.render(<Popover isOpen />)
+
+    expect(cy.getByCy('PopoverContent').exists()).toBeTruthy()
+
+    document.body.click()
+    fastForwardTimers()
+
+    expect(cy.getByCy('PopoverContent').exists()).toBeFalsy()
+  })
+
+  test('Can be closed on ESC keypress', () => {
+    cy.render(<Popover isOpen />)
+
+    cy.type('{esc}')
+
+    expect(cy.getByCy('PopoverContent').exists()).toBeFalsy()
+  })
+
+  test('Can be closed on content click', async () => {
+    cy.render(<Popover isOpen closeOnContentClick={true} />)
+
+    await cy.getByCy('PopoverPopper').click()
+    fastForwardTimers()
+
+    expect(cy.getByCy('PopoverContent').exists()).toBeFalsy()
+  })
+})
+
+describe('shouldOpen/shouldClose', () => {
+  test('Can allow for Popover to open with shouldOpen', async () => {
+    const shouldOpen = () => true
+    cy.render(<Popover triggerOn="click" shouldOpen={shouldOpen} />)
+
+    await cy.getByCy('Popover').click()
+    fastForwardTimers()
+
+    expect(cy.getByCy('PopoverContent').exists()).toBeTruthy()
+  })
+
+  test('Can prevent Popover from opening with shouldOpen', async () => {
+    const shouldOpen = () => false
+    cy.render(<Popover triggerOn="click" shouldOpen={shouldOpen} />)
+
+    await cy.getByCy('Popover').click()
+    fastForwardTimers()
+
+    expect(cy.getByCy('PopoverContent').exists()).toBeFalsy()
+  })
+
+  test('Can allow for Popover to close with shouldClose', async () => {
+    const shouldClose = () => true
+    cy.render(<Popover isOpen={true} shouldClose={shouldClose} />)
+
+    await document.body.click()
+    fastForwardTimers()
+
+    expect(cy.getByCy('PopoverContent').exists()).toBeFalsy()
+  })
+
+  test('Can prevent Popover from closing with shouldClose', async () => {
+    const shouldClose = () => false
+    cy.render(<Popover isOpen={true} shouldClose={shouldClose} />)
+
+    await document.body.click()
+    fastForwardTimers()
+
+    expect(cy.getByCy('PopoverContent').exists()).toBeTruthy()
+  })
+})

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -17,6 +17,7 @@ export interface Props extends PopProps {
   contentClassName?: string
   className?: string
   color: string
+  dataCyPopper: string
   innerRef: (node: HTMLElement) => void
   minWidth?: number | string
   maxWidth?: number | string
@@ -36,6 +37,7 @@ export class Tooltip extends React.PureComponent<Props> {
     color: getColor('charcoal.700'),
     closeOnContentClick: false,
     closeOnMouseLeave: true,
+    dataCyPopper: 'TooltipContent',
     innerRef: noop,
     isOpen: false,
     modifiers: {},
@@ -94,11 +96,12 @@ export class Tooltip extends React.PureComponent<Props> {
   }
 
   renderPopper = (renderProps?: any) => {
-    const { maxWidth, minWidth } = this.props
+    const { dataCyPopper, maxWidth, minWidth } = this.props
 
     return (
       <Popper
         className={this.getContentClassName()}
+        data-cy={dataCyPopper}
         style={{ maxWidth, minWidth }}
       >
         {this.renderContent(renderProps || /* istanbul ignore next */ {})}
@@ -119,7 +122,10 @@ export class Tooltip extends React.PureComponent<Props> {
 
     return (
       <TooltipUI {...rest} className={this.getClassName()}>
-        <Pop.Reference className="c-Tooltip__reference">
+        <Pop.Reference
+          className="c-Tooltip__reference"
+          data-cy={`${this.props['data-cy']}Reference`}
+        >
           {children}
         </Pop.Reference>
         <Pop.Popper


### PR DESCRIPTION
## Pop (Tooltip/Popover): Fix closeOnBodyClick

![Screen Recording 2019-05-15 at 10 22 AM](https://user-images.githubusercontent.com/2322354/57783056-6d0dca80-76fb-11e9-8edd-c7b9a5210b12.gif)


This update fixes the closeOnBodyClick mechanic of `Pop`, which powers
`Tooltip` and `Popover`.

The issue was the click handler was never actually called. The solution
was to add `EventListener` to scope on `document.body` to handle the
interaction.

A nice enhancement was added to `Pop` to allow for the user to determine
if the `Pop` component should open/close before it happens with a
`Function` that returns a `boolean`. This enables finer grain control
for situations.

Cyan tests have been added to `Popover` to test these interactions and
integrations.

Also! For this PR, `closeOnBodyClick` will be set to **true** by default!

Resolves: https://github.com/helpscout/hsds-react/issues/623