### PR TITLE
Editable Field Follow Up Fixes Part II

### DIFF
--- a/src/components/EditableField/EditableField.Input.tsx
+++ b/src/components/EditableField/EditableField.Input.tsx
@@ -436,12 +436,14 @@ export class EditableFieldInput extends React.Component<
   }
 
   renderStaticOption = () => {
-    const { fieldValue } = this.props
+    const { fieldValue, renderAsBlock, actions = [] } = this.props
 
     return (
       <StaticOptionUI
         className={CLASSNAMES.staticOption}
         innerRef={this.setStaticOptionNode}
+        numberOfActions={actions.length}
+        renderAsBlock={renderAsBlock}
       >
         <Truncate>{fieldValue.option}</Truncate>
       </StaticOptionUI>
@@ -482,7 +484,7 @@ export class EditableFieldInput extends React.Component<
 
   render() {
     const {
-      actions,
+      actions = [],
       disabled,
       emphasize,
       fieldValue,
@@ -547,6 +549,8 @@ export class EditableFieldInput extends React.Component<
             innerRef={this.setStaticValueNode}
             onBlur={this.handleStaticValueBlur}
             onKeyDown={this.handleStaticValueKeyDown}
+            numberOfActions={actions.length}
+            renderAsBlock={renderAsBlock}
           >
             {fieldValue.value ? (
               <Truncated

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -459,7 +459,7 @@ export class EditableField extends React.Component<
         onClick={this.handleAddValue}
         disabled={isLastValueEmpty}
       >
-        <Icon name={ACTION_ICONS.plus} size="20" />
+        <Icon name={ACTION_ICONS.plus} size="24" />
       </AddButtonUI>
     ) : null
   }

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -1,6 +1,7 @@
 import styled from '../../styled/index'
 import baseStyles from '../../../styles/resets/baseStyles.css'
 import { getColor } from '../../../styles/utilities/color'
+import { FONT_FAMILY } from '../../../styles/configs/constants'
 
 import {
   EF_I_COMPONENT_KEY,
@@ -176,6 +177,14 @@ export const OptionsDropdownUI = styled('div')`
   line-height: ${CONTENT_HEIGHT}px;
   height: ${CONTENT_HEIGHT - 2}px;
   color: ${COLOURS.invisible};
+  font-family: ${FONT_FAMILY};
+
+  &:hover .c-Icon {
+    color: ${getColor('charcoal.200')};
+  }
+  .is-active &:hover .c-Icon {
+    color: ${getColor('charcoal.800')};
+  }
 
   .is-active & {
     color: ${getColor('charcoal.800')};
@@ -294,9 +303,14 @@ export const StaticContentUI = styled('div')`
   z-index: 2;
   pointer-events: none;
   white-space: nowrap;
+  font-family: ${FONT_FAMILY};
 
   .is-active & {
     z-index: 1;
+  }
+
+  & .c-Truncate {
+    width: calc(100% - 20px);
   }
 `
 
@@ -336,6 +350,10 @@ export const StaticOptionUI = styled('span')`
   &:focus {
     outline: none;
     border-bottom: 1px dashed ${COLOURS.static.focused};
+  }
+
+  .c-Truncate {
+    width: 60px;
   }
 `
 

--- a/src/components/EditableField/styles/EditableField.Input.css.ts
+++ b/src/components/EditableField/styles/EditableField.Input.css.ts
@@ -308,10 +308,6 @@ export const StaticContentUI = styled('div')`
   .is-active & {
     z-index: 1;
   }
-
-  & .c-Truncate {
-    width: calc(100% - 20px);
-  }
 `
 
 export const StaticOptionUI = styled('span')`
@@ -407,6 +403,11 @@ export const StaticValueUI = styled('span')`
 
   .is-disabled & .is-placeholder {
     color: ${COLOURS.static.placeholder.disabled};
+  }
+
+  .c-Truncate {
+    width: ${({ renderAsBlock, numberOfActions }) =>
+      renderAsBlock ? `calc(100% - ${numberOfActions * 20}px)` : '100%'};
   }
 
   &:focus {

--- a/src/components/EditableField/styles/EditableField.css.ts
+++ b/src/components/EditableField/styles/EditableField.css.ts
@@ -55,7 +55,9 @@ export const AddButtonUI = styled('button')`
   }
 
   .c-Icon {
-    margin: 0 auto;
+    position: relative;
+    left: -2px;
+    top: -2px;
   }
 
   &::-moz-focus-inner {

--- a/src/components/Page/styles/Page.Card.css.ts
+++ b/src/components/Page/styles/Page.Card.css.ts
@@ -7,14 +7,14 @@ import PageConfig from './Page.config.css'
 export const config = {
   borderRadius: '4px',
   boxShadow: `
-    0px 0px 0px 1px rgba(0, 0, 0, 0.05),
-    0px 5px 10px 0px ${getColor('grey.300')},
-    0px 3px 3px 0px rgba(0, 0, 0, 0.05)
+    0 0 0 1px rgba(0, 0, 0, 0.04), 
+    0 2px 8px 0 rgba(0,0,0,0.04), 
+    0 5px 10px 0 rgba(99, 116, 134, 0.03)
   `,
   boxShadowHover: `
-    0px 0px 0px 1px ${getColor('grey.500')},
-    0px 5px 10px 1px ${getColor('grey.300')},
-    0px 3px 3px 0px rgba(0, 0, 0, 0.05)
+    rgb(214, 221, 227) 0px 0px 0px 1px, 
+    0 2px 8px 0 rgba(0,0,0,0.04), 
+    0 5px 10px 0 rgba(99, 116, 134, 0.03)
   `,
   flexDirection: {
     default: 'column',

--- a/stories/EditableField.stories.js
+++ b/stories/EditableField.stories.js
@@ -8,6 +8,7 @@ import { jsxDecorator } from 'storybook-addon-jsx'
 
 import styled from '../src/components/styled'
 import baseStyles from '../src/styles/resets/baseStyles.css'
+import { withAktiv } from './utils'
 
 const stories = storiesOf('EditableField', module)
   .addParameters({
@@ -15,6 +16,7 @@ const stories = storiesOf('EditableField', module)
     readme: { sidebar: ReadMe },
     a11y: { element: 'c-EditableField' },
   })
+  .addDecorator(withAktiv)
   .addDecorator(jsxDecorator)
 
 const ContainerUI = styled('div')`


### PR DESCRIPTION
This update add some small improvements to the `<EditableField />` component.

**Increase the size of the + icon**
<img width="144" alt="Image 2019-07-26 at 1 56 22 PM" src="https://user-images.githubusercontent.com/203992/61971476-2ebf4200-afad-11e9-9ee1-9a98647e74d0.png">

**Add padding to the delete/clear icon**
<img width="281" alt="Image 2019-07-26 at 1 57 11 PM" src="https://user-images.githubusercontent.com/203992/61971526-4696c600-afad-11e9-9800-4c59ee6c8dfa.png">

**Show caret on hover**
![Screen Recording 2019-07-26 at 01 57 PM](https://user-images.githubusercontent.com/203992/61971561-60380d80-afad-11e9-92d2-a2cb6c6aec13.gif)

**System font on all static content to match inputs**
![Screen Recording 2019-07-26 at 01 58 PM](https://user-images.githubusercontent.com/203992/61971606-8067cc80-afad-11e9-9943-8b2a9d4e5cef.gif)

**Update the Page.Card shadow**
_Not part of the EditableField component, but I squeeze that in_
![Screen Recording 2019-07-26 at 01 59 PM](https://user-images.githubusercontent.com/203992/61971659-9d9c9b00-afad-11e9-8401-618f2abe3c62.gif)
