### PR TITLE
Avatar fallback image

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -118,7 +118,6 @@ export class Avatar extends React.PureComponent<Props, State> {
         [
           IMAGE_STATES.loading,
           IMAGE_STATES.loaded,
-          ,
           IMAGE_STATES.fallbackLoading,
           IMAGE_STATES.fallbackLoaded,
         ],

--- a/src/components/Avatar/Avatar.utils.ts
+++ b/src/components/Avatar/Avatar.utils.ts
@@ -1,3 +1,5 @@
+import { includes } from '../../utilities/arrays'
+
 export const COMPONENT_KEY = 'Avatar'
 
 export const IMAGE_STATES = {
@@ -6,4 +8,51 @@ export const IMAGE_STATES = {
   failed: 'failed',
   fallbackLoading: 'fallbackLoading',
   fallbackLoaded: 'fallbackLoaded',
+}
+
+export const isImageLoaded = (props, state): boolean => {
+  const { image } = props
+  const { imageLoaded } = state
+
+  return shouldUseFallbackImage(props, state)
+    ? isFallbackImageLoaded(props, state)
+    : !!(image && imageLoaded === IMAGE_STATES.loaded)
+}
+
+export const isFallbackImageLoaded = (props, state): boolean => {
+  const { fallbackImage } = props
+  const { imageLoaded } = state
+
+  return !!(fallbackImage && imageLoaded === IMAGE_STATES.fallbackLoaded)
+}
+
+export const hasImage = (props, state): boolean => {
+  const { image } = props
+  const { imageLoaded } = state
+
+  return !!(
+    image &&
+    includes(
+      [
+        IMAGE_STATES.loading,
+        IMAGE_STATES.loaded,
+        IMAGE_STATES.fallbackLoading,
+        IMAGE_STATES.fallbackLoaded,
+      ],
+      imageLoaded
+    )
+  )
+}
+
+export const shouldUseFallbackImage = (props, state): boolean => {
+  const { imageLoaded } = state
+  return (
+    isFallbackImageLoaded(props, state) ||
+    imageLoaded === IMAGE_STATES.fallbackLoading
+  )
+}
+
+export const getImageUrl = (props, state): string => {
+  const { fallbackImage, image } = props
+  return shouldUseFallbackImage(props, state) ? fallbackImage : image
 }

--- a/src/components/Avatar/Avatar.utils.ts
+++ b/src/components/Avatar/Avatar.utils.ts
@@ -4,4 +4,6 @@ export const IMAGE_STATES = {
   loading: 'loading',
   loaded: 'loaded',
   failed: 'failed',
+  fallbackLoading: 'fallbackLoading',
+  fallbackLoaded: 'fallbackLoaded',
 }

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -175,6 +175,19 @@ describe('ClassNames', () => {
     expect(classNames).toContain('arctic')
     expect(classNames).toContain('puffin')
   })
+
+  test('Add light classname to component and title', () => {
+    const wrapper = mount(<Avatar name="Buddy" light={true} />)
+    const root = wrapper.find(`div${ui.root}`)
+
+    expect(root.props().className).toContain('is-light')
+    expect(
+      wrapper
+        .find(ui.initials)
+        .first()
+        .prop('className')
+    ).toContain('is-light')
+  })
 })
 
 describe('Border color', () => {
@@ -230,14 +243,6 @@ describe('Border color', () => {
     const o = wrapper.find(StatusDot)
 
     expect(o.prop('outerBorderColor')).toBe('red')
-  })
-
-  test('Add light classname to component and title', () => {
-    const wrapper = mount(<Avatar name="Buddy" light={true} />)
-    const classNames = wrapper.prop('className')
-
-    expect(classNames).toContain('is-light')
-    expect(wrapper.find(ui.initials).prop('className')).toContain('is-light')
   })
 })
 

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -123,6 +123,26 @@ describe('Image', () => {
     expect(image.exists()).toBeFalsy()
   })
 
+  test('Replaces image with fallback on error', () => {
+    const fallbackSrc = 'buddy2.jpg'
+    const wrapper = mount(
+      <Avatar
+        name="Buddy the Elf"
+        image="buddy.jpg"
+        fallbackImage={fallbackSrc}
+      />
+    )
+    wrapper
+      .find('img')
+      .first()
+      .simulate('error')
+      .simulate('load')
+
+    const image = wrapper.update().find(`div${ui.image}`)
+
+    expect(image.prop('style').backgroundImage).toContain(fallbackSrc)
+  })
+
   test('Background style is unset on error', () => {
     const wrapper = mount(<Avatar name="Buddy the Elf" image="buddy.jpg" />)
     wrapper
@@ -210,6 +230,14 @@ describe('Border color', () => {
     const o = wrapper.find(StatusDot)
 
     expect(o.prop('outerBorderColor')).toBe('red')
+  })
+
+  test('Add light classname to component and title', () => {
+    const wrapper = mount(<Avatar name="Buddy" light={true} />)
+    const classNames = wrapper.prop('className')
+
+    expect(classNames).toContain('is-light')
+    expect(wrapper.find(ui.initials).prop('className')).toContain('is-light')
   })
 })
 

--- a/stories/Avatar/Avatar.stories.js
+++ b/stories/Avatar/Avatar.stories.js
@@ -11,8 +11,24 @@ stories.add('default', () => (
   <Avatar name={fixture.name} image={fixture.image} />
 ))
 
-stories.add('fallback', () => (
+stories.add('failed', () => (
   <Avatar name={fixture.name} image="https://notfound" />
+))
+
+stories.add('fallback', () => (
+  <Avatar
+    name={fixture.name}
+    image="https://notfound"
+    fallbackImage={fixture.image}
+  />
+))
+
+stories.add('fallback failed', () => (
+  <Avatar
+    name={fixture.name}
+    image="https://notfound"
+    fallbackImage="https://notfound2"
+  />
 ))
 
 stories.add('themed', () => (


### PR DESCRIPTION
This update add the possibility of having a fallback image in case the original image failed to load

If the fallback image failed to load as well, we default to the avatar background color.

```javascript
<Avatar
    name={fixture.name}
    image="https://notfound"
    fallbackImage={imageUrl}
  />
```

The component was also reorganized to move some utility function out of the component, to make it cleaner and "simpler"

```javascript
isImageLoaded(props, state): boolean
hasImage(props, state): boolean
isFallbackImageLoaded(props, state): boolean
getImageUrl(props, state): string
```