### PR TITLE
ActionSelect: Fix resize and refocus interactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.43.2",
+  "version": "2.43.3-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.43.2",
+  "version": "2.43.3-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
+++ b/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
@@ -28,6 +28,7 @@ export class ContentResizer extends React.PureComponent<
     innerRef: noop,
     isFadeContentOnOpen: true,
     onResize: noop,
+    resizeCount: 0,
     selectedKey: null,
   }
 
@@ -46,7 +47,7 @@ export class ContentResizer extends React.PureComponent<
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.children !== this.props.children) {
+    if (nextProps.resizeCount !== this.props.resizeCount) {
       this.handleResize(nextProps)
     }
   }

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -36,6 +36,7 @@ export class ActionSelect extends React.PureComponent<
 
   state = {
     isOpen: this.props.isOpen,
+    resizeCount: 0,
     selectedItem: null,
   }
 
@@ -71,6 +72,7 @@ export class ActionSelect extends React.PureComponent<
     this.autoFocusChildNode()
 
     this.safeSetState({
+      resizeCount: this.state.resizeCount + 1,
       selectedItem: props.item,
     })
   }
@@ -142,9 +144,10 @@ export class ActionSelect extends React.PureComponent<
           animationEasing={animationEasing}
           borderWidth={1}
           innerRef={this.setContentNode}
-          onResize={onResize}
-          selectedKey={getUniqueKeyFromItem(selectedItem)}
           isOpen={this.state.isOpen}
+          onResize={onResize}
+          resizeCount={this.state.resizeCount}
+          selectedKey={getUniqueKeyFromItem(selectedItem)}
         >
           {children}
         </ContentResizer>

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -51,6 +51,12 @@ export class ActionSelect extends React.PureComponent<
     this._isMounted = false
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.selectedItem !== this.props.selectedItem) {
+      this.resizeContent()
+    }
+  }
+
   safeSetState = (nextState, callback?) => {
     if (this._isMounted) {
       this.setState(nextState, callback)
@@ -67,12 +73,18 @@ export class ActionSelect extends React.PureComponent<
     )
   }
 
+  resizeContent = () => {
+    this.safeSetState({
+      resizeCount: this.state.resizeCount + 1,
+    })
+  }
+
   handleOnSelect = (item, props) => {
     this.props.onSelect(item, props)
     this.autoFocusChildNode()
 
+    this.resizeContent()
     this.safeSetState({
-      resizeCount: this.state.resizeCount + 1,
       selectedItem: props.item,
     })
   }

