### PR TITLE
Add a new prop to Chat to change the position of the meta block

### DIFF
--- a/src/components/Message/Message.Chat.tsx
+++ b/src/components/Message/Message.Chat.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { MessageBubble } from './Message.types'
 import Bubble from './Message.Bubble'
 import Caption from './Message.Caption'
-import ChatBlock from './Message.ChatBlock'
+import ChatBlock, { MetaPosition } from './Message.ChatBlock'
 import Flexy from '../Flexy'
 import Spinner from '../Spinner'
 import styled from '../styled'
@@ -19,6 +19,7 @@ type Props = MessageBubble & {
   errorMessage?: string
   error?: boolean | string
   isLoading?: boolean
+  metaPosition?: MetaPosition
   onBubbleClick: (event: Event) => void
 }
 
@@ -28,6 +29,7 @@ export class Chat extends React.PureComponent<Props> {
     error: false,
     errorMessage: "Couldn't send.",
     isLoading: false,
+    metaPosition: 'bottom',
   }
   static displayName = 'Message.Chat'
 
@@ -37,6 +39,7 @@ export class Chat extends React.PureComponent<Props> {
       bubbleClassName,
       caption,
       captionSize,
+      metaPosition,
       children,
       className,
       error,
@@ -112,6 +115,7 @@ export class Chat extends React.PureComponent<Props> {
       <ChatBlock
         className={componentClassName}
         meta={metaMarkup}
+        metaPosition={metaPosition}
         read={read}
         {...chatProps}
         {...rest}

--- a/src/components/Message/Message.ChatBlock.tsx
+++ b/src/components/Message/Message.ChatBlock.tsx
@@ -12,17 +12,25 @@ import { noop } from '../../utilities/other'
 import css from './styles/ChatBlock.css'
 import { COMPONENT_KEY } from './Message.utils'
 
+export type MetaPosition = 'top' | 'bottom'
+
 type Props = MessageChat & {
   body?: string
   children?: any
   icon?: string
   meta?: any
+  metaPosition?: string
 }
 
 export class ChatBlock extends React.PureComponent<Props> {
   static contextTypes = {
     theme: noop,
   }
+
+  static defaultProps = {
+    metaPosition: 'bottom',
+  }
+
   static displayName = 'Message.ChatBlock'
 
   getChildrenMarkup = () => {
@@ -64,6 +72,7 @@ export class ChatBlock extends React.PureComponent<Props> {
       isNote,
       ltr,
       meta,
+      metaPosition,
       read,
       rtl,
       timestamp,
@@ -87,6 +96,7 @@ export class ChatBlock extends React.PureComponent<Props> {
 
     return (
       <div {...getValidProps(rest)} className={componentClassName}>
+        {metaPosition !== 'bottom' && meta}
         <Flexy className="c-MessageChatBlock__flexy" gap="sm">
           {to && timestampMarkup}
           <Flexy.Item className="c-MessageChatBlock__block">
@@ -94,7 +104,7 @@ export class ChatBlock extends React.PureComponent<Props> {
           </Flexy.Item>
           {from && timestampMarkup}
         </Flexy>
-        {meta}
+        {metaPosition === 'bottom' && meta}
       </div>
     )
   }

--- a/src/components/Message/__tests__/Message.Chat.test.js
+++ b/src/components/Message/__tests__/Message.Chat.test.js
@@ -1,5 +1,7 @@
 import * as React from 'react'
+import cy from '@helpscout/cyan'
 import { mount } from 'enzyme'
+
 import Bubble from '../Message.Bubble'
 import ChatBlock from '../Message.ChatBlock'
 import Chat from '../Message.Chat'
@@ -187,5 +189,50 @@ describe('Loading', () => {
     expect(l.length).toBe(1)
     expect(c.length).toBe(1)
     expect(e.length).toBe(1)
+  })
+})
+
+describe('Meta', () => {
+  test('Renders meta', () => {
+    const wrapper = cy.render(<Chat caption="test" />)
+
+    expect(wrapper.get('.c-MessageChat__meta').exists()).toBeTruthy()
+    expect(wrapper.get('.c-MessageChat__meta').text()).toBe('test')
+  })
+
+  test('Renders meta before the bubble', () => {
+    const wrapper = cy.render(<Chat caption="test" metaPosition="top" />)
+
+    expect(
+      wrapper
+        .get('.c-MessageChatBlock')
+        .children()
+        .first()
+        .hasClassName('c-MessageChat__meta')
+    ).toBeTruthy()
+  })
+
+  test('Renders meta after bubble by default', () => {
+    const wrapper = cy.render(<Chat caption="test" />)
+
+    expect(
+      wrapper
+        .get('.c-MessageChatBlock')
+        .children()
+        .last()
+        .hasClassName('c-MessageChat__meta')
+    ).toBeTruthy()
+  })
+
+  test('Renders meta after bubble when passing random value', () => {
+    const wrapper = cy.render(<Chat caption="test" metaPostion="noclue" />)
+
+    expect(
+      wrapper
+        .get('.c-MessageChatBlock')
+        .children()
+        .last()
+        .hasClassName('c-MessageChat__meta')
+    ).toBeTruthy()
   })
 })

--- a/stories/Message/Message.Chat.stories.js
+++ b/stories/Message/Message.Chat.stories.js
@@ -61,6 +61,14 @@ stories.add('states', () => {
       <Message.Chat read timestamp="9:41am" error="Something went wrong!">
         Error state, with custom message.
       </Message.Chat>
+      <Message.Chat
+        read
+        timestamp="9:41am"
+        caption="Caption before the bubble"
+        metaPosition="top"
+      >
+        With custom message & meta positioned before the bubble
+      </Message.Chat>
     </Message>
   )
 })

--- a/stories/Message/Message.Chat.stories.js
+++ b/stories/Message/Message.Chat.stories.js
@@ -69,6 +69,22 @@ stories.add('states', () => {
       >
         With custom message & meta positioned before the bubble
       </Message.Chat>
+      <Message.Chat
+        read
+        timestamp="9:41am"
+        caption="Caption after the bubble"
+        metaPosition="bottom"
+      >
+        With custom message & meta positioned AFTER the bubble
+      </Message.Chat>
+      <Message.Chat
+        read
+        timestamp="9:41am"
+        caption="Caption before the bubble with jibberish metaPosition"
+        metaPosition="qwerty"
+      >
+        With custom message & meta positioned before the bubble with jibberish
+      </Message.Chat>
     </Message>
   )
 })


### PR DESCRIPTION
This update add a new prop to the `Chat` component called `metaPosition` to move the rendering of the meta block before or after the message bubble.

<img width="515" alt="Image 2019-07-19 at 4 50 26 PM" src="https://user-images.githubusercontent.com/203992/61564879-6b3aed00-aa45-11e9-8158-32908e2719b9.png">

Prop value can be either `bottom` or `top`