### PR TITLE
Add isWithRemove to condition field to hide close icon

### DIFF
--- a/src/components/ConditionField/ConditionField.tsx
+++ b/src/components/ConditionField/ConditionField.tsx
@@ -24,6 +24,7 @@ export class ConditionField extends React.PureComponent<ConditionFieldProps> {
     closeIcon: 'collapse',
     innerRef: noop,
     isWithOr: false,
+    isWithRemove: true,
     onRemove: noop,
     removeTitle: 'Remove',
     tooltipDelay: 800,
@@ -52,6 +53,7 @@ export class ConditionField extends React.PureComponent<ConditionFieldProps> {
       children,
       closeIcon,
       innerRef,
+      isWithRemove,
       onRemove,
       removeTitle,
       tooltipDelay,
@@ -74,11 +76,13 @@ export class ConditionField extends React.PureComponent<ConditionFieldProps> {
               animationDelay={tooltipDelay}
               animationDuration={tooltipDuration}
             >
-              <IconButton
-                data-cy="ConditionFieldRemoveButton"
-                icon={closeIcon}
-                onClick={onRemove}
-              />
+              {isWithRemove ? (
+                <IconButton
+                  data-cy="ConditionFieldRemoveButton"
+                  icon={closeIcon}
+                  onClick={onRemove}
+                />
+              ) : null}
             </Tooltip>
           </FieldCloseWrapperUI>
         </FieldUI>

--- a/src/components/ConditionField/ConditionField.types.ts
+++ b/src/components/ConditionField/ConditionField.types.ts
@@ -7,6 +7,7 @@ export interface ConditionBaseProps {
 export interface ConditionFieldProps extends ConditionBaseProps {
   closeIcon: string
   isWithOr: boolean
+  isWithRemove: boolean
   onRemove: () => void
   removeTitle: string
   tooltipDelay: number

--- a/src/components/ConditionField/README.md
+++ b/src/components/ConditionField/README.md
@@ -28,6 +28,7 @@ A ConditionField is a single item that renders within a [Condition](../Condition
 | className       | `string`   |            | The className of the component.                                                       |
 | closeIcon       | `string`   | `collapse` | The [Icon](../Icon) to render.                                                        |
 | innerRef        | `Function` |            | Retrieve the inner DOM node.                                                          |
+| isWithRemove    | `boolean`  | `true`     | Whether to show the remove button or not.                                             |
 | onRemove        | `Function` |            | Callback when the remove [IconButton](../IconButton) is clicked.                      |
 | removeTitle     | `string`   |            | Title to show in the [Tooltip](../Tooltip) on the remove [IconButton](../IconButton). |
 | tooltipDelay    | `string`   |            | Delay before the [Tooltip](../Tooltip) renders, on hover.                             |

--- a/src/components/ConditionField/__tests__/ConditionField.test.tsx
+++ b/src/components/ConditionField/__tests__/ConditionField.test.tsx
@@ -38,6 +38,13 @@ describe('onRemove', () => {
     expect(el.getTagName()).toBe('button')
   })
 
+  test('Does not render a remove button', () => {
+    cy.render(<ConditionField isWithRemove={false} />)
+    const el = cy.getByCy('ConditionFieldRemoveButton')
+
+    expect(el.exists()).toBeFalsy()
+  })
+
   test('Fires onRemove callback when remove button is clicked', () => {
     const spy = jest.fn()
     cy.render(<ConditionField onRemove={spy} />)

--- a/stories/ConditionField.stories.js
+++ b/stories/ConditionField.stories.js
@@ -74,3 +74,54 @@ stories.add('Default', () => {
     </Condition>
   )
 })
+
+stories.add('No remove', () => {
+  const props = {
+    error: boolean('error', false),
+    isWithRemove: boolean('isWithRemove', false),
+    removeTitle: text('removeTitle', 'Remove'),
+    tooltipDelay: number('tooltipDelay', 800),
+    tooltipDuration: number('tooltipDuration', 60),
+  }
+
+  const { error } = props
+
+  return (
+    <Condition options={options} value="time-on-page">
+      <ConditionField {...props}>
+        <ConditionField.Item>
+          <ConditionField.Static>Show after</ConditionField.Static>
+        </ConditionField.Item>
+        <ConditionField.Block>
+          <Flexy gap="xs">
+            <Flexy.Item>
+              <Input
+                inputType="number"
+                autoComplete="off"
+                width={error ? 75 : 55}
+                value={5}
+                state={error && 'error'}
+              />
+            </Flexy.Item>
+            <Flexy.Block>
+              <Select
+                options={[
+                  {
+                    label: 'Seconds',
+                    value: 'seconds',
+                  },
+                  {
+                    label: 'Minutes',
+                    value: 'minutes',
+                  },
+                ]}
+                width={160}
+                value="seconds"
+              />
+            </Flexy.Block>
+          </Flexy>
+        </ConditionField.Block>
+      </ConditionField>
+    </Condition>
+  )
+})


### PR DESCRIPTION
This PR updates ConditionField with a 'isWithRemove' prop, which allows enabling / disabling of the remove button.

Here's an example of why this functionality is needed:
http://c.hlp.sc/47c2d62e537f