--- a/src/components/ActionSelect/ActionSelect.types.ts
+++ b/src/components/ActionSelect/ActionSelect.types.ts
@@ -23,12 +23,14 @@ export interface ActionSelectProps
 
 export interface ActionSelectState {
   isOpen: boolean
+  resizeCount: number
   selectedItem?: any
 }
 
 export interface ActionSelectContentResizerProps extends ActionSelectBaseProps {
   borderWidth: number
   isOpen: boolean
+  resizeCount: number
 }
 
 export interface ActionSelectContentResizerState {

--- a/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
+++ b/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
@@ -156,10 +156,9 @@ describe('Open/Close', () => {
 })
 
 describe('Resize', () => {
-  test('Resizes content when child updates', () => {
+  test('Resizes content when an item is selected', () => {
     const spy = jest.fn()
     const Small = () => <div className="ChildContent" />
-    const Big = () => <div className="OtherContent" />
 
     const wrapper = cy.render(
       <ActionSelect
@@ -174,7 +173,10 @@ describe('Resize', () => {
 
     expect(spy).toHaveBeenCalledTimes(1)
 
-    wrapper.setProps({ children: <Big /> })
+    cy
+      .getByCy('DropdownItem')
+      .last()
+      .click()
 
     expect(spy).toHaveBeenCalledTimes(3)
   })

--- a/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
+++ b/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
@@ -180,4 +180,24 @@ describe('Resize', () => {
 
     expect(spy).toHaveBeenCalledTimes(3)
   })
+
+  test('Resizes content when an selectedItem is updated', () => {
+    const spy = jest.fn()
+
+    const wrapper = cy.render(
+      <ActionSelect
+        items={mockItems}
+        isOpen={true}
+        isAutoFocusNodeOnSelect={false}
+        selectedItem={mockItems[1]}
+        onResize={spy}
+      />
+    )
+
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    wrapper.setProps({ selectedItem: mockItems[0] })
+
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
 })

--- a/src/components/Choice/Choice.tsx
+++ b/src/components/Choice/Choice.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react'
-import { ChoiceAlign, ChoiceType, ChoiceValue } from './Choice.types'
-import { UIState } from '../../constants/types'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import Input from './Choice.Input'
 import Flexy from '../Flexy'
@@ -20,41 +18,11 @@ import {
   ChoiceHelpTextUI,
 } from './styles/Choice.css'
 import { COMPONENT_KEY } from './Choice.utils'
-
-type Props = {
-  align: ChoiceAlign
-  autoFocus: boolean
-  children?: any
-  checked: boolean
-  className?: string
-  componentID: string
-  disabled: boolean
-  helpText?: string
-  hideLabel: boolean
-  id?: string
-  inputRef: (node: HTMLElement) => void
-  innerRef: (node: HTMLElement) => void
-  kind?: string
-  label?: string
-  onBlur: (event: Event) => void
-  onChange: (event: Event, checked: boolean) => void
-  onFocus: (event: Event) => void
-  name?: string
-  readOnly: boolean
-  stacked: boolean
-  state?: UIState
-  type: ChoiceType
-  value: ChoiceValue
-}
-
-type State = {
-  checked: boolean
-  id: string
-}
+import { ChoiceValue, ChoiceProps, ChoiceState } from './Choice.types'
 
 const uniqueID = createUniqueIDFactory('Choice')
 
-class Choice extends React.PureComponent<Props, State> {
+class Choice extends React.PureComponent<ChoiceProps, ChoiceState> {
   static defaultProps = {
     autoFocus: false,
     checked: false,
@@ -66,21 +34,18 @@ class Choice extends React.PureComponent<Props, State> {
     onFocus: noop,
     inputRef: noop,
     innerRef: noop,
+    isBlock: false,
     readOnly: false,
     type: 'checkbox',
     value: '',
   }
 
-  constructor(props: Props) {
-    super(props)
-
-    this.state = {
-      checked: props.checked,
-      id: props.id || uniqueID(props.componentID),
-    }
+  state = {
+    checked: this.props.checked,
+    id: this.props.id || uniqueID(this.props.componentID),
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentWillReceiveProps(nextProps: ChoiceProps) {
     this.setState({
       checked: nextProps.checked,
       id: nextProps.id || this.state.id,
@@ -282,6 +247,7 @@ class Choice extends React.PureComponent<Props, State> {
       id,
       inputRef,
       innerRef,
+      isBlock,
       onBlur,
       onChange,
       onFocus,
@@ -302,6 +268,7 @@ class Choice extends React.PureComponent<Props, State> {
       `is-${type}`,
       checked && 'is-selected',
       disabled && 'is-disabled',
+      isBlock && 'is-block',
       kind && `is-${kind}`,
       readOnly && 'is-readonly',
       stacked && 'is-stacked',
@@ -313,6 +280,7 @@ class Choice extends React.PureComponent<Props, State> {
       'c-Choice__label',
       checked && 'is-selected',
       disabled && 'is-disabled',
+      isBlock && 'is-block',
       stacked && 'is-stacked'
     )
 

--- a/src/components/Choice/Choice.types.ts
+++ b/src/components/Choice/Choice.types.ts
@@ -1,5 +1,37 @@
+import { UIState } from '../../constants/types'
+
 export type ChoiceAlign = 'top' | ''
-
 export type ChoiceType = 'checkbox' | 'radio'
-
 export type ChoiceValue = string | number | boolean
+
+export interface ChoiceProps {
+  align: ChoiceAlign
+  autoFocus: boolean
+  children?: any
+  checked: boolean
+  className?: string
+  componentID: string
+  disabled: boolean
+  helpText?: string
+  hideLabel: boolean
+  id?: string
+  isBlock: boolean
+  inputRef: (node: HTMLElement) => void
+  innerRef: (node: HTMLElement) => void
+  kind?: string
+  label?: string
+  onBlur: (event: Event) => void
+  onChange: (event: Event, checked: boolean) => void
+  onFocus: (event: Event) => void
+  name?: string
+  readOnly: boolean
+  stacked: boolean
+  state?: UIState
+  type: ChoiceType
+  value: ChoiceValue
+}
+
+export interface ChoiceState {
+  checked: boolean
+  id: string
+}

--- a/src/components/Choice/__tests__/Choice.test.js
+++ b/src/components/Choice/__tests__/Choice.test.js
@@ -216,6 +216,20 @@ describe('States', () => {
     wrapper.unmount()
   })
 
+  test('Applies isBlock styles, if specified', () => {
+    const wrapper = mount(<Choice isBlock={true} />)
+    const o = wrapper.find('div.c-Choice')
+
+    expect(o.prop('className')).toContain('is-block')
+  })
+
+  test('Does not render isBlock styles, by default', () => {
+    const wrapper = mount(<Choice />)
+    const o = wrapper.find('div.c-Choice')
+
+    expect(o.prop('className')).not.toContain('is-block')
+  })
+
   test('Applies checkbox styles if specified', () => {
     const wrapper = mount(<Choice type="checkbox" />)
     const o = wrapper.find('div.c-Choice')

--- a/src/components/Choice/styles/Choice.css.js
+++ b/src/components/Choice/styles/Choice.css.js
@@ -7,8 +7,8 @@ export const config = {
     labelDefault: getColor('text.muted'),
     labelSelected: getColor('text.default'),
   },
-  helpTextOffset: 24,
-  labelTextMargin: 10,
+  helpTextOffset: '24px',
+  labelTextMargin: '10px',
 }
 
 export const ChoiceUI = styled('div')`
@@ -16,8 +16,16 @@ export const ChoiceUI = styled('div')`
 `
 
 export const ChoiceLabelUI = styled('label')`
+  ${baseStyles};
   cursor: pointer;
+  display: inline-block;
   margin-bottom: 0;
+  vertical-align: middle;
+
+  &.is-block {
+    display: block;
+    vertical-align: initial;
+  }
 
   &.is-disabled {
     cursor: not-allowed;
@@ -33,7 +41,8 @@ export const ChoiceLabelUI = styled('label')`
 `
 
 export const ChoiceHelpTextUI = styled('div')`
-  margin-left: ${config.helpTextOffset}px;
+  ${baseStyles};
+  margin-left: ${config.helpTextOffset};
 
   &.is-stacked {
     margin-left: 0;
@@ -41,10 +50,12 @@ export const ChoiceHelpTextUI = styled('div')`
 `
 
 export const ChoiceLabelTextUI = styled('span')`
+  ${baseStyles};
+
   &.is-stacked {
     display: block;
     font-weight: bold;
-    margin-top: ${config.labelTextMargin}px;
+    margin-top: ${config.labelTextMargin};
   }
 `
 

--- a/src/components/Dropdown/V2/Dropdown.Trigger.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Trigger.tsx
@@ -50,11 +50,11 @@ export class Trigger extends React.PureComponent<Props> {
   handleOnKeyDown = (event: KeyboardEvent) => {
     switch (event.keyCode) {
       case Keys.DOWN_ARROW:
-        this.openDropdown()
+        this.openDropdown(event)
         break
 
       case Keys.ENTER:
-        this.openDropdown()
+        this.openDropdown(event)
         break
 
       case Keys.TAB:
@@ -70,10 +70,11 @@ export class Trigger extends React.PureComponent<Props> {
     this.props.onKeyDown(event)
   }
 
-  openDropdown() {
+  openDropdown(event) {
     const { isOpen, openDropdown } = this.props
 
     if (!isOpen) {
+      event.preventDefault()
       return openDropdown()
     }
   }

--- a/src/components/Dropdown/V2/Dropdown.actions.ts
+++ b/src/components/Dropdown/V2/Dropdown.actions.ts
@@ -18,7 +18,10 @@ import {
   getValueFromItemDOMNode,
   findTriggerNode,
 } from './Dropdown.renderUtils'
+
 import { dispatch } from './Dropdown.store'
+
+import { focusWithoutScrolling } from '../../../utilities/focus'
 
 export const changeDirection = state => {
   return dispatch(state, {
@@ -207,8 +210,7 @@ export const closeAndRefocusTriggerNode = state => {
 
     // Refocus triggerNode
     const triggerNode = findTriggerNode(envNode)
-    // @ts-ignore
-    triggerNode && triggerNode.focus()
+    focusWithoutScrolling(triggerNode)
   }
 }
 

--- a/src/components/Message/__tests__/Message.integration.test.js
+++ b/src/components/Message/__tests__/Message.integration.test.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { cy } from '@helpscout/cyan'
+import Message from '../index'
+
+describe('Export', () => {
+  test('Correctly exports sub-components', () => {
+    cy.render(<Message />)
+    cy.render(<Message.Action />)
+    cy.render(<Message.Attachment />)
+    cy.render(<Message.Bubble />)
+    cy.render(<Message.Caption />)
+    cy.render(<Message.Chat />)
+    cy.render(<Message.Content />)
+    cy.render(<Message.Embed />)
+    cy.render(<Message.Media />)
+    cy.render(<Message.Provider />)
+    cy.render(<Message.Question />)
+  })
+})

--- a/src/components/Pop/Pop.tsx
+++ b/src/components/Pop/Pop.tsx
@@ -117,13 +117,29 @@ class Pop extends React.Component<Props, State> {
 
   handleOnBodyClick = event => {
     if (!this.shouldHandleHover() && !this.props.closeOnBodyClick) return
-    if (!event || event.target === this.node) return
+    const popperNode = document.getElementById(this.state.id) as HTMLElement
+
+    if (
+      !event ||
+      event.target === this.node ||
+      // @ts-ignore
+      this.node.contains(event.target) ||
+      (popperNode && popperNode.contains(event.target))
+    ) {
+      return
+    }
+
     this.close({ type: INTERACTION_TYPE.BODY_CLICK, props: { event } })
   }
 
   handleOnContentClick = (event: React.MouseEvent) => {
     this.props.onContentClick(event)
-    if (!this.props.closeOnContentClick) return
+
+    if (!this.props.closeOnContentClick) {
+      event.stopPropagation()
+      return
+    }
+
     this.close({ type: INTERACTION_TYPE.CONTENT_CLICK, props: { event } })
   }
 

--- a/src/components/Pop/Pop.tsx
+++ b/src/components/Pop/Pop.tsx
@@ -116,6 +116,7 @@ class Pop extends React.Component<Props, State> {
   }
 
   handleOnBodyClick = event => {
+    if (!this.state.isOpen) return
     if (!this.shouldHandleHover() && !this.props.closeOnBodyClick) return
     const popperNode = document.getElementById(this.state.id) as HTMLElement
 

--- a/src/components/Pop/__tests__/Pop.test.js
+++ b/src/components/Pop/__tests__/Pop.test.js
@@ -523,7 +523,7 @@ describe('Pop', () => {
     test('Closes on block click, if defined', async () => {
       const spy = jest.fn()
       const wrapper = mount(
-        <Pop closeOnBodyClick onClose={spy}>
+        <Pop closeOnBodyClick isOpen onClose={spy}>
           <Pop.Reference />
         </Pop>
       )
@@ -540,7 +540,7 @@ describe('Pop', () => {
     test('Does not close on block click, if defined', () => {
       const spy = jest.fn()
       const wrapper = mount(
-        <Pop closeOnBodyClick={false} onClose={spy}>
+        <Pop closeOnBodyClick={false} isOpen onClose={spy}>
           <Pop.Reference />
         </Pop>
       )

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -1,4 +1,4 @@
-import { getNodeScope, isNodeElement } from './node'
+import { getNodeScope, getWindowFromNode, isNodeElement } from './node'
 
 export const FOCUSABLE_SELECTOR =
   'a,frame,iframe,input:not([type=hidden]),select,textarea,button:not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])'
@@ -128,4 +128,15 @@ export const incrementFocusIndex = options => {
   }
 
   return newFocusIndex
+}
+
+export const focusWithoutScrolling = node => {
+  const _window = getWindowFromNode(node)
+  // Cache the current position
+  const { scrollX, scrollY } = _window
+
+  node.focus()
+
+  // Immediately scroll to the cached position
+  _window.scrollTo(scrollX, scrollY)
 }

--- a/src/utilities/node.ts
+++ b/src/utilities/node.ts
@@ -1,4 +1,5 @@
 import closest from './closest'
+import get from './get'
 import { isNodeEnv } from './other'
 
 type Node = HTMLElement | any
@@ -247,4 +248,9 @@ export const scrollIntoView = (node: Node) => {
   if (node['scrollIntoViewIfNeeded']) return node.scrollIntoViewIfNeeded()
   /* istanbul ignore else */
   if (node['scrollIntoView']) return node.scrollIntoView()
+}
+
+export const getWindowFromNode = (node: Node) => {
+  if (!isNodeElement(node)) return window
+  return get(node, 'ownerDocument.defaultView', window)
 }

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.43.2',
+  version: '2.43.3-0',
 }

--- a/stories/ActionSelect.stories.js
+++ b/stories/ActionSelect.stories.js
@@ -2,14 +2,10 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import ActionSelect from '../src/components/ActionSelect'
 import FormGroup from '../src/components/FormGroup'
+import Checkbox from '../src/components/Checkbox'
 import Input from '../src/components/Input'
-import {
-  withKnobs,
-  boolean,
-  number,
-  text,
-  select,
-} from '@storybook/addon-knobs'
+import { action } from '@storybook/addon-actions'
+import { boolean, number, text, select } from '@storybook/addon-knobs'
 
 const stories = storiesOf('ActionSelect', module)
 
@@ -24,6 +20,7 @@ stories.add('Default', () => {
         'search-docs': {
           text: 'Do a search',
           query: '',
+          isEnabled: false,
         },
       },
     }
@@ -76,6 +73,15 @@ stories.add('Default', () => {
                   value={this.state.values['search-docs'].query}
                 />
               </FormGroup>
+              <FormGroup>
+                <Checkbox
+                  label="Enabled"
+                  onChange={(event, value) => {
+                    this.onChange('search-docs', 'isEnabled')(value)
+                  }}
+                  checked={this.state.values['search-docs'].isEnabled}
+                />
+              </FormGroup>
             </div>
           )
         default:
@@ -99,6 +105,7 @@ stories.add('Default', () => {
           <ActionSelect
             label="Action Select"
             items={items}
+            onResize={action('onResize')}
             onSelect={this.onSelect}
             shouldRefocusOnClose={this.shouldRefocusOnClose}
           >


### PR DESCRIPTION
## ActionSelect: Fix resize and refocus interactions

This update fixes the resizing and refocus interactions when an item
is selected from the Dropdown.

A special focus util has been added to ensure the scroll position doesn't
jump on focus.

The resizing mechanism in ActionSelect has been optimized to only fire during
a new selection, rather than on children change.

### Checkbox improvements

Ensure Checkbox/Radio aren't display block, by default

### Pop/Popper/Tooltip

Fix click interactions with Trigger, `document.body`, and content.