### PR TITLE
Pagination - Hide next & last button on last page

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -196,27 +196,30 @@ export class Pagination extends React.PureComponent<Props> {
             <Icon name="arrow-left-single-large" size="24" center />
           </ButtonIconUI>,
         ]}
-
-        <ButtonIconUI
-          version={2}
-          disabled={isLastPage || isLoading}
-          onClick={this.handleNextClick}
-          className="c-Pagination__nextButton"
-          title="Next page (k)"
-          data-cy="Pagination-nextButton"
-        >
-          <Icon name="arrow-right-single-large" size="24" center />
-        </ButtonIconUI>
-        <ButtonIconUI
-          version={2}
-          disabled={isLastPage || isLoading}
-          onClick={this.handleEndClick}
-          className="c-Pagination__lastButton"
-          title="Last page"
-          data-cy="Pagination-lastButton"
-        >
-          <Icon name="arrow-right-double-large" size="24" center />
-        </ButtonIconUI>
+        {!isLastPage && [
+          <ButtonIconUI
+            key="nextButton"
+            version={2}
+            disabled={isLoading}
+            onClick={this.handleNextClick}
+            className="c-Pagination__nextButton"
+            title="Next page (k)"
+            data-cy="Pagination-nextButton"
+          >
+            <Icon name="arrow-right-single-large" size="24" center />
+          </ButtonIconUI>,
+          <ButtonIconUI
+            key="lastButton"
+            version={2}
+            disabled={isLoading}
+            onClick={this.handleEndClick}
+            className="c-Pagination__lastButton"
+            title="Last page"
+            data-cy="Pagination-lastButton"
+          >
+            <Icon name="arrow-right-double-large" size="24" center />
+          </ButtonIconUI>,
+        ]}
       </NavigationUI>
     )
   }

--- a/src/components/Pagination/__tests__/Pagination.test.js
+++ b/src/components/Pagination/__tests__/Pagination.test.js
@@ -140,7 +140,7 @@ describe('Navigation', () => {
     expect(last.length).toBeTruthy()
   })
 
-  test('Disables next & last button on last page', () => {
+  test('Hides next & last button on last page', () => {
     const wrapper = mount(
       <Pagination
         showNavigation={true}
@@ -150,11 +150,11 @@ describe('Navigation', () => {
       />
     )
 
-    const next = wrapper.find('Button.c-Pagination__nextButton').first()
-    const last = wrapper.find('Button.c-Pagination__lastButton').first()
+    const next = wrapper.find('Button.c-Pagination__nextButton')
+    const last = wrapper.find('Button.c-Pagination__lastButton')
 
-    expect(next.props('disabled')).toBeTruthy()
-    expect(last.props('disabled')).toBeTruthy()
+    expect(next.length).not.toBeTruthy()
+    expect(last.length).not.toBeTruthy()
   })
 
   test('Disables all buttons when loading', () => {
@@ -164,7 +164,7 @@ describe('Navigation', () => {
         showNavigation={true}
         totalItems={15}
         rangePerPage={5}
-        activePage={3}
+        activePage={2}
       />
     )
 


### PR DESCRIPTION
This update hides the next and last button when the pagination is on the last page. This change of behavior was requested for hs-app

![Screen Recording 2019-05-29 at 04 02 PM](https://user-images.githubusercontent.com/203992/58591157-a3873180-8233-11e9-8443-a1c85dc4e8a8.gif)
