### PR TITLE
Editable Field Follow Up Fixes

### DIFF
--- a/src/components/EditableField/EditableField.Input.tsx
+++ b/src/components/EditableField/EditableField.Input.tsx
@@ -25,8 +25,9 @@ import propConnect from '../PropProvider/propConnect'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import {
   ACTION_ICONS,
-  COMPONENT_KEY,
+  EF_I_COMPONENT_KEY,
   isEllipsisActive,
+  getComponentClassNames,
 } from './EditableField.utils'
 import { classNames } from '../../utilities/classNames'
 import { key } from '../../constants/Keys'
@@ -38,11 +39,13 @@ import {
   EditableFieldInputState,
 } from './EditableField.types'
 
+const CLASSNAMES: any = getComponentClassNames(EF_I_COMPONENT_KEY)
+
 export class EditableFieldInput extends React.Component<
   EditableFieldInputProps,
   EditableFieldInputState
 > {
-  static className = 'c-EditableFieldInput'
+  static className = CLASSNAMES.component
   static defaultProps = {
     isActive: false,
     disabled: false,
@@ -169,11 +172,12 @@ export class EditableFieldInput extends React.Component<
     const staticValueNode = this.staticValueRef
 
     const contentNode =
-      staticValueNode && staticValueNode.querySelector('.c-Truncate__content')
+      staticValueNode && staticValueNode.querySelector(`.${CLASSNAMES.content}`)
     const emailNode =
-      staticValueNode && staticValueNode.querySelector('.TruncateFirstChunk')
+      staticValueNode &&
+      staticValueNode.querySelector(`.${CLASSNAMES.firstChunk}`)
 
-    /* istanbul ignore if */
+    /* istanbul ignore next */
     if (
       (contentNode && isEllipsisActive(contentNode)) ||
       (emailNode && isEllipsisActive(emailNode))
@@ -192,10 +196,10 @@ export class EditableFieldInput extends React.Component<
         0
     const staticContentNode = this.staticContentRef
     const staticOptionNode = staticContentNode.querySelector(
-      '.EditableField__staticOption'
+      `.${CLASSNAMES.staticOption}`
     )
     const staticValueNode = staticContentNode.querySelector(
-      '.EditableField__staticValue'
+      `.${CLASSNAMES.staticValue}`
     )
     const staticOptionWidth = staticOptionNode
       ? staticOptionNode.getBoundingClientRect().width + 10
@@ -214,7 +218,7 @@ export class EditableFieldInput extends React.Component<
     temporaryValueNode.textContent = staticValueNode.textContent
 
     // To get an accurate width, apply the font styles of the field
-    temporaryValueNode.classList.add('is-temporary-value')
+    temporaryValueNode.classList.add(CLASSNAMES.isTemporaryValue)
     editableFieldInputNode.appendChild(temporaryValueNode)
     contentWidth = Math.ceil(
       temporaryValueNode.getBoundingClientRect().width + staticOptionWidth
@@ -245,7 +249,7 @@ export class EditableFieldInput extends React.Component<
         : /* istanbul ignore next */
           0
       const placeholderNode = this.staticContentRef.querySelector(
-        '.is-placeholder'
+        `.${CLASSNAMES.isPlaceholder}`
       )
       const staticContentWidth = placeholderNode
         ? placeholderNode.getBoundingClientRect().width
@@ -272,9 +276,9 @@ export class EditableFieldInput extends React.Component<
     return classNames(
       EditableFieldInput.className,
       className,
-      isActive && 'is-active',
-      valueOptions && 'has-options',
-      !Boolean(fieldValue.value) && 'is-empty'
+      isActive && CLASSNAMES.isActive,
+      valueOptions && CLASSNAMES.hasOptions,
+      !Boolean(fieldValue.value) && CLASSNAMES.isEmpty
     )
   }
 
@@ -324,7 +328,7 @@ export class EditableFieldInput extends React.Component<
     const isEnter = event.key === key.ENTER
     const isEscape = event.key === key.ESCAPE
     const isDropdownTrigger = event.target.classList.contains(
-      'c-DropdownV2Trigger'
+      CLASSNAMES.dropDownTrigger
     )
     /* istanbul ignore else */
     if ((isEnter && !isDropdownTrigger) || isEscape) {
@@ -398,11 +402,11 @@ export class EditableFieldInput extends React.Component<
 
     return (
       <OptionsWrapperUI
-        className="EditableField__optionsWrapper"
+        className={CLASSNAMES.optionsWrapper}
         onKeyDown={this.handleKeyDown}
       >
         <Dropdown
-          className="EditableField__Dropdown"
+          className={CLASSNAMES.dropdown}
           items={valueOptions}
           disabled={disabled}
           shouldRefocusOnClose={() => false}
@@ -413,17 +417,17 @@ export class EditableFieldInput extends React.Component<
           onSelect={this.handleDropdownSelect}
           triggerRef={this.setOptionsDropdownNode}
           renderTrigger={
-            <TriggerUI className="EditableField__optionsTrigger">
+            <TriggerUI className={CLASSNAMES.optionsTrigger}>
               <OptionsDropdownUI
-                className="EditableField__optionsDropdown"
+                className={CLASSNAMES.optionsDropdown}
                 title={fieldValue.option}
               >
-                <Truncate className="EditableField__selectedOption">
+                <Truncate className={CLASSNAMES.selectedOption}>
                   {fieldValue.option}
                 </Truncate>
                 <Icon name={ACTION_ICONS.valueOption} />
               </OptionsDropdownUI>
-              <FocusIndicatorUI className="EditableField__focusIndicator" />
+              <FocusIndicatorUI className={CLASSNAMES.focusIndicator} />
             </TriggerUI>
           }
         />
@@ -436,7 +440,7 @@ export class EditableFieldInput extends React.Component<
 
     return (
       <StaticOptionUI
-        className="EditableField__staticOption"
+        className={CLASSNAMES.staticOption}
         innerRef={this.setStaticOptionNode}
       >
         <Truncate>{fieldValue.option}</Truncate>
@@ -449,7 +453,7 @@ export class EditableFieldInput extends React.Component<
 
     return (
       <FieldActionsUI
-        className="EditableField__actions"
+        className={CLASSNAMES.actions}
         innerRef={this.setActionsNode}
         // ts complains about actions possibly being undefined
         // but renderActions is never called if actions is undefined (same below in the mapping)
@@ -460,7 +464,7 @@ export class EditableFieldInput extends React.Component<
         {(actions as any).map(action => {
           return (
             <FieldButtonUI
-              className={`FieldButton action-${action.name}`}
+              className={`${CLASSNAMES.fieldButton} action-${action.name}`}
               key={action.name}
               tabIndex="-1"
               type="button"
@@ -501,15 +505,15 @@ export class EditableFieldInput extends React.Component<
         innerRef={this.setEditableFieldInputNode}
       >
         <InteractiveContentUI
-          className="EditableField__interactiveContent"
+          className={CLASSNAMES.interactiveContent}
           innerRef={this.setInteractiveContentNode}
         >
           {valueOptions ? this.renderInteractiveOptions() : null}
 
-          <InputWrapperUI className="EditableField__inputWrapper">
+          <InputWrapperUI className={CLASSNAMES.inputWrapper}>
             <InputUI
               {...getValidProps(rest)}
-              className="EditableField__input"
+              className={CLASSNAMES.input}
               id={name}
               innerRef={this.setInputNode}
               name={name}
@@ -522,12 +526,12 @@ export class EditableFieldInput extends React.Component<
               onFocus={this.handleInputFocus}
               onKeyDown={this.handleKeyDown}
             />
-            <FocusIndicatorUI className="EditableField__focusIndicator" />
+            <FocusIndicatorUI className={CLASSNAMES.focusIndicator} />
           </InputWrapperUI>
         </InteractiveContentUI>
 
         <StaticContentUI
-          className="EditableField__staticContent"
+          className={CLASSNAMES.staticContent}
           renderAsBlock={renderAsBlock}
           staticContentWidth={staticContentWidth}
           innerRef={this.setStaticContentNode}
@@ -536,9 +540,9 @@ export class EditableFieldInput extends React.Component<
 
           <StaticValueUI
             className={classNames(
-              'EditableField__staticValue',
-              !fieldValue.value && 'with-placeholder',
-              emphasize && 'is-emphasized'
+              CLASSNAMES.staticValue,
+              !fieldValue.value && CLASSNAMES.withPlaceholder,
+              emphasize && CLASSNAMES.isEmphasized
             )}
             innerRef={this.setStaticValueNode}
             onBlur={this.handleStaticValueBlur}
@@ -550,7 +554,7 @@ export class EditableFieldInput extends React.Component<
                 splitter={type === 'email' ? '@' : undefined}
               />
             ) : (
-              <span className="is-placeholder">{placeholder}</span>
+              <span className={CLASSNAMES.isPlaceholder}>{placeholder}</span>
             )}
           </StaticValueUI>
         </StaticContentUI>
@@ -563,7 +567,7 @@ export class EditableFieldInput extends React.Component<
   }
 }
 
-const PropConnectedComponent = propConnect(`${COMPONENT_KEY}Input`)(
+const PropConnectedComponent = propConnect(EF_I_COMPONENT_KEY)(
   EditableFieldInput
 )
 

--- a/src/components/EditableField/EditableField.Input.tsx
+++ b/src/components/EditableField/EditableField.Input.tsx
@@ -468,7 +468,7 @@ export class EditableFieldInput extends React.Component<
                 this.handleActionClick({ action, event })
               }}
             >
-              <Icon name={action.icon || ACTION_ICONS[action.name]} size="16" />
+              <Icon name={action.icon || ACTION_ICONS[action.name]} size="24" />
             </FieldButtonUI>
           )
         })}

--- a/src/components/EditableField/EditableField.Truncate.tsx
+++ b/src/components/EditableField/EditableField.Truncate.tsx
@@ -2,22 +2,28 @@ import * as React from 'react'
 import { TruncateUI } from './styles/EditableField.Truncate.css'
 
 import Truncate from '../Truncate'
+import {
+  EF_TRUNC_COMPONENT_KEY,
+  getComponentClassNames,
+} from './EditableField.utils'
 import { TruncateProps } from './EditableField.types'
+
+export const CLASSNAMES: any = getComponentClassNames(EF_TRUNC_COMPONENT_KEY)
 
 const Truncated = ({ string, splitter }: TruncateProps) => {
   if (splitter) {
     const [first, second] = string.split(splitter)
 
     return (
-      <TruncateUI className="TruncatedWithSplitter">
-        <span className="TruncateFirstChunk">{first}</span>
-        <span className="TruncateSplitterChunk">{splitter}</span>
-        <span className="TruncateSecondChunk">{second}</span>
+      <TruncateUI className={`${CLASSNAMES.withSplitter}`}>
+        <span className={`${CLASSNAMES.firstChunk}`}>{first}</span>
+        <span className={`${CLASSNAMES.splitterChunk}`}>{splitter}</span>
+        <span className={`${CLASSNAMES.secondChunk}`}>{second}</span>
       </TruncateUI>
     )
   }
 
-  return <Truncate className="Truncated">{string}</Truncate>
+  return <Truncate className={`${CLASSNAMES.truncated}`}>{string}</Truncate>
 }
 
 export default Truncated

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -13,9 +13,10 @@ import propConnect from '../PropProvider/propConnect'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import { classNames } from '../../utilities/classNames'
 import {
-  COMPONENT_KEY,
+  EF_COMPONENT_KEY,
   createNewValueFieldFactory,
   generateFieldActions,
+  getComponentClassNames,
   normalizeFieldValue,
   ACTION_ICONS,
 } from './EditableField.utils'
@@ -32,14 +33,17 @@ import {
   FieldValue,
 } from './EditableField.types'
 
-const nextUuid = createUniqueIDFactory('EditableField')
+const nextUuid = createUniqueIDFactory(EF_COMPONENT_KEY)
 const createNewFieldValue = createNewValueFieldFactory(nextUuid)
+
+const CLASSNAMES: any = getComponentClassNames(EF_COMPONENT_KEY)
+const EMPTY_VALUE = ''
 
 export class EditableField extends React.Component<
   EditableFieldProps,
   EditableFieldState
 > {
-  static className = 'c-EditableField'
+  static className = CLASSNAMES.component
   static defaultProps = {
     type: 'text',
     defaultOption: null,
@@ -47,7 +51,7 @@ export class EditableField extends React.Component<
     emphasizeTopValue: false,
     multipleValues: false,
     renderFieldsAsBlocks: false,
-    value: '',
+    value: EMPTY_VALUE,
     innerRef: noop,
     onInputFocus: noop,
     onInputBlur: noop,
@@ -90,7 +94,7 @@ export class EditableField extends React.Component<
 
     this.state = {
       actions: generateFieldActions(actions),
-      activeField: '',
+      activeField: EMPTY_VALUE,
       fieldValue: initialFieldValue,
       initialFieldValue,
       multipleValuesEnabled: isArray(value) || multipleValues,
@@ -119,7 +123,7 @@ export class EditableField extends React.Component<
     return classNames(
       EditableField.className,
       className,
-      disabled && 'is-disabled'
+      disabled && CLASSNAMES.isDisabled
     )
   }
 
@@ -152,7 +156,7 @@ export class EditableField extends React.Component<
     /* istanbul ignore else */
     if (!focusedByLabel) {
       this.setState({
-        activeField: '',
+        activeField: EMPTY_VALUE,
       })
 
       onInputBlur({
@@ -195,13 +199,13 @@ export class EditableField extends React.Component<
         const impactedField = find(initialFieldValue, val => val.id === name)
         // Case 1: in multi-value fields if value is empty
         // Do nothing
-        if (multipleValuesEnabled && inputValue === '') {
+        if (multipleValuesEnabled && inputValue === EMPTY_VALUE) {
           return
         }
         // Case 2: value was not changed
         // Just change active status
         else if (impactedField && inputValue === impactedField.value) {
-          this.setState({ activeField: '' }, () => {
+          this.setState({ activeField: EMPTY_VALUE }, () => {
             resolve()
 
             onEnter({ name, value: fieldValue, event: cachedEvent })
@@ -219,7 +223,7 @@ export class EditableField extends React.Component<
 
           this.setState(
             {
-              activeField: '',
+              activeField: EMPTY_VALUE,
               fieldValue: updatedFieldValue,
               initialFieldValue: updatedFieldValue,
             },
@@ -236,7 +240,7 @@ export class EditableField extends React.Component<
       if (isEscape) {
         // Change active status and return fieldValue to initialValue
         this.setState(
-          { activeField: '', fieldValue: initialFieldValue },
+          { activeField: EMPTY_VALUE, fieldValue: initialFieldValue },
           () => {
             resolve()
 
@@ -286,14 +290,15 @@ export class EditableField extends React.Component<
   handleAddValue = () => {
     const { onAdd } = this.props
     const { fieldValue, defaultOption } = this.state
-    const isNotSingleEmptyValue = fieldValue[fieldValue.length - 1].value !== ''
+    const isNotSingleEmptyValue =
+      fieldValue[fieldValue.length - 1].value !== EMPTY_VALUE
     /* istanbul ignore next */
     if (isNotSingleEmptyValue) {
       // it is tested
       const { name } = this.props
       const newValueObject = createNewFieldValue(
         {
-          value: '',
+          value: EMPTY_VALUE,
           name,
         },
         defaultOption
@@ -320,7 +325,7 @@ export class EditableField extends React.Component<
     if (fieldValue.length === 1) {
       const emptyValue = { ...fieldValue[0] }
 
-      emptyValue.value = ''
+      emptyValue.value = EMPTY_VALUE
       /* istanbul ignore next */
       if (defaultOption != null) {
         emptyValue.option = defaultOption
@@ -369,8 +374,20 @@ export class EditableField extends React.Component<
     if (targetNode instanceof Element) {
       /* istanbul ignore if */
       if (document.activeElement === targetNode) return
-      /* istanbul ignore if */
-      if (targetNode.classList.contains('c-DropdownV2Item')) return
+
+      // Avoid acting on anything that comes from the options/dropdown
+      /* istanbul ignore next */
+      if (
+        targetNode.classList.contains(CLASSNAMES.dropdownItem) ||
+        targetNode.classList.contains(CLASSNAMES.truncateContent)
+      )
+        return
+
+      const optionsNode = this.editableFieldRef.querySelector(
+        `.${CLASSNAMES.optionsWrapper}`
+      )
+      /* istanbul ignore next */
+      if (optionsNode && optionsNode.contains(targetNode)) return
 
       const { name } = this.props
       const { fieldValue, initialFieldValue } = this.state
@@ -381,7 +398,7 @@ export class EditableField extends React.Component<
         // It's tested, go home Istanbul
         this.setState(
           {
-            activeField: '',
+            activeField: EMPTY_VALUE,
           },
           () => {
             if (!equal(initialFieldValue, this.state.fieldValue)) {
@@ -396,7 +413,7 @@ export class EditableField extends React.Component<
           // Case 2.A: value unchanged
           // It's tested, go home Istanbul
           this.setState({
-            activeField: '',
+            activeField: EMPTY_VALUE,
           })
         } else {
           // Case 2.B: value changed
@@ -413,7 +430,7 @@ export class EditableField extends React.Component<
           }
 
           this.setState(
-            { fieldValue: updatedFieldValue, activeField: '' },
+            { fieldValue: updatedFieldValue, activeField: EMPTY_VALUE },
             () => {
               if (emptyFound) {
                 this.props.onDiscard({ value: this.state.fieldValue })
@@ -431,17 +448,18 @@ export class EditableField extends React.Component<
     const { disabled } = this.props
     const { fieldValue, multipleValuesEnabled } = this.state
 
-    const isLastValueEmpty = fieldValue[fieldValue.length - 1].value === ''
+    const isLastValueEmpty =
+      fieldValue[fieldValue.length - 1].value === EMPTY_VALUE
     const isSingleAndEmpty = fieldValue.length === 1 && isLastValueEmpty
 
     return multipleValuesEnabled && !isSingleAndEmpty && !disabled ? (
       <AddButtonUI
-        className="EditableField_addButton"
+        className={CLASSNAMES.addButton}
         type="button"
         onClick={this.handleAddValue}
         disabled={isLastValueEmpty}
       >
-        <Icon name={ACTION_ICONS['plus']} size="20" />
+        <Icon name={ACTION_ICONS.plus} size="20" />
       </AddButtonUI>
     ) : null
   }
@@ -464,7 +482,7 @@ export class EditableField extends React.Component<
     } = this.state
 
     return (
-      <div className="EditableField__main">
+      <div className={CLASSNAMES.mainContent}>
         {fieldValue.map((val, index) => {
           return (
             <EditableFieldInput
@@ -521,11 +539,11 @@ export class EditableField extends React.Component<
         innerRef={this.setEditableNode}
       >
         <label
-          className="EditableField__label"
+          className={CLASSNAMES.label}
           htmlFor={fieldValue[0].id}
           onClick={this.handleLabelClick}
         >
-          <LabelTextUI className="EditableField__labelText">
+          <LabelTextUI className={CLASSNAMES.labelText}>
             {label || name}
           </LabelTextUI>
         </label>
@@ -540,6 +558,6 @@ export class EditableField extends React.Component<
   }
 }
 
-const PropConnectedComponent = propConnect(COMPONENT_KEY)(EditableField)
+const PropConnectedComponent = propConnect(EF_COMPONENT_KEY)(EditableField)
 
 export default PropConnectedComponent

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -78,11 +78,7 @@ export class EditableField extends React.Component<
     let defaultStateOption: string | null = null
 
     if (valueOptions) {
-      if (defaultOption) {
-        defaultStateOption = defaultOption
-      } else {
-        defaultStateOption = valueOptions[0]
-      }
+      defaultStateOption = defaultOption ? defaultOption : valueOptions[0]
     }
 
     const initialFieldValue = normalizeFieldValue({

--- a/src/components/EditableField/EditableField.types.ts
+++ b/src/components/EditableField/EditableField.types.ts
@@ -102,7 +102,7 @@ export interface EditableFieldInputProps {
 
 export interface EditableFieldInputState {
   dynamicFieldWidth: string | null
-  staticContentWidth: number | null
+  staticContentWidth: string | null
 }
 
 export interface TruncateProps {

--- a/src/components/EditableField/EditableField.utils.ts
+++ b/src/components/EditableField/EditableField.utils.ts
@@ -2,7 +2,9 @@ import { FieldAction, FieldValue } from './EditableField.types'
 import { isArray, isObject } from '../../utilities/is'
 import { find } from '../../utilities/arrays'
 
-export const COMPONENT_KEY = 'EditableField'
+export const EF_COMPONENT_KEY = 'EditableField'
+export const EF_I_COMPONENT_KEY = 'EditableFieldInput'
+export const EF_TRUNC_COMPONENT_KEY = 'EditableFieldTruncate'
 
 export const ACTION_ICONS = {
   delete: 'cross-small',
@@ -77,6 +79,62 @@ export function generateFieldActions(actions): FieldAction[] | [] {
     : actionsArray.concat(deleteAction)
 }
 
+/* istanbul ignore next */
 export function isEllipsisActive(e) {
   return e.offsetWidth < e.scrollWidth
+}
+
+export function getComponentClassNames(componentKey) {
+  if (componentKey === EF_I_COMPONENT_KEY) return EF_INPUT_CLASSNAMES
+  if (componentKey === EF_TRUNC_COMPONENT_KEY) return EF_TRUNC_CLASSNAMES
+
+  // Return main component classes by default
+  return EF_CLASSNAMES
+}
+
+const EF_CLASSNAMES = {
+  component: `c-${EF_COMPONENT_KEY}`,
+  optionsWrapper: `${EF_COMPONENT_KEY}__optionsWrapper`,
+  addButton: `${EF_COMPONENT_KEY}__addButton`,
+  mainContent: `${EF_COMPONENT_KEY}__main`,
+  label: `${EF_COMPONENT_KEY}__label`,
+  labelText: `${EF_COMPONENT_KEY}__labelText`,
+  isDisabled: 'is-disabled',
+  dropdownItem: 'c-DropdownV2Item',
+  truncateContent: 'c-Truncate__content',
+}
+
+const EF_INPUT_CLASSNAMES = {
+  component: `c-${EF_I_COMPONENT_KEY}`,
+  interactiveContent: `${EF_I_COMPONENT_KEY}__interactiveContent`,
+  inputWrapper: `${EF_I_COMPONENT_KEY}__inputWrapper`,
+  input: `${EF_I_COMPONENT_KEY}__input`,
+  actions: `${EF_I_COMPONENT_KEY}__actions`,
+  fieldButton: 'FieldButton',
+  staticContent: `${EF_I_COMPONENT_KEY}__staticContent`,
+  staticOption: `${EF_I_COMPONENT_KEY}__staticOption`,
+  staticValue: `${EF_I_COMPONENT_KEY}__staticValue`,
+  optionsWrapper: `${EF_I_COMPONENT_KEY}__optionsWrapper`,
+  dropdown: `${EF_I_COMPONENT_KEY}__Dropdown`,
+  optionsTrigger: `${EF_I_COMPONENT_KEY}__optionsTrigger`,
+  optionsDropdown: `${EF_I_COMPONENT_KEY}__optionsDropdown`,
+  selectedOption: `${EF_I_COMPONENT_KEY}__selectedOption`,
+  dropDownTrigger: 'c-DropdownV2Trigger',
+  focusIndicator: `${EF_I_COMPONENT_KEY}__focusIndicator`,
+  withPlaceholder: 'with-placeholder',
+  isPlaceholder: 'is-placeholder',
+  isEmphasized: 'is-emphasized',
+  isActive: 'is-active',
+  hasOptions: 'has-options',
+  isEmpty: 'is-empty',
+  isTemporaryValue: 'is-temporary-value',
+}
+
+const EF_TRUNC_CLASSNAMES = {
+  truncated: 'Truncated',
+  withSplitter: 'TruncatedWithSplitter',
+  firstChunk: 'TruncateFirstChunk',
+  splitterChunk: 'TruncateSplitterChunk',
+  secondChunk: 'TruncateSecondChunk',
+  content: 'c-Truncate__content',
 }

--- a/src/components/EditableField/EditableField.utils.ts
+++ b/src/components/EditableField/EditableField.utils.ts
@@ -5,9 +5,9 @@ import { find } from '../../utilities/arrays'
 export const COMPONENT_KEY = 'EditableField'
 
 export const ACTION_ICONS = {
-  delete: 'cross-medium',
-  link: 'new-window-large',
-  plus: 'plus-medium',
+  delete: 'cross-small',
+  link: 'new-window',
+  plus: 'plus-small',
   valueOption: 'chevron-down',
 }
 

--- a/src/components/EditableField/__tests__/EditableField.Input.test.tsx
+++ b/src/components/EditableField/__tests__/EditableField.Input.test.tsx
@@ -2,6 +2,14 @@ import * as React from 'react'
 import { cy } from '@helpscout/cyan'
 import { mount } from 'enzyme'
 import { EditableFieldInput } from '../EditableField.Input'
+import {
+  EF_I_COMPONENT_KEY,
+  EF_TRUNC_COMPONENT_KEY,
+  getComponentClassNames,
+} from '../EditableField.utils'
+
+const EF_I_CLASSNAMES: any = getComponentClassNames(EF_I_COMPONENT_KEY)
+const EF_TRUNC_CLASSNAMES: any = getComponentClassNames(EF_TRUNC_COMPONENT_KEY)
 
 describe('Should component update', () => {
   test('fieldValue', () => {
@@ -83,7 +91,7 @@ describe('calculateFieldWidth', () => {
     }
     cy.render(<EditableFieldInput name="greeting" fieldValue={val} isActive />)
 
-    const field = cy.get('.c-EditableFieldInput')
+    const field = cy.get(`.${EF_I_CLASSNAMES.component}`)
 
     expect(field.getComputedStyle('width')).toBe('100%')
   })
@@ -97,7 +105,7 @@ describe('calculateFieldWidth', () => {
       <EditableFieldInput name="greeting" fieldValue={val} isActive={false} />
     )
 
-    const field = cy.get('.c-EditableFieldInput')
+    const field = cy.get(`.${EF_I_CLASSNAMES.component}`)
 
     expect(field.getComputedStyle('width')).toContain('px')
   })
@@ -116,7 +124,7 @@ describe('calculateFieldWidth', () => {
       />
     )
 
-    const field = cy.get('.c-EditableFieldInput')
+    const field = cy.get(`.${EF_I_CLASSNAMES.component}`)
 
     expect(field.getComputedStyle('width')).toBe('100%')
   })
@@ -135,7 +143,7 @@ describe('calculateFieldWidth', () => {
       />
     )
 
-    const field = cy.get('.c-EditableFieldInput')
+    const field = cy.get(`.${EF_I_CLASSNAMES.component}`)
 
     expect(field.getComputedStyle('width')).toContain('px')
   })
@@ -150,12 +158,16 @@ describe('email type', () => {
 
     cy.render(<EditableFieldInput type="email" name="email" fieldValue={val} />)
 
-    expect(cy.get('.TruncatedWithSplitter').exists()).toBeTruthy()
-    expect(cy.get('.TruncateFirstChunk').exists()).toBeTruthy()
-    expect(cy.get('.TruncateSplitterChunk').exists()).toBeTruthy()
-    expect(cy.get('.TruncateSecondChunk').exists()).toBeTruthy()
-    expect(cy.get('.TruncateFirstChunk').text()).toBe('email')
-    expect(cy.get('.TruncateSplitterChunk').text()).toBe('@')
-    expect(cy.get('.TruncateSecondChunk').text()).toBe('somethingcool.com')
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.withSplitter}`).exists()).toBeTruthy()
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.firstChunk}`).exists()).toBeTruthy()
+    expect(
+      cy.get(`.${EF_TRUNC_CLASSNAMES.splitterChunk}`).exists()
+    ).toBeTruthy()
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.secondChunk}`).exists()).toBeTruthy()
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.firstChunk}`).text()).toBe('email')
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.splitterChunk}`).text()).toBe('@')
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.secondChunk}`).text()).toBe(
+      'somethingcool.com'
+    )
   })
 })

--- a/src/components/EditableField/__tests__/EditableField.test.tsx
+++ b/src/components/EditableField/__tests__/EditableField.test.tsx
@@ -2,6 +2,14 @@ import * as React from 'react'
 import { cy } from '@helpscout/cyan'
 import { mount } from 'enzyme'
 import { EditableField } from '../EditableField'
+import {
+  EF_COMPONENT_KEY,
+  EF_I_COMPONENT_KEY,
+  getComponentClassNames,
+} from '../EditableField.utils'
+
+const EF_CLASSNAMES: any = getComponentClassNames(EF_COMPONENT_KEY)
+const EF_I_CLASSNAMES: any = getComponentClassNames(EF_I_COMPONENT_KEY)
 
 cy.useFakeTimers()
 
@@ -9,7 +17,7 @@ describe('className', () => {
   test('Has default className', () => {
     const wrapper = cy.render(<EditableField name="company" />)
 
-    expect(wrapper.hasClass('c-EditableField')).toBeTruthy()
+    expect(wrapper.hasClass(EF_CLASSNAMES.component)).toBeTruthy()
   })
 
   test('Can render custom className', () => {
@@ -34,14 +42,14 @@ describe('HTML props', () => {
 describe('Label', () => {
   test('Renders label', () => {
     cy.render(<EditableField name="company" />)
-    const el = cy.get('.EditableField__label')
+    const el = cy.get(`.${EF_CLASSNAMES.label}`)
 
     expect(el.exists()).toBeTruthy()
   })
 
   test('The label has the correct "for" attribute based of name', () => {
     cy.render(<EditableField name="company" />)
-    const el = cy.get('.EditableField__label')
+    const el = cy.get(`.${EF_CLASSNAMES.label}`)
     const forAttr = el.getAttribute('for')
 
     expect(forAttr).toContain('company')
@@ -49,14 +57,14 @@ describe('Label', () => {
 
   test('Renders text based of "label" prop', () => {
     cy.render(<EditableField name="company" label="Company" />)
-    const el = cy.get('.EditableField__labelText')
+    const el = cy.get(`.${EF_CLASSNAMES.labelText}`)
 
     expect(el.getText()).toBe('Company')
   })
 
   test('Renders text if "label" prop not provided using "name"', () => {
     cy.render(<EditableField name="company" />)
-    const el = cy.get('.EditableField__labelText')
+    const el = cy.get(`.${EF_CLASSNAMES.labelText}`)
 
     expect(el.getText()).toBe('company')
   })
@@ -67,7 +75,7 @@ describe('InnerRef', () => {
     const spy = jest.fn()
     const wrapper = mount(<EditableField name="company" innerRef={spy} />)
     const o = wrapper
-      .find('.c-EditableField')
+      .find(`.${EF_CLASSNAMES.component}`)
       .first()
       .getDOMNode()
 
@@ -252,7 +260,7 @@ describe('Value', () => {
       <EditableField name="company" value={['hello', 'goodbye', 'hola']} />
     )
 
-    const button = cy.get('.EditableField_addButton')
+    const button = cy.get(`.${EF_CLASSNAMES.addButton}`)
     expect(button.exists()).toBeTruthy()
   })
 
@@ -261,7 +269,7 @@ describe('Value', () => {
       <EditableField name="company" value={['hello', 'goodbye', 'hola']} />
     )
 
-    const button = cy.get('.EditableField_addButton')
+    const button = cy.get(`.${EF_CLASSNAMES.addButton}`)
 
     expect(cy.get('input').length).toBe(3)
     button.click()
@@ -277,7 +285,7 @@ describe('Value', () => {
       />
     )
 
-    const button = cy.get('.EditableField_addButton')
+    const button = cy.get(`.${EF_CLASSNAMES.addButton}`)
 
     expect(cy.get('input').length).toBe(1)
     button.click()
@@ -295,7 +303,7 @@ describe('Value', () => {
       <EditableField name="company" value={['hello', 'goodbye', 'hola']} />
     )
 
-    const button = cy.get('.EditableField_addButton')
+    const button = cy.get(`.${EF_CLASSNAMES.addButton}`)
 
     expect(cy.get('input').length).toBe(3)
     button.click()
@@ -389,7 +397,7 @@ describe('Options', () => {
       />
     )
 
-    expect(cy.get('.EditableField__selectedOption').getText()).toBe('Work')
+    expect(cy.get(`.${EF_I_CLASSNAMES.selectedOption}`).getText()).toBe('Work')
   })
 
   test('Option text should be the default with empty value', () => {
@@ -402,7 +410,7 @@ describe('Options', () => {
       />
     )
 
-    expect(cy.get('.EditableField__selectedOption').getText()).toBe('Other')
+    expect(cy.get(`.${EF_I_CLASSNAMES.selectedOption}`).getText()).toBe('Other')
   })
 
   test('Option text should be the default with empty value (obj case)', () => {
@@ -415,7 +423,7 @@ describe('Options', () => {
       />
     )
 
-    expect(cy.get('.EditableField__selectedOption').getText()).toBe('Other')
+    expect(cy.get(`.${EF_I_CLASSNAMES.selectedOption}`).getText()).toBe('Other')
   })
 
   test('With no value option text should be the default option passed', () => {
@@ -427,7 +435,7 @@ describe('Options', () => {
       />
     )
 
-    expect(cy.get('.EditableField__selectedOption').getText()).toBe('Other')
+    expect(cy.get(`.${EF_I_CLASSNAMES.selectedOption}`).getText()).toBe('Other')
   })
 
   test('With no value option text should be the first in the list', () => {
@@ -435,7 +443,7 @@ describe('Options', () => {
       <EditableField name="company" valueOptions={['Home', 'Work', 'Other']} />
     )
 
-    expect(cy.get('.EditableField__selectedOption').getText()).toBe('Home')
+    expect(cy.get(`.${EF_I_CLASSNAMES.selectedOption}`).getText()).toBe('Home')
   })
 
   test('With no value option text should be default passed in', () => {
@@ -447,7 +455,7 @@ describe('Options', () => {
       />
     )
 
-    expect(cy.get('.EditableField__selectedOption').getText()).toBe('Other')
+    expect(cy.get(`.${EF_I_CLASSNAMES.selectedOption}`).getText()).toBe('Other')
   })
 
   test('Change option text when clicking a dropdown item', () => {
@@ -466,7 +474,7 @@ describe('Options', () => {
       .first()
       .click()
 
-    expect(cy.get('.EditableField__selectedOption').getText()).toBe('Home')
+    expect(cy.get(`.${EF_I_CLASSNAMES.selectedOption}`).getText()).toBe('Home')
   })
 })
 
@@ -474,7 +482,7 @@ describe('Static Value', () => {
   test('should render the placeholder if no value present', () => {
     cy.render(<EditableField name="company" placeholder="Add something" />)
 
-    expect(cy.get('.EditableField__staticValue').getText()).toBe(
+    expect(cy.get(`.${EF_I_CLASSNAMES.staticValue}`).getText()).toBe(
       'Add something'
     )
   })
@@ -484,7 +492,7 @@ describe('Static Value', () => {
       <EditableField name="company" value="hello" placeholder="Add something" />
     )
 
-    expect(cy.get('.EditableField__staticValue').getText()).toBe('hello')
+    expect(cy.get(`.${EF_I_CLASSNAMES.staticValue}`).getText()).toBe('hello')
   })
 
   test('should emphasize the value if emphasizeTopValue and multivalue enabled', () => {
@@ -500,7 +508,7 @@ describe('Static Value', () => {
     expect(cy.get('.is-emphasized').exists()).toBeTruthy()
     expect(cy.get('.is-emphasized').getText()).toBe('hello')
     expect(
-      cy.get('.EditableField__staticValue').getComputedStyle('fontWeight')
+      cy.get(`.${EF_I_CLASSNAMES.staticValue}`).getComputedStyle('fontWeight')
     ).toBe('500')
   })
 
@@ -510,7 +518,7 @@ describe('Static Value', () => {
     )
 
     expect(
-      cy.get('.EditableField__staticContent').getComputedStyle('zIndex')
+      cy.get(`.${EF_I_CLASSNAMES.staticContent}`).getComputedStyle('zIndex')
     ).toBe('2')
   })
 
@@ -524,7 +532,7 @@ describe('Static Value', () => {
     input.focus()
 
     expect(
-      cy.get('.EditableField__staticContent').getComputedStyle('zIndex')
+      cy.get(`.${EF_I_CLASSNAMES.staticContent}`).getComputedStyle('zIndex')
     ).toBe('1')
   })
 
@@ -537,14 +545,14 @@ describe('Static Value', () => {
       />
     )
 
-    expect(cy.get('.EditableField__staticOption').getText()).toBe('Work')
+    expect(cy.get(`.${EF_I_CLASSNAMES.staticOption}`).getText()).toBe('Work')
 
     cy.getByCy('DropdownTrigger').click()
     cy.getByCy('DropdownItem')
       .first()
       .click()
 
-    expect(cy.get('.EditableField__staticOption').getText()).toBe('Home')
+    expect(cy.get(`.${EF_I_CLASSNAMES.staticOption}`).getText()).toBe('Home')
   })
 })
 
@@ -552,7 +560,7 @@ describe('Actions', () => {
   test('should render delete action by default', () => {
     cy.render(<EditableField name="company" value="hello" />)
 
-    expect(cy.get('.EditableField__actions').exists()).toBeTruthy()
+    expect(cy.get(`.${EF_I_CLASSNAMES.actions}`).exists()).toBeTruthy()
     expect(cy.get('.action-delete').exists()).toBeTruthy()
   })
 
@@ -678,7 +686,7 @@ describe('disabled', () => {
       />
     )
 
-    expect(cy.get('.EditableField__actions').exists()).toBeFalsy()
+    expect(cy.get(`.${EF_I_CLASSNAMES.actions}`).exists()).toBeFalsy()
     expect(cy.get('.action-delete').exists()).toBeFalsy()
   })
 
@@ -692,7 +700,7 @@ describe('disabled', () => {
       />
     )
 
-    const button = cy.get('.EditableField_addButton')
+    const button = cy.get(`.${EF_CLASSNAMES.addButton}`)
     expect(button.exists()).toBeFalsy()
   })
 
@@ -719,7 +727,7 @@ describe('Label click event', () => {
         valueOptions={['Home', 'Work', 'Other']}
       />
     )
-    const label = wrapper.find('.EditableField__label').first()
+    const label = wrapper.find(`.${EF_CLASSNAMES.label}`).first()
 
     label.simulate('click')
 
@@ -735,7 +743,7 @@ describe('Label click event', () => {
         disabled
       />
     )
-    const label = wrapper.find('.EditableField__label').first()
+    const label = wrapper.find(`.${EF_CLASSNAMES.label}`).first()
 
     label.simulate('click')
 
@@ -953,7 +961,7 @@ describe('Events', () => {
       />
     )
 
-    const button = cy.get('.EditableField_addButton')
+    const button = cy.get(`.${EF_CLASSNAMES.addButton}`)
 
     button.click()
     expect(spy).toHaveBeenCalled()
@@ -974,7 +982,7 @@ describe('Events', () => {
       />
     )
 
-    const button = cy.get('.EditableField_addButton')
+    const button = cy.get(`.${EF_CLASSNAMES.addButton}`)
 
     button.click()
     expect(spy).not.toHaveBeenCalled()

--- a/src/components/EditableField/__tests__/EditableField.test.tsx
+++ b/src/components/EditableField/__tests__/EditableField.test.tsx
@@ -959,6 +959,27 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalled()
   })
 
+  test('onAdd: empty', () => {
+    const spy = jest.fn()
+
+    cy.render(
+      <EditableField
+        name="company"
+        value={[
+          { id: 'hh_0', value: 'dd' },
+          { id: 'hh_1', value: 'fff' },
+          { id: 'hh_2', value: '' },
+        ]}
+        onAdd={spy}
+      />
+    )
+
+    const button = cy.get('.EditableField_addButton')
+
+    button.click()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
   test('Pressing Enter: should commit if value changes', () => {
     const onEnterSpy = jest.fn()
     const onCommitSpy = jest.fn()
@@ -1002,6 +1023,29 @@ describe('Events', () => {
     input.simulate('keydown', { key: 'Enter' })
 
     expect(onEnterSpy).toHaveBeenCalled()
+    expect(onCommitSpy).not.toHaveBeenCalled()
+  })
+
+  test('Pressing Enter: should not commit if value empty', () => {
+    const onEnterSpy = jest.fn()
+    const onCommitSpy = jest.fn()
+    const wrapper = mount(
+      <EditableField
+        name="company"
+        multipleValues
+        value="hello"
+        onEnter={onEnterSpy}
+        onCommit={onCommitSpy}
+      />
+    )
+
+    const input = wrapper.find('input').first()
+
+    // @ts-ignore
+    input.getDOMNode().value = ''
+
+    input.simulate('keydown', { key: 'Enter' })
+
     expect(onCommitSpy).not.toHaveBeenCalled()
   })
 

--- a/src/components/EditableField/__tests__/EditableField.truncate.test.tsx
+++ b/src/components/EditableField/__tests__/EditableField.truncate.test.tsx
@@ -1,23 +1,33 @@
 import * as React from 'react'
 import { cy } from '@helpscout/cyan'
 import Truncated from '../EditableField.Truncate'
+import {
+  EF_TRUNC_COMPONENT_KEY,
+  getComponentClassNames,
+} from '../EditableField.utils'
+
+const EF_TRUNC_CLASSNAMES: any = getComponentClassNames(EF_TRUNC_COMPONENT_KEY)
 
 describe('Editable Field truncate', () => {
   test('should truncate with HSDS truncate if no splitter provided', () => {
     cy.render(<Truncated string="001122334455677889900" />)
 
-    expect(cy.get('.Truncated').exists()).toBeTruthy()
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.truncated}`).exists()).toBeTruthy()
   })
 
   test('should truncate with with splitter if provided', () => {
     cy.render(<Truncated string="email@something.com" splitter="@" />)
 
-    expect(cy.get('.TruncatedWithSplitter').exists()).toBeTruthy()
-    expect(cy.get('.TruncateFirstChunk').exists()).toBeTruthy()
-    expect(cy.get('.TruncateSplitterChunk').exists()).toBeTruthy()
-    expect(cy.get('.TruncateSecondChunk').exists()).toBeTruthy()
-    expect(cy.get('.TruncateFirstChunk').text()).toBe('email')
-    expect(cy.get('.TruncateSplitterChunk').text()).toBe('@')
-    expect(cy.get('.TruncateSecondChunk').text()).toBe('something.com')
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.withSplitter}`).exists()).toBeTruthy()
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.firstChunk}`).exists()).toBeTruthy()
+    expect(
+      cy.get(`.${EF_TRUNC_CLASSNAMES.splitterChunk}`).exists()
+    ).toBeTruthy()
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.secondChunk}`).exists()).toBeTruthy()
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.firstChunk}`).text()).toBe('email')
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.splitterChunk}`).text()).toBe('@')
+    expect(cy.get(`.${EF_TRUNC_CLASSNAMES.secondChunk}`).text()).toBe(
+      'something.com'
+    )
   })
 })

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -13,7 +13,10 @@ export const EditableFieldInputUI = styled('div')`
 
   &:hover .EditableField__actions {
     opacity: 1;
-    cursor: pointer;
+  }
+
+  &:hover .EditableField__interactiveContent {
+    border-bottom: 1px dashed #93a1b0;
   }
 
   &.is-active:hover .EditableField__actions {
@@ -27,6 +30,15 @@ export const EditableFieldInputUI = styled('div')`
 
   .is-disabled &:hover .with-placeholder {
     border-bottom: 1px solid transparent;
+  }
+
+  .is-temporary-value {
+    position: absolute;
+    left: -99999px;
+    font-size: 14px;
+    visibility: hidden;
+    width: auto;
+    height: auto;
   }
 `
 
@@ -214,7 +226,7 @@ export const StaticContentUI = styled('div')`
   position: relative;
   display: inline-block;
   width: ${({ staticContentWidth, renderAsBlock }) =>
-    renderAsBlock ? '100%' : `${staticContentWidth}px`};
+    renderAsBlock ? '100%' : `${staticContentWidth}`};
   max-width: 100%;
   height: 25px;
   z-index: 2;
@@ -334,20 +346,18 @@ export const FocusIndicatorUI = styled('span')`
 `
 
 export const FieldActionsUI = styled('div')`
-  ${({ numberOfActions }) => `width: ${numberOfActions * 25}px;`}
-  height: 20px;
+  ${({ numberOfActions }) => `width: ${numberOfActions * 25 + 5}px;`}
+  height: 25px;
   position: absolute;
   top: 1px;
-  left: 100%;
   left: ${({ renderAsBlock, numberOfActions }) =>
-    renderAsBlock ? `calc(100% - ${numberOfActions * 25}px)` : '100%'};
+    renderAsBlock ? `calc(100% - ${numberOfActions * 25 + 5}px)` : '100%'};
   z-index: 4;
   opacity: 0;
   text-align: right;
 
   &:hover {
     opacity: 1;
-    cursor: pointer;
   }
 `
 
@@ -355,7 +365,7 @@ export const FieldButtonUI = styled('button')`
   display: inline-block;
   vertical-align: middle;
   height: 25px;
-  width: 20px;
+  width: 25px;
   padding: 0;
   margin: 0;
   border: none;

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -2,10 +2,14 @@ import styled from '../../styled/index'
 import baseStyles from '../../../styles/resets/baseStyles.css'
 import { getColor } from '../../../styles/utilities/color'
 
+const WRAPPER_HEIGHT = 26
+const CONTENT_HEIGHT = 25
+const TIGHTNESS = 3 // How close should content and bottom border be
+
 export const EditableFieldInputUI = styled('div')`
   ${baseStyles};
   position: relative;
-  height: 25px;
+  height: ${CONTENT_HEIGHT}px;
   margin-bottom: 2px;
   width: ${({ dynamicFieldWidth, renderAsBlock }) =>
     renderAsBlock ? 'auto' : `${dynamicFieldWidth}`};
@@ -15,8 +19,9 @@ export const EditableFieldInputUI = styled('div')`
     opacity: 1;
   }
 
-  &:hover .EditableField__interactiveContent {
-    border-bottom: 1px dashed #93a1b0;
+  &:hover .EditableField__staticOption,
+  &:hover .EditableField__staticValue {
+    border-bottom: 1px dashed ${getColor('charcoal.200')};
   }
 
   &.is-active:hover .EditableField__actions {
@@ -44,7 +49,7 @@ export const EditableFieldInputUI = styled('div')`
 
 export const InteractiveContentUI = styled('div')`
   display: flex;
-  height: 26px;
+  height: ${WRAPPER_HEIGHT}px;
   width: 100%;
   max-width: 100%;
   position: absolute;
@@ -52,11 +57,6 @@ export const InteractiveContentUI = styled('div')`
   left: 0;
   z-index: 1;
   border-bottom: 1px solid transparent;
-
-  &:hover {
-    cursor: pointer;
-    border-bottom: 1px dashed #93a1b0;
-  }
 
   .is-disabled &:hover {
     cursor: initial;
@@ -72,7 +72,7 @@ export const InteractiveContentUI = styled('div')`
 
 export const InputWrapperUI = styled('div')`
   position: relative;
-  height: 25px;
+  height: ${CONTENT_HEIGHT}px;
   width: 100%;
 
   .has-options & {
@@ -87,10 +87,10 @@ export const InputWrapperUI = styled('div')`
 export const OptionsWrapperUI = styled('div')`
   position: relative;
   width: 60px;
-  height: 25px;
+  height: ${CONTENT_HEIGHT}px;
   margin-right: 20px;
   font-size: 14px;
-  line-height: 25px;
+  line-height: ${CONTENT_HEIGHT + TIGHTNESS}px;
   pointer-events: auto;
 
   .is-disabled & .EditableField__Dropdown:hover {
@@ -106,6 +106,10 @@ export const OptionsWrapperUI = styled('div')`
     width: 60px;
     margin-right: 20px;
   }
+
+  .c-DropdownV2Trigger:hover {
+    cursor: text;
+  }
 `
 
 export const TriggerUI = styled('div')`
@@ -118,7 +122,7 @@ export const OptionsDropdownUI = styled('div')`
   margin-bottom: 5px;
   background: white;
   font-size: 14px;
-  line-height: 25px;
+  line-height: ${CONTENT_HEIGHT + TIGHTNESS}px;
   color: transparent;
 
   .is-active & {
@@ -160,8 +164,8 @@ export const OptionsDropdownUI = styled('div')`
 
 export const InputUI = styled('input')`
   width: 100%;
-  height: 25px;
-  padding: 0;
+  height: ${CONTENT_HEIGHT}px;
+  padding: ${TIGHTNESS}px 0 0 0;
   border: none;
   color: transparent;
   font-size: 14px;
@@ -195,7 +199,8 @@ export const InputUI = styled('input')`
     }
 
     &::placeholder {
-      color: #b7c2cc;
+      color: ${getColor('charcoal.300')};
+      opacity: 1;
     }
   }
 
@@ -228,7 +233,7 @@ export const StaticContentUI = styled('div')`
   width: ${({ staticContentWidth, renderAsBlock }) =>
     renderAsBlock ? '100%' : `${staticContentWidth}`};
   max-width: 100%;
-  height: 25px;
+  height: ${CONTENT_HEIGHT}px;
   z-index: 2;
   pointer-events: none;
   white-space: nowrap;
@@ -241,13 +246,14 @@ export const StaticContentUI = styled('div')`
 export const StaticOptionUI = styled('span')`
   display: inline-block;
   vertical-align: bottom;
+  position: relative;
   width: 70px;
-  height: 26px;
+  height: ${WRAPPER_HEIGHT}px;
   margin-right: 10px;
   color: ${getColor('charcoal.600')};
   font-size: 14px;
   font-weight: 500;
-  line-height: 25px;
+  line-height: ${CONTENT_HEIGHT + TIGHTNESS}px;
   z-index: 2;
   pointer-events: none;
   white-space: nowrap;
@@ -263,7 +269,7 @@ export const StaticOptionUI = styled('span')`
   }
 
   & .is-placeholder {
-    color: ${getColor('charcoal.400')};
+    color: ${getColor('charcoal.300')};
   }
 
   .is-disabled & {
@@ -279,12 +285,12 @@ export const StaticOptionUI = styled('span')`
 export const StaticValueUI = styled('span')`
   display: inline-block;
   vertical-align: bottom;
-  height: 26px;
+  height: ${WRAPPER_HEIGHT}px;
   width: 100%;
   max-width: 100%;
-  color: ${getColor('charcoal.600')};
+  color: ${getColor('charcoal.800')};
   font-size: 14px;
-  line-height: 25px;
+  line-height: ${CONTENT_HEIGHT + TIGHTNESS}px;
   z-index: 2;
   pointer-events: none;
   white-space: nowrap;
@@ -308,11 +314,12 @@ export const StaticValueUI = styled('span')`
   }
 
   &.with-placeholder {
-    border-bottom: 1px dashed #93a1b0;
+    width: auto;
+    border-bottom: 1px dashed ${getColor('grey.800')};
   }
 
   & .is-placeholder {
-    color: ${getColor('charcoal.400')};
+    color: ${getColor('charcoal.300')};
   }
 
   .is-disabled &.with-placeholder {
@@ -347,7 +354,7 @@ export const FocusIndicatorUI = styled('span')`
 
 export const FieldActionsUI = styled('div')`
   ${({ numberOfActions }) => `width: ${numberOfActions * 25 + 5}px;`}
-  height: 25px;
+  height: ${CONTENT_HEIGHT}px;
   position: absolute;
   top: 1px;
   left: ${({ renderAsBlock, numberOfActions }) =>
@@ -364,8 +371,8 @@ export const FieldActionsUI = styled('div')`
 export const FieldButtonUI = styled('button')`
   display: inline-block;
   vertical-align: middle;
-  height: 25px;
-  width: 25px;
+  height: ${CONTENT_HEIGHT}px;
+  width: 20px;
   padding: 0;
   margin: 0;
   border: none;
@@ -373,6 +380,7 @@ export const FieldButtonUI = styled('button')`
   color: slategray;
   font-size: 12px;
   text-align: center;
+  overflow: hidden;
 
   &:hover,
   &:focus {
@@ -392,6 +400,7 @@ export const FieldButtonUI = styled('button')`
   }
 
   .c-Icon {
-    margin: 0 auto;
+    width: 24px;
+    transform: translateX(3px);
   }
 `

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -11,6 +11,20 @@ const CLASSNAMES: any = getComponentClassNames(EF_I_COMPONENT_KEY)
 
 const CONTENT_HEIGHT = 25
 
+const resetHSAppInputRules = `
+  border-radius: 0;
+  display: block;
+  margin: 0;
+  vertical-align: baseline;
+  border: none;
+  transition: none;
+  
+  &:focus {
+    border: none;
+    outline: 0;
+  }
+`
+
 export const EditableFieldInputUI = styled('div')`
   ${baseStyles};
   position: relative;
@@ -167,67 +181,72 @@ export const OptionsDropdownUI = styled('div')`
 `
 
 export const InputUI = styled('input')`
-  width: 100%;
-  height: ${CONTENT_HEIGHT}px;
-  padding: 0;
-  border: none;
-  color: transparent;
-  font-size: 14px;
-  background: white;
-  pointer-events: auto;
-
-  &::placeholder {
+  /* Guard styles from other globally applied rules for input tags */
+  &.${CLASSNAMES.input} {
+    ${resetHSAppInputRules}
+    width: 100%;
+    height: ${CONTENT_HEIGHT}px;
+    line-height: ${CONTENT_HEIGHT}px;
+    padding: 0;
+    border: none;
     color: transparent;
-  }
-
-  .is-active &:focus {
-    outline: none;
-
-    & + .${CLASSNAMES.focusIndicator} {
-      transform: scaleX(1);
-      background-color: ${getColor('blue.500')} !important;
-      height: 2px;
-    }
-  }
-
-  .is-active & {
-    outline: none;
-    color: ${getColor('charcoal.600')};
-    z-index: 2;
-    cursor: initial;
-
-    & + .${CLASSNAMES.focusIndicator} {
-      transform: scaleX(1);
-      height: 1px;
-      background-color: #c6d0d8;
-    }
+    font-size: 14px;
+    background: white;
+    pointer-events: auto;
 
     &::placeholder {
-      color: ${getColor('charcoal.300')};
-      opacity: 1;
+      color: transparent;
     }
-  }
 
-  .is-empty & {
-    cursor: pointer;
-  }
+    .is-active &:focus {
+      outline: none;
 
-  .is-disabled & {
-    cursor: not-allowed;
-  }
+      & + .${CLASSNAMES.focusIndicator} {
+        transform: scaleX(1);
+        background-color: ${getColor('blue.500')} !important;
+        height: 2px;
+      }
+    }
 
-  .is-empty &:focus {
-    cursor: initial;
-  }
+    .is-active & {
+      outline: none;
+      color: ${getColor('charcoal.600')};
+      z-index: 2;
+      cursor: initial;
 
-  &[type='number']::-webkit-inner-spin-button,
-  &[type='number']::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
+      & + .${CLASSNAMES.focusIndicator} {
+        transform: scaleX(1);
+        height: 1px;
+        background-color: #c6d0d8;
+      }
 
-  &[type='number'] {
-    -moz-appearance: textfield;
+      &::placeholder {
+        color: ${getColor('charcoal.300')};
+        opacity: 1;
+      }
+    }
+
+    .is-empty & {
+      cursor: pointer;
+    }
+
+    .is-disabled & {
+      cursor: not-allowed;
+    }
+
+    .is-empty &:focus {
+      cursor: initial;
+    }
+
+    &[type='number']::-webkit-inner-spin-button,
+    &[type='number']::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    &[type='number'] {
+      -moz-appearance: textfield;
+    }
   }
 `
 

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -333,7 +333,8 @@ export const StaticValueUI = styled('span')`
   }
 
   &:focus {
-    outline: 1px dashed rgba(197, 208, 217, 0.5);
+    outline: 0;
+    border-bottom: 1px dashed rgba(197, 208, 217, 0.5);
   }
 `
 

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -2,6 +2,13 @@ import styled from '../../styled/index'
 import baseStyles from '../../../styles/resets/baseStyles.css'
 import { getColor } from '../../../styles/utilities/color'
 
+import {
+  EF_I_COMPONENT_KEY,
+  getComponentClassNames,
+} from '../EditableField.utils'
+
+const CLASSNAMES: any = getComponentClassNames(EF_I_COMPONENT_KEY)
+
 const CONTENT_HEIGHT = 25
 
 export const EditableFieldInputUI = styled('div')`
@@ -13,16 +20,15 @@ export const EditableFieldInputUI = styled('div')`
     renderAsBlock ? 'auto' : `${dynamicFieldWidth}`};
   transition: width 0.2s ease-in-out;
 
-  &:hover .EditableField__actions {
+  &:hover .${CLASSNAMES.actions} {
     opacity: 1;
   }
 
-  &:hover .EditableField__staticOption,
-  &:hover .EditableField__staticValue {
+  &:hover .${CLASSNAMES.staticOption}, &:hover .${CLASSNAMES.staticValue} {
     border-bottom: 1px dashed ${getColor('charcoal.200')};
   }
 
-  &.is-active:hover .EditableField__actions {
+  &.is-active:hover .${CLASSNAMES.actions} {
     display: none;
     cursor: initial;
   }
@@ -90,7 +96,7 @@ export const OptionsWrapperUI = styled('div')`
   font-size: 14px;
   pointer-events: auto;
 
-  .is-disabled & .EditableField__Dropdown:hover {
+  .is-disabled & ${`.${CLASSNAMES.dropDown}`}:hover {
     cursor: initial;
   }
 
@@ -104,8 +110,7 @@ export const OptionsWrapperUI = styled('div')`
     margin-right: 20px;
   }
 
-  .c-DropdownV2Trigger,
-  .c-DropdownV2Trigger:hover {
+  .${CLASSNAMES.dropDownTrigger}, ${`.${CLASSNAMES.dropDownTrigger}`}:hover {
     cursor: text;
   }
 `
@@ -127,17 +132,17 @@ export const OptionsDropdownUI = styled('div')`
   .is-active & {
     color: black;
 
-    & + .EditableField__focusIndicator {
+    & + .${CLASSNAMES.focusIndicator} {
       transform: scaleX(1);
       height: 1px;
       background-color: #c6d0d8;
     }
   }
 
-  .is-active .c-DropdownV2Trigger:focus & {
+  .is-active ${`.${CLASSNAMES.dropDownTrigger}`}:focus & {
     outline: none;
 
-    & + .EditableField__focusIndicator {
+    & + .${CLASSNAMES.focusIndicator} {
       transform: scaleX(1);
       background-color: ${getColor('blue.500')};
       height: 2px;
@@ -145,7 +150,7 @@ export const OptionsDropdownUI = styled('div')`
   }
 
   &:focus {
-    & + .EditableField__focusIndicator {
+    & + .${CLASSNAMES.focusIndicator} {
       transform: scaleX(1);
     }
   }
@@ -178,7 +183,7 @@ export const InputUI = styled('input')`
   .is-active &:focus {
     outline: none;
 
-    & + .EditableField__focusIndicator {
+    & + .${CLASSNAMES.focusIndicator} {
       transform: scaleX(1);
       background-color: ${getColor('blue.500')} !important;
       height: 2px;
@@ -191,7 +196,7 @@ export const InputUI = styled('input')`
     z-index: 2;
     cursor: initial;
 
-    & + .EditableField__focusIndicator {
+    & + .${CLASSNAMES.focusIndicator} {
       transform: scaleX(1);
       height: 1px;
       background-color: #c6d0d8;
@@ -208,7 +213,7 @@ export const InputUI = styled('input')`
   }
 
   .is-disabled & {
-    cursor: initial;
+    cursor: not-allowed;
   }
 
   .is-empty &:focus {
@@ -334,6 +339,7 @@ export const StaticValueUI = styled('span')`
   }
 
   &:focus {
+    width: auto;
     outline: 0;
     border-bottom: 1px dashed rgba(197, 208, 217, 0.5);
   }

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -104,6 +104,7 @@ export const OptionsWrapperUI = styled('div')`
     margin-right: 20px;
   }
 
+  .c-DropdownV2Trigger,
   .c-DropdownV2Trigger:hover {
     cursor: text;
   }

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -2,9 +2,7 @@ import styled from '../../styled/index'
 import baseStyles from '../../../styles/resets/baseStyles.css'
 import { getColor } from '../../../styles/utilities/color'
 
-const WRAPPER_HEIGHT = 26
 const CONTENT_HEIGHT = 25
-const TIGHTNESS = 3 // How close should content and bottom border be
 
 export const EditableFieldInputUI = styled('div')`
   ${baseStyles};
@@ -49,7 +47,7 @@ export const EditableFieldInputUI = styled('div')`
 
 export const InteractiveContentUI = styled('div')`
   display: flex;
-  height: ${WRAPPER_HEIGHT}px;
+  height: ${CONTENT_HEIGHT}px;
   width: 100%;
   max-width: 100%;
   position: absolute;
@@ -72,7 +70,7 @@ export const InteractiveContentUI = styled('div')`
 
 export const InputWrapperUI = styled('div')`
   position: relative;
-  height: ${CONTENT_HEIGHT}px;
+  height: ${CONTENT_HEIGHT - 2}px;
   width: 100%;
 
   .has-options & {
@@ -90,7 +88,6 @@ export const OptionsWrapperUI = styled('div')`
   height: ${CONTENT_HEIGHT}px;
   margin-right: 20px;
   font-size: 14px;
-  line-height: ${CONTENT_HEIGHT + TIGHTNESS}px;
   pointer-events: auto;
 
   .is-disabled & .EditableField__Dropdown:hover {
@@ -122,8 +119,8 @@ export const OptionsDropdownUI = styled('div')`
   margin-bottom: 5px;
   background: white;
   font-size: 14px;
-  line-height: ${CONTENT_HEIGHT + 3}px;
-  height: ${CONTENT_HEIGHT}px;
+  line-height: ${CONTENT_HEIGHT}px;
+  height: ${CONTENT_HEIGHT - 2}px;
   color: transparent;
 
   .is-active & {
@@ -166,7 +163,7 @@ export const OptionsDropdownUI = styled('div')`
 export const InputUI = styled('input')`
   width: 100%;
   height: ${CONTENT_HEIGHT}px;
-  padding: ${TIGHTNESS}px 0 0 0;
+  padding: 0;
   border: none;
   color: transparent;
   font-size: 14px;
@@ -249,12 +246,12 @@ export const StaticOptionUI = styled('span')`
   vertical-align: bottom;
   position: relative;
   width: 70px;
-  height: ${WRAPPER_HEIGHT}px;
+  height: ${CONTENT_HEIGHT - 2}px;
   margin-right: 10px;
   color: ${getColor('charcoal.600')};
   font-size: 14px;
   font-weight: 500;
-  line-height: ${CONTENT_HEIGHT + TIGHTNESS}px;
+  line-height: ${CONTENT_HEIGHT}px;
   z-index: 2;
   pointer-events: none;
   white-space: nowrap;
@@ -286,12 +283,12 @@ export const StaticOptionUI = styled('span')`
 export const StaticValueUI = styled('span')`
   display: inline-block;
   vertical-align: bottom;
-  height: ${WRAPPER_HEIGHT}px;
+  height: ${CONTENT_HEIGHT - 2}px;
+  line-height: ${CONTENT_HEIGHT}px;
   width: 100%;
   max-width: 100%;
   color: ${getColor('charcoal.800')};
   font-size: 14px;
-  line-height: ${CONTENT_HEIGHT + TIGHTNESS}px;
   z-index: 2;
   pointer-events: none;
   white-space: nowrap;
@@ -302,7 +299,7 @@ export const StaticValueUI = styled('span')`
   }
 
   .has-options.is-empty & {
-    width: 100%;
+    width: auto;
   }
 
   .is-active & {

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -149,7 +149,7 @@ export const OptionsDropdownUI = styled('div')`
   color: transparent;
 
   .is-active & {
-    color: black;
+    color: ${getColor('charcoal.800')};
 
     & + .${CLASSNAMES.focusIndicator} {
       transform: scaleX(1);
@@ -215,7 +215,7 @@ export const InputUI = styled('input')`
 
     .is-active & {
       outline: none;
-      color: ${getColor('charcoal.600')};
+      color: ${getColor('charcoal.800')};
       z-index: 2;
       cursor: initial;
 
@@ -278,7 +278,7 @@ export const StaticOptionUI = styled('span')`
   width: 70px;
   height: ${CONTENT_HEIGHT - 2}px;
   margin-right: 10px;
-  color: ${getColor('charcoal.600')};
+  color: ${getColor('charcoal.800')};
   font-size: 14px;
   font-weight: 500;
   line-height: ${CONTENT_HEIGHT}px;

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -122,7 +122,7 @@ export const OptionsDropdownUI = styled('div')`
   margin-bottom: 5px;
   background: white;
   font-size: 14px;
-  line-height: ${CONTENT_HEIGHT + TIGHTNESS}px;
+  line-height: ${CONTENT_HEIGHT}px;
   color: transparent;
 
   .is-active & {

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -8,8 +8,37 @@ import {
 } from '../EditableField.utils'
 
 const CLASSNAMES: any = getComponentClassNames(EF_I_COMPONENT_KEY)
-
 const CONTENT_HEIGHT = 25
+const COLOURS = {
+  static: {
+    border: getColor('charcoal.200'),
+    disabled: getColor('charcoal.300'),
+    focused: 'rgba(197, 208, 217, 0.5)',
+    regular: getColor('charcoal.800'),
+    placeholder: {
+      regular: getColor('charcoal.300'),
+      disabled: getColor('charcoal.200'),
+      border: {
+        regular: getColor('grey.800'),
+        hover: getColor('blue.500'),
+      },
+    },
+  },
+  interactive: {
+    regular: getColor('charcoal.800'),
+    placeholder: getColor('charcoal.300'),
+  },
+  focusIndicator: {
+    active: getColor('blue.500'),
+    inactive: '#c6d0d8',
+  },
+  invisible: 'transparent',
+  button: {
+    regular: 'slategray',
+    hover: '#3c5263',
+    delete: getColor('red.500'),
+  },
+}
 
 const resetHSAppInputRules = `
   border-radius: 0;
@@ -39,7 +68,7 @@ export const EditableFieldInputUI = styled('div')`
   }
 
   &:hover .${CLASSNAMES.staticOption}, &:hover .${CLASSNAMES.staticValue} {
-    border-bottom: 1px dashed ${getColor('charcoal.200')};
+    border-bottom: 1px dashed ${COLOURS.static.border};
   }
 
   &.is-active:hover .${CLASSNAMES.actions} {
@@ -48,7 +77,7 @@ export const EditableFieldInputUI = styled('div')`
   }
 
   &:hover .with-placeholder {
-    border-bottom: 1px dashed ${getColor('blue.500')};
+    border-bottom: 1px dashed ${COLOURS.static.placeholder.border.hover};
   }
 
   .is-disabled
@@ -57,7 +86,7 @@ export const EditableFieldInputUI = styled('div')`
     .is-disabled
     &:hover
     .${CLASSNAMES.staticValue} {
-    border-bottom: 1px solid transparent;
+    border-bottom: 1px solid ${COLOURS.invisible};
   }
 
   .is-temporary-value {
@@ -79,17 +108,17 @@ export const InteractiveContentUI = styled('div')`
   top: 0;
   left: 0;
   z-index: 1;
-  border-bottom: 1px solid transparent;
+  border-bottom: 1px solid ${COLOURS.invisible};
 
   .is-disabled &:hover {
     cursor: initial;
-    border-bottom: 1px solid transparent;
+    border-bottom: 1px solid ${COLOURS.invisible};
   }
 
   .is-active & {
     pointer-events: none;
     z-index: 2;
-    border-bottom-color: transparent !important;
+    border-bottom-color: ${COLOURS.invisible} !important;
   }
 `
 
@@ -146,7 +175,7 @@ export const OptionsDropdownUI = styled('div')`
   font-size: 14px;
   line-height: ${CONTENT_HEIGHT}px;
   height: ${CONTENT_HEIGHT - 2}px;
-  color: transparent;
+  color: ${COLOURS.invisible};
 
   .is-active & {
     color: ${getColor('charcoal.800')};
@@ -154,7 +183,7 @@ export const OptionsDropdownUI = styled('div')`
     & + .${CLASSNAMES.focusIndicator} {
       transform: scaleX(1);
       height: 1px;
-      background-color: #c6d0d8;
+      background-color: ${COLOURS.focusIndicator.inactive};
     }
   }
 
@@ -163,7 +192,7 @@ export const OptionsDropdownUI = styled('div')`
 
     & + .${CLASSNAMES.focusIndicator} {
       transform: scaleX(1);
-      background-color: ${getColor('blue.500')};
+      background-color: ${COLOURS.focusIndicator.active};
       height: 2px;
     }
   }
@@ -194,13 +223,13 @@ export const InputUI = styled('input')`
     line-height: ${CONTENT_HEIGHT}px;
     padding: 0;
     border: none;
-    color: transparent;
+    color: ${COLOURS.invisible};
     font-size: 14px;
     background: white;
     pointer-events: auto;
 
     &::placeholder {
-      color: transparent;
+      color: ${COLOURS.invisible};
     }
 
     .is-active &:focus {
@@ -208,14 +237,14 @@ export const InputUI = styled('input')`
 
       & + .${CLASSNAMES.focusIndicator} {
         transform: scaleX(1);
-        background-color: ${getColor('blue.500')} !important;
+        background-color: ${COLOURS.focusIndicator.active} !important;
         height: 2px;
       }
     }
 
     .is-active & {
       outline: none;
-      color: ${getColor('charcoal.800')};
+      color: ${COLOURS.interactive.regular};
       z-index: 2;
       cursor: initial;
 
@@ -226,7 +255,7 @@ export const InputUI = styled('input')`
       }
 
       &::placeholder {
-        color: ${getColor('charcoal.300')};
+        color: ${COLOURS.interactive.placeholder};
         opacity: 1;
       }
     }
@@ -278,14 +307,14 @@ export const StaticOptionUI = styled('span')`
   width: 70px;
   height: ${CONTENT_HEIGHT - 2}px;
   margin-right: 10px;
-  color: ${getColor('charcoal.800')};
+  color: ${COLOURS.static.regular};
   font-size: 14px;
   font-weight: 500;
   line-height: ${CONTENT_HEIGHT}px;
   z-index: 2;
   pointer-events: none;
   white-space: nowrap;
-  border-bottom: 1px solid transparent;
+  border-bottom: 1px solid ${COLOURS.invisible};
 
   .is-empty & {
     display: none;
@@ -297,16 +326,16 @@ export const StaticOptionUI = styled('span')`
   }
 
   & .is-placeholder {
-    color: ${getColor('charcoal.300')};
+    color: ${COLOURS.static.placeholder.regular};
   }
 
   .is-disabled & {
-    color: ${getColor('charcoal.300')};
+    color: ${COLOURS.static.disabled};
   }
 
   &:focus {
     outline: none;
-    border-bottom: 1px dashed #93a1b0;
+    border-bottom: 1px dashed ${COLOURS.static.focused};
   }
 `
 
@@ -317,12 +346,12 @@ export const StaticValueUI = styled('span')`
   line-height: ${CONTENT_HEIGHT}px;
   width: 100%;
   max-width: 100%;
-  color: ${getColor('charcoal.800')};
+  color: ${COLOURS.static.regular};
   font-size: 14px;
   z-index: 2;
   pointer-events: none;
   white-space: nowrap;
-  border-bottom: 1px solid transparent;
+  border-bottom: 1px solid ${COLOURS.invisible};
 
   .has-options & {
     width: calc(100% - 80px);
@@ -343,29 +372,29 @@ export const StaticValueUI = styled('span')`
 
   &.with-placeholder {
     width: auto;
-    border-bottom: 1px dashed ${getColor('grey.800')};
+    border-bottom: 1px dashed ${COLOURS.static.placeholder.border.regular};
   }
 
   & .is-placeholder {
-    color: ${getColor('charcoal.300')};
+    color: ${COLOURS.static.placeholder.regular};
   }
 
   .is-disabled &.with-placeholder {
-    border-bottom: 1px solid transparent;
+    border-bottom: 1px solid ${COLOURS.invisible};
   }
 
   .is-disabled & {
-    color: ${getColor('charcoal.300')};
+    color: ${COLOURS.static.disabled};
   }
 
   .is-disabled & .is-placeholder {
-    color: ${getColor('charcoal.200')};
+    color: ${COLOURS.static.placeholder.disabled};
   }
 
   &:focus {
     width: auto;
     outline: 0;
-    border-bottom: 1px dashed rgba(197, 208, 217, 0.5);
+    border-bottom: 1px dashed ${COLOURS.static.focused};
   }
 `
 
@@ -375,7 +404,7 @@ export const FocusIndicatorUI = styled('span')`
   left: 0;
   right: 0;
   height: 2px;
-  background-color: ${getColor('blue.500')};
+  background-color: ${COLOURS.focusIndicator.active};
   transform-origin: bottom left;
   transform: scaleX(0);
   transition: transform 0.3s ease, background-color 0.3s ease;
@@ -406,8 +435,8 @@ export const FieldButtonUI = styled('button')`
   padding: 0;
   margin: 0;
   border: none;
-  background-color: transparent;
-  color: slategray;
+  background-color: ${COLOURS.invisible};
+  color: ${COLOURS.button.regular};
   font-size: 12px;
   text-align: center;
   overflow: hidden;
@@ -415,7 +444,7 @@ export const FieldButtonUI = styled('button')`
   &:hover,
   &:focus {
     cursor: pointer;
-    color: #3c5263;
+    color: ${COLOURS.button.hover};
   }
 
   &:focus {
@@ -425,7 +454,7 @@ export const FieldButtonUI = styled('button')`
   &.action-delete {
     &:focus,
     &:hover {
-      color: ${getColor('red.500')};
+      color: ${COLOURS.button.delete};
     }
   }
 

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -51,7 +51,12 @@ export const EditableFieldInputUI = styled('div')`
     border-bottom: 1px dashed ${getColor('blue.500')};
   }
 
-  .is-disabled &:hover .with-placeholder {
+  .is-disabled
+    &:hover
+    .${CLASSNAMES.staticOption},
+    .is-disabled
+    &:hover
+    .${CLASSNAMES.staticValue} {
     border-bottom: 1px solid transparent;
   }
 
@@ -296,7 +301,7 @@ export const StaticOptionUI = styled('span')`
   }
 
   .is-disabled & {
-    color: ${getColor('charcoal.200')};
+    color: ${getColor('charcoal.300')};
   }
 
   &:focus {

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -122,7 +122,8 @@ export const OptionsDropdownUI = styled('div')`
   margin-bottom: 5px;
   background: white;
   font-size: 14px;
-  line-height: ${CONTENT_HEIGHT}px;
+  line-height: ${CONTENT_HEIGHT + 3}px;
+  height: ${CONTENT_HEIGHT}px;
   color: transparent;
 
   .is-active & {

--- a/src/components/EditableField/styles/EditableField.css.ts
+++ b/src/components/EditableField/styles/EditableField.css.ts
@@ -49,6 +49,12 @@ export const AddButtonUI = styled('button')`
     transform: translateZ(0);
   }
 
+  &:disabled {
+    cursor: not-allowed;
+    color: #c6d0d8;
+    background-color: #f6f7f8;
+  }
+
   .c-Icon {
     margin: 0 auto;
   }

--- a/src/components/EditableField/styles/EditableField.css.ts
+++ b/src/components/EditableField/styles/EditableField.css.ts
@@ -5,7 +5,7 @@ import { getColor } from '../../../styles/utilities/color'
 export const EditableFieldUI = styled('div')`
   ${baseStyles};
   position: relative;
-  margin-bottom: 20px;
+  margin-bottom: 40px;
 `
 
 export const EditableFieldLabelUI = styled('label')`
@@ -45,12 +45,11 @@ export const AddButtonUI = styled('button')`
     color: white;
     background-color: ${getColor('blue.500')};
     box-shadow: 0 0 0 1px white, 0 0 0 3px ${getColor('blue.400')};
-
     transform: translateZ(0);
   }
 
   &:disabled {
-    cursor: not-allowed;
+    cursor: default;
     color: #c6d0d8;
     background-color: #f6f7f8;
   }

--- a/src/components/EditableField/styles/EditableField.css.ts
+++ b/src/components/EditableField/styles/EditableField.css.ts
@@ -28,7 +28,7 @@ export const AddButtonUI = styled('button')`
   height: 20px;
   width: 20px;
   padding: 0;
-  margin: 10px 0 0 0;
+  margin: 8px 0 0 0;
   border: none;
   color: #c6d0d8;
   background-color: #f6f7f8;

--- a/stories/EditableField.stories.js
+++ b/stories/EditableField.stories.js
@@ -80,6 +80,7 @@ stories.add('Text Multiple', () => (
       label="Films"
       name="films"
       type="text"
+      multipleValues
       placeholder="Add a film name"
     />
     <EditableField


### PR DESCRIPTION
This PR is a quick follow to the just merged Editable Fields.

- [x] Render as block: adding a new item would not automatically focus the new field
- [x] Hover over the actions would not render the border on the field
- [x] Refactors and fixes `calculateWidth` for Fields of dynamic width
- [x] Tweaked actions interactive area
- [x] Fixes interactions with keyboard on multi value fields: escape and enter had a couple of buggy behaviours on different scenarios

### Revision July 22nd

- [x] Increased the Field margin bottom from 20 to 40px
- [x] Blank slate text color changed to "charcoal.300"
- [x] Placeholder text color changed to "charcoal.300"
- [x] Blank slate border color changed to "grey.800"
- [x] Border bottom on blank slate is the width of the text instead of full-width
- [x] Tighten the spacing between the content and the borders by 3px
- [x] Static Value color changed to "charcoal.800"
- [x] Adjusted icon sizes and types
- [x] Pushed delete icon all the way to the right
- [x] On fields with options, hovering static state, now there is a gap between the option and the value (same as the space on active state)
- [x] Hovering the option shows the caret cursor instead of pointer

### Revision July 23rd

- [x] Fixed the blur effect when selecting an option a second or third time
- [x] Added the not-allowed cursor on disabled fields
- [x] Refactored class names handling
- [x] Made the width of the dashed border on ENTER or ESCAPE the width of the text instead of full width
- [x] Shielded input styles from other globally applied rules
- [x] Decreased space between add button and fields

### Revision July 24nd
- [x] Uniformed colours for various states that had slight discrepancies
- [x] Extracted colours into constants
- [x] Removed border on hover when fields are disabled