### PR TITLE
ActionSelect: Scroll into view if needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.43.7",
+  "version": "2.43.8-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.43.7",
+  "version": "2.43.8-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -87,6 +87,10 @@ export class ActionSelect extends React.PureComponent<
 
     const { y } = this.contentNode.getBoundingClientRect() as DOMRect
     const position = y
+    const shouldScrollIntoView = window.scrollY < y
+
+    /* istanbul ignore next */
+    if (!shouldScrollIntoView) return
 
     smoothScrollTo({
       node: window,

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -92,6 +92,8 @@ export class ActionSelect extends React.PureComponent<
     /* istanbul ignore next */
     if (!shouldScrollIntoView) return
 
+    // Ignoring since JSDOM does not have window scroll events.
+    /* istanbul ignore next */
     smoothScrollTo({
       node: window,
       position,

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.43.7',
+  version: '2.43.8-0',
 }


### PR DESCRIPTION
## ActionSelect: Scroll into view if needed

This update adjusts the scrollIntoView mechanism of ActionSelect to
check against the current position of `window.y` to determine if scrolling
is required.
