### PR TITLE
ConditionField: Pass props through to Flexy

### DIFF
--- a/src/components/ConditionField/ConditionField.tsx
+++ b/src/components/ConditionField/ConditionField.tsx
@@ -64,7 +64,7 @@ export class ConditionField extends React.PureComponent<ConditionFieldProps> {
     return (
       <FieldWrapperUI data-cy="ConditionFieldWrapper">
         {this.renderOperator()}
-        <FieldUI {...getValidProps(rest)} className={this.getClassName()}>
+        <FieldUI {...rest} className={this.getClassName()}>
           <FieldContentWrapperUI data-cy="ConditionFieldContentWrapper">
             <Flexy align="top" gap="md">
               {children}


### PR DESCRIPTION
## ConditionField: Pass props through to Flexy

This update adjusts the `ConditionField` component to allow for props to be
passed through to `Flexy`, allowing for finer grain adjustments for configs
like `align`.