### PR TITLE
GreeterRow: Fix link clicks

### DIFF
--- a/src/components/Accordion/Accordion.Title.tsx
+++ b/src/components/Accordion/Accordion.Title.tsx
@@ -68,6 +68,7 @@ class Title extends React.Component<TitleProps> {
     isPage: false,
     isSeamless: false,
     setOpen: noop,
+    onClick: noop,
     onOpen: noop,
     onClose: noop,
   }
@@ -87,6 +88,9 @@ class Title extends React.Component<TitleProps> {
   }
 
   handleClick = (event: Event | KeyboardEvent) => {
+    this.props.onClick(event)
+    if (this.getIsLink()) return
+
     event && event.preventDefault()
     const { isOpen, setOpen, uuid } = this.props
     setOpen(uuid, !isOpen)

--- a/src/components/Accordion/Accordion.types.ts
+++ b/src/components/Accordion/Accordion.types.ts
@@ -54,6 +54,7 @@ export type TitleProps = {
   isOpen: boolean
   isPage: boolean
   isSeamless: boolean
+  onClick: (event: Event) => void
   onOpen?: (uuid: string) => void
   onClose?: (uuid: string) => void
   setOpen: (uuid: string, isOpen?: boolean) => void

--- a/src/components/Accordion/__tests__/Accordion.Title.test.js
+++ b/src/components/Accordion/__tests__/Accordion.Title.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { cy } from '@helpscout/cyan'
 import { mount } from 'enzyme'
 import Accordion from '../Accordion'
 import Section, { SectionWithUuid } from '../Accordion.Section'
@@ -188,5 +189,25 @@ describe('isOpen', () => {
     const el = wrapper.find(`a.${classNames.baseComponentClassName}`)
 
     expect(el.hasClass('is-open')).toBeFalsy()
+  })
+})
+
+describe('Events', () => {
+  test('onClick callback works', () => {
+    const spy = jest.fn()
+    const wrapper = cy.render(<Title onClick={spy} />)
+
+    wrapper.click()
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('onClick callback works for links', () => {
+    const spy = jest.fn()
+    const wrapper = cy.render(<Title onClick={spy} to="/" />)
+
+    wrapper.click()
+
+    expect(spy).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## GreeterRow: Fix link clicks
This update fixes the GreeterRow to ensure that clicks (and keyboard Enter
press) works as expected (which is that it performs like a regular link).