### PR TITLE
Page: Adjust margins

### DIFF
--- a/src/components/FormGroup/styles/Choice.css.ts
+++ b/src/components/FormGroup/styles/Choice.css.ts
@@ -2,7 +2,8 @@ import baseStyles from '../../../styles/resets/baseStyles.css'
 import styled from '../../styled'
 
 export const FormGroupChoiceUI = styled('div')`
-  ${baseStyles} margin-bottom: 8px;
+  ${baseStyles};
+  margin-bottom: 8px;
 
   &.is-responsive {
     flex: 1;

--- a/src/components/FormGroup/styles/FormGroup.css.ts
+++ b/src/components/FormGroup/styles/FormGroup.css.ts
@@ -2,7 +2,8 @@ import baseStyles from '../../../styles/resets/baseStyles.css'
 import styled from '../../styled'
 
 export const FormGroupUI = styled('div')`
-  ${baseStyles} margin-bottom: 18px;
+  ${baseStyles};
+  margin-bottom: 20px;
 
   &:last-child {
     margin-bottom: 0;

--- a/src/components/Page/styles/Page.Card.css.ts
+++ b/src/components/Page/styles/Page.Card.css.ts
@@ -22,8 +22,8 @@ export const config = {
   },
   marginBottom: '40px',
   padding: {
-    default: '50px 50px',
-    widescreen: '50px 100px',
+    default: '50px 50px 65px',
+    widescreen: '50px 100px 65px',
     superWidescreen: '65px 50px',
     fullscreen: '65px 100px',
   },

--- a/stories/Page/Page.Example.stories.js
+++ b/stories/Page/Page.Example.stories.js
@@ -28,23 +28,14 @@ stories.add('Responsive', () => {
   return (
     <Page isResponsive={isResponsive}>
       <Page.Card>
-        <Page.Section>
-          <Page.Header
-            render={({ Title, Subtitle }) => (
-              <div>
-                <Title headingLevel="h1">Edit your account</Title>
-                <Subtitle>Welcome to the Dharma Initiative.</Subtitle>
-              </div>
-            )}
-          />
-          <Page.Content>
-            <FormGroup>
-              <FormLabel label="Site Name">
-                <Input value="Dashing Dash" />
-              </FormLabel>
-            </FormGroup>
-          </Page.Content>
-        </Page.Section>
+        <Page.Header
+          render={({ Title, Subtitle }) => (
+            <div>
+              <Title headingLevel="h1">Edit your account</Title>
+              <Subtitle>Welcome to the Dharma Initiative.</Subtitle>
+            </div>
+          )}
+        />
 
         <Page.Section>
           <Page.Header


### PR DESCRIPTION
## Page: Adjust margins

![Screen Shot 2019-05-15 at 11 49 52 AM](https://user-images.githubusercontent.com/2322354/57790872-9cc3cf00-7709-11e9-9a76-17bd14b11456.png)

![Screen Shot 2019-05-15 at 11 50 01 AM](https://user-images.githubusercontent.com/2322354/57790875-9f262900-7709-11e9-8479-21feb821d2cc.png)

(Screenshots from Zeplin)

This update adjusts the bottom of `Page.Card` to have a margin of `65px`,
matching the latest designs. `FormGroup` margin has also been bumped to `20px`.

cc'ing @digitaldesigner for heads up!