### PR TITLE
Fixed error with Tooltips in Embed

### DIFF
--- a/src/components/Pop/Pop.tsx
+++ b/src/components/Pop/Pop.tsx
@@ -249,22 +249,24 @@ class Pop extends React.Component<Props, State> {
 
     return (
       <Manager>
-        <EventListener
-          event="click"
-          handler={this.handleOnBodyClick}
-          scope={document.body}
-        />
-        <PopUI
-          className={componentClassName}
-          data-cy={this.props['data-cy']}
-          innerRef={this.setNodeRef}
-          onMouseMove={this.handleMouseMove}
-          onMouseLeave={this.handleMouseLeave}
-          onClick={this.handleClick}
-        >
-          {referenceMarkup}
-          {popperMarkup}
-        </PopUI>
+        <div>
+          <EventListener
+            event="click"
+            handler={this.handleOnBodyClick}
+            scope={document.body}
+          />
+          <PopUI
+            className={componentClassName}
+            data-cy={this.props['data-cy']}
+            innerRef={this.setNodeRef}
+            onMouseMove={this.handleMouseMove}
+            onMouseLeave={this.handleMouseLeave}
+            onClick={this.handleClick}
+          >
+            {referenceMarkup}
+            {popperMarkup}
+          </PopUI>
+        </div>
       </Manager>
     )
   }

--- a/src/components/Popover/__tests__/Popover.test.tsx
+++ b/src/components/Popover/__tests__/Popover.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { cy } from '@helpscout/cyan'
 import { mount, render } from 'enzyme'
 import { Popover } from '../Popover'
 
@@ -13,16 +14,16 @@ function mountContent(Component) {
 
 describe('className', () => {
   test('Has default className', () => {
-    const wrapper = render(<Popover />)
+    cy.render(<Popover />)
 
-    expect(wrapper.hasClass('c-Popover')).toBeTruthy()
+    expect(cy.get('.c-Popover').exists()).toBeTruthy()
   })
 
   test('Can render custom className', () => {
     const customClassName = 'blue'
-    const wrapper = render(<Popover className={customClassName} />)
+    cy.render(<Popover className={customClassName} />)
 
-    expect(wrapper.hasClass(customClassName)).toBeTruthy()
+    expect(cy.get(`.${customClassName}`).exists()).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
## Problem

When attempting to upgrade hsds-react in Beacon embed, I ran into an issue that was preventing the app from rendering.

I found out that the issue originated in version 2.43.1, which added an `EventListener` to the `Pop` component: https://github.com/helpscout/hsds-react/releases/tag/v2.43.1

## Solution

I'm not sure if this issue doesn't happen in hs-app, and if that's the case it might be because embed is still in React 15, but the issue seemed to be that "Providers" can only have a single child component, and with this update we were now returning two: `EventListener` and `PopUI`.

To fix this, I've wrapped both components in a `div`, which is the only React 15-compatible solution I know of, but if you know of a better one, please let me know!