### PR TITLE
Refactor EmojiPicker active/hover state styling

### DIFF
--- a/src/components/EmojiPicker/styles/EmojiPicker.css.ts
+++ b/src/components/EmojiPicker/styles/EmojiPicker.css.ts
@@ -3,14 +3,6 @@ import Icon from '../../Icon'
 import { getColor, rgba } from '../../../styles/utilities/color'
 
 export const config = {
-  colors: {
-    grey: 'grey.300',
-    purple: 'purple.300',
-    red: 'red.300',
-    yellow: 'yellow.300',
-  },
-  hoverBackgroundOpacity: 0.5,
-  hoverBackgroundActiveOpacity: 0.85,
   sizes: {
     default: '24px',
     sm: '16px',
@@ -20,6 +12,7 @@ export const config = {
 
 export const MenuUI = styled('div')`
   display: flex;
+  overflow: hidden;
   padding-left: 5px;
   padding-right: 5px;
 
@@ -37,29 +30,12 @@ export const ItemWrapperUI = styled('div')`
   display: flex;
   justify-content: center;
   margin: 3px;
-  transition: background 200ms linear;
+  transform: scale(1);
+  transition: transform 0.15s cubic-bezier(0.2, 0, 0.13, 2);
 
   .c-DropdownV2Item.is-focused &,
   &:hover {
-    ${({ hoverBackgroundColor }) =>
-      hoverBackgroundColor &&
-      `
-        background-color: ${rgba(
-          getColor(`${config.colors[hoverBackgroundColor]}`),
-          config.hoverBackgroundOpacity
-        )};
-      `};
-  }
-
-  &:active {
-    ${({ hoverBackgroundColor }) =>
-      hoverBackgroundColor &&
-      `
-        background-color: ${rgba(
-          getColor(`${config.colors[hoverBackgroundColor]}`),
-          config.hoverBackgroundActiveOpacity
-        )};
-      `};
+    transform: scale(1.075);
   }
 
   ${({ size }) =>


### PR DESCRIPTION
This is a proposal for an alternative way of handling styles for Emoji Picker active/hover states. Previously, it was difficult to get the correct spacing for the background color for each emoji. This was inspired by how Github handles it's emoji picker for reactions. 

## Before
![Screen Recording 2019-07-05 at 06 10 PM](https://user-images.githubusercontent.com/7111256/60918363-006d0300-a248-11e9-9f5c-6fba2513f114.gif)

## After
![Screen Recording 2019-07-10 at 12 31 PM](https://user-images.githubusercontent.com/7111256/60999219-74bea980-a30f-11e9-8026-642fcfdbbfe7.gif)
