### PR TITLE
Remove EmojiPicker hover state transition

### DIFF
--- a/src/components/EmojiPicker/styles/EmojiPicker.css.ts
+++ b/src/components/EmojiPicker/styles/EmojiPicker.css.ts
@@ -31,7 +31,6 @@ export const ItemWrapperUI = styled('div')`
   justify-content: center;
   margin: 3px;
   transform: scale(1);
-  transition: transform 0.15s cubic-bezier(0.2, 0, 0.13, 2);
 
   .c-DropdownV2Item.is-focused &,
   &:hover {


### PR DESCRIPTION
This removes the transition animation from the EmojiPicker when items are hovered or active. 

## Before: 
![Screen Recording 2019-07-10 at 02 37 PM](https://user-images.githubusercontent.com/7111256/61009574-ed316480-a327-11e9-8590-c64cfbd335c4.gif)

## After: 
![Screen Recording 2019-07-10 at 03 28 PM](https://user-images.githubusercontent.com/7111256/61009583-f0c4eb80-a327-11e9-82f3-8597fabf3f00.gif)
