### PR TITLE
Page.Action: Add guard for IntersectionObserver

### DIFF
--- a/src/components/Page/Page.Actions.tsx
+++ b/src/components/Page/Page.Actions.tsx
@@ -72,7 +72,6 @@ export class Actions extends React.PureComponent<
       zIndex,
       ...rest
     } = this.props
-    const { isStickyActive } = this.state
 
     const content = (
       <ActionsUI

--- a/src/components/Page/Page.StickyActions.tsx
+++ b/src/components/Page/Page.StickyActions.tsx
@@ -32,6 +32,9 @@ class StickyActions extends React.PureComponent<
   }
 
   observerStart() {
+    /* istanbul ignore next */
+    if (!IntersectionObserver) return
+
     const { offset } = this.props
     const observerOptions = {
       root: null,
@@ -46,6 +49,9 @@ class StickyActions extends React.PureComponent<
   }
 
   observerStop() {
+    /* istanbul ignore next */
+    if (!IntersectionObserver) return
+
     this.observer.unobserve(this.node)
     this.observer.disconnect()
   }


### PR DESCRIPTION
## Page.Action: Add guard for IntersectionObserver

This update adds a guard for `IntersectionObserver`, which is used for the
sticky feature in `Page.Action`.

The issue would only occur JSDOM. Target browsers (Edge+) supports this
feature