### PR TITLE
Remove wrapper component to support extension

### DIFF
--- a/src/components/Condition/Condition.Operator.tsx
+++ b/src/components/Condition/Condition.Operator.tsx
@@ -4,7 +4,7 @@ import Text from '../Text'
 import { classNames } from '../../utilities/classNames'
 import { COMPONENT_KEY } from './Condition.utils'
 import { ConditionOperatorProps } from './Condition.types'
-import { OperatorWrapperUI, OperatorUI } from './styles/Condition.css'
+import { OperatorUI } from './styles/Condition.css'
 
 export const Operator = (props: ConditionOperatorProps) => {
   const { className, isBorderless, type, ...rest } = props
@@ -18,13 +18,11 @@ export const Operator = (props: ConditionOperatorProps) => {
   )
 
   return (
-    <OperatorWrapperUI className="c-ConditionOperatorWrapper">
-      <OperatorUI {...rest} className={componentClassName}>
-        <Text block lineHeightReset size="11">
-          {label}
-        </Text>
-      </OperatorUI>
-    </OperatorWrapperUI>
+    <OperatorUI {...rest} className={componentClassName}>
+      <Text block lineHeightReset size="11">
+        {label}
+      </Text>
+    </OperatorUI>
   )
 }
 

--- a/src/components/Condition/styles/Condition.css.ts
+++ b/src/components/Condition/styles/Condition.css.ts
@@ -33,11 +33,6 @@ export const OptionsWrapperUI = styled(Flexy.Item)`
 
 export const ContentWrapperUI = styled(Flexy.Block)``
 
-export const OperatorWrapperUI = styled('div')`
-  ${baseStyles};
-  margin: 5px 0;
-`
-
 export const OperatorUI = styled('div')`
   ${baseStyles};
   background: ${getColor('grey.600')};
@@ -45,6 +40,7 @@ export const OperatorUI = styled('div')`
   box-shadow: 0 0 0 ${config.operatorBorderWidth} white;
   color: white;
   display: inline-block;
+  margin: 5px 0;
   padding: 3px 5px;
   text-transform: uppercase;
   line-height: 1;


### PR DESCRIPTION
This change makes it easier to extend the `Condition.Operator` component. 