### PR TITLE
Add char validator to text inputs

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -146,8 +146,8 @@ export class Input extends React.PureComponent<InputProps, InputState> {
     const { inputType, charValidatorLimit, withCharValidator } = this.props
     let nextValue = value
 
-    if (withCharValidator && nextValue.length > charValidatorLimit) {
-      nextValue = nextValue.substring(0, charValidatorLimit)
+    if (withCharValidator && nextValue.length > charValidatorLimit + 1) {
+      nextValue = nextValue.substring(0, charValidatorLimit + 1)
     }
 
     if (inputType === 'number') {
@@ -563,9 +563,9 @@ export class Input extends React.PureComponent<InputProps, InputState> {
     } = this.state
     const isVisible =
       charValidatorShowAt === 0 || (count > 0 && count >= charValidatorShowAt)
-    const currentCount = charValidatorLimit - count
-    const isTooMuch = count !== 0 && count >= charValidatorLimit
     if (!isVisible) return null
+    const currentCount = charValidatorLimit - count
+    const isTooMuch = count !== 0 && count >= charValidatorLimit + 1
     return (
       <CharValidatorUI>
         <Badge

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -146,8 +146,8 @@ export class Input extends React.PureComponent<InputProps, InputState> {
     const { inputType, charValidatorLimit, withCharValidator } = this.props
     let nextValue = value
 
-    if (withCharValidator && nextValue.length > charValidatorLimit + 1) {
-      nextValue = nextValue.substring(0, charValidatorLimit + 1)
+    if (withCharValidator && nextValue.length > charValidatorLimit) {
+      nextValue = nextValue.substring(0, charValidatorLimit)
     }
 
     if (inputType === 'number') {
@@ -565,7 +565,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
       charValidatorShowAt === 0 || (count > 0 && count >= charValidatorShowAt)
     if (!isVisible) return null
     const currentCount = charValidatorLimit - count
-    const isTooMuch = count !== 0 && count >= charValidatorLimit + 1
+    const isTooMuch = count !== 0 && count >= charValidatorLimit
     return (
       <CharValidatorUI>
         <Badge

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,5 +1,6 @@
 /* eslint react/no-deprecated: off */
 import * as React from 'react'
+import Animate from '../Animate'
 import Badge from '../Badge'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import FormLabelContext from '../FormLabel/Context'
@@ -563,17 +564,25 @@ export class Input extends React.PureComponent<InputProps, InputState> {
     } = this.state
     const isVisible =
       charValidatorShowAt === 0 || (count > 0 && count >= charValidatorShowAt)
-    if (!isVisible) return null
     const currentCount = charValidatorLimit - count
     const isTooMuch = count !== 0 && count >= charValidatorLimit
     return (
       <CharValidatorUI>
-        <Badge
-          status={isTooMuch ? 'error' : 'success'}
-          style={{ fontWeight: 100 }}
+        <Animate
+          animateOnMount={true}
+          duration={250}
+          easing="bounce"
+          in={isVisible}
+          sequence="fade"
+          unmountOnExit
         >
-          {count} / {charValidatorLimit}
-        </Badge>
+          <Badge
+            status={isTooMuch ? 'error' : 'success'}
+            style={{ fontWeight: 100 }}
+          >
+            {count} / {charValidatorLimit}
+          </Badge>
+        </Animate>
       </CharValidatorUI>
     )
   }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -553,12 +553,8 @@ export class Input extends React.PureComponent<InputProps, InputState> {
   }
 
   getCharValidatorMarkup() {
-    const {
-      withCharValidator,
-      charValidatorLimit,
-      charValidatorShowAt,
-    } = this.props
-    if (!withCharValidator) return null
+    if (!this.props.withCharValidator) return null
+    const { charValidatorLimit, charValidatorShowAt } = this.props
     const {
       value: { length: count },
     } = this.state

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,5 +1,6 @@
 /* eslint react/no-deprecated: off */
 import * as React from 'react'
+import Badge from '../Badge'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import FormLabelContext from '../FormLabel/Context'
 import AddOn from './Input.AddOn'
@@ -29,6 +30,7 @@ import {
   isTextArea,
 } from './Input.utils'
 import {
+  CharValidatorUI,
   InputWrapperUI,
   InlinePrefixSuffixUI,
   FieldUI,
@@ -42,6 +44,8 @@ const uniqueID = createUniqueIDFactory('Input')
 export class Input extends React.PureComponent<InputProps, InputState> {
   static defaultProps = {
     autoFocus: false,
+    charValidatorShowAt: 0,
+    charValidatorLimit: 500,
     disabled: false,
     errorIcon: 'alert',
     forceAutoFocusTimeout: 0,
@@ -80,6 +84,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
     typingThrottleInterval: 500,
     typingTimeoutDelay: 5000,
     value: '',
+    withCharValidator: false,
     withTypingEvent: false,
   }
 
@@ -138,8 +143,12 @@ export class Input extends React.PureComponent<InputProps, InputState> {
   }
 
   setValue = value => {
-    const { inputType } = this.props
+    const { inputType, charValidatorLimit, withCharValidator } = this.props
     let nextValue = value
+
+    if (withCharValidator && nextValue.length > charValidatorLimit) {
+      nextValue = nextValue.substring(0, charValidatorLimit)
+    }
 
     if (inputType === 'number') {
       nextValue = value.replace(/\D/g, '')
@@ -542,6 +551,33 @@ export class Input extends React.PureComponent<InputProps, InputState> {
     return typeof multiline === 'number' ? multiline : 1
   }
 
+  getCharValidatorMarkup() {
+    const {
+      withCharValidator,
+      charValidatorLimit,
+      charValidatorShowAt,
+    } = this.props
+    if (!withCharValidator) return null
+    const {
+      value: { length: count },
+    } = this.state
+    const isVisible =
+      charValidatorShowAt === 0 || (count > 0 && count >= charValidatorShowAt)
+    const currentCount = charValidatorLimit - count
+    const isTooMuch = count !== 0 && count >= charValidatorLimit
+    if (!isVisible) return null
+    return (
+      <CharValidatorUI>
+        <Badge
+          status={isTooMuch ? 'error' : 'success'}
+          style={{ fontWeight: 100 }}
+        >
+          {count} / {charValidatorLimit}
+        </Badge>
+      </CharValidatorUI>
+    )
+  }
+
   getResizerMarkup() {
     const { multiline, offsetAmount, seamless } = this.props
 
@@ -732,6 +768,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
               />
               {this.getResizerMarkup()}
             </InputUI>
+            {this.getCharValidatorMarkup()}
             {this.getHintTextMarkup()}
           </InputWrapperUI>
         )}

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -26,6 +26,8 @@ export type InputValue = string
 export type InputProps = {
   action?: any
   autoFocus: boolean
+  charValidatorLimit: number
+  charValidatorShowAt: number
   className: string
   disabled: boolean
   errorIcon?: string
@@ -81,7 +83,8 @@ export type InputProps = {
   typingTimeoutDelay: number
   value: InputValue
   width: string | number
-  withTypingEvent: false
+  withCharValidator: boolean
+  withTypingEvent: boolean
 }
 
 export type InputState = {

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -54,6 +54,8 @@ Note: Be sure the version for `Button` is at least version 2.
 | ------------------------ | -------------------------- | -------------------------------------------------------------------------- |
 | action                   | `React.Component`          | Embedded actions for the Input.                                            |
 | autoFocus                | `boolean`                  | Automatically focuses the input.                                           |
+| charValidatorLimit       | `number`                   | How many chars are allowed to be input.                                    |
+| charValidatorShowAt      | `boolean`                  | At how many chars input should the charValidator be shown.                 |
 | className                | `string`                   | Custom class names to be added to the component.                           |
 | disabled                 | `boolean`                  | Disable the input.                                                         |
 | errorIcon                | `string`                   | Icon that renders when the state is `error`.                               |
@@ -99,6 +101,7 @@ Note: Be sure the version for `Button` is at least version 2.
 | typingThrottleInterval   | `number`                   | Determines the rate limiting interval for firing `onStartTyping`.          |
 | typingTimeoutDelay       | `number`                   | Determines the delay of when `onStopTyping` fires after typing stops.      |
 | value                    | `string`                   | Initial value of the input.                                                |
+| withCharValidator        | `boolean`                  | Adds a char validator UI to the input.                                     |
 | withTypingEvent          | `boolean`                  | Enables typing `onStartTyping` and `onStopTyping` event callbacks.         |
 
 ### States

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -55,7 +55,7 @@ Note: Be sure the version for `Button` is at least version 2.
 | action                   | `React.Component`          | Embedded actions for the Input.                                            |
 | autoFocus                | `boolean`                  | Automatically focuses the input.                                           |
 | charValidatorLimit       | `number`                   | How many chars are allowed to be input.                                    |
-| charValidatorShowAt      | `boolean`                  | At how many chars input should the charValidator be shown.                 |
+| charValidatorShowAt      | `number`                   | At how many chars input should the charValidator be shown.                 |
 | className                | `string`                   | Custom class names to be added to the component.                           |
 | disabled                 | `boolean`                  | Disable the input.                                                         |
 | errorIcon                | `string`                   | Icon that renders when the state is `error`.                               |

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -1126,7 +1126,7 @@ describe('inputType', () => {
   })
 })
 
-describe.only('charValidator', () => {
+describe('charValidator', () => {
   test('it should render charValidator', () => {
     const wrapper = mount(<Input withCharValidator={true} />)
     expect(wrapper.find(Badge).length).toEqual(1)

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -3,6 +3,8 @@ import { cy } from '@helpscout/cyan'
 import { mount, shallow, render } from 'enzyme'
 import Input from '../Input'
 import Resizer from '../Input.Resizer'
+import Badge from '../../Badge'
+import { CharValidatorUI } from '../styles/Input.css'
 
 jest.useFakeTimers()
 
@@ -1121,5 +1123,54 @@ describe('inputType', () => {
 
     expect(el.attr('value')).toBe('123')
     expect(spy).toHaveBeenCalledWith('123')
+  })
+})
+
+describe.only('charValidator', () => {
+  test('it should render charValidator', () => {
+    const wrapper = mount(<Input withCharValidator={true} />)
+    expect(wrapper.find(Badge).length).toEqual(1)
+    expect(wrapper.find(CharValidatorUI).length).toEqual(1)
+  })
+  test('it should not render charValidator', () => {
+    const wrapper = mount(<Input />)
+    expect(wrapper.find(CharValidatorUI).length).toEqual(0)
+  })
+  test('it should not render charValidator, because showAt has not been reached', () => {
+    const wrapper = mount(
+      <Input
+        withCharValidator={true}
+        charValidatorShowAt={9}
+        value="12345678"
+      />
+    )
+    expect(wrapper.find(CharValidatorUI).length).toEqual(0)
+    expect(wrapper.find(Badge).length).toEqual(0)
+  })
+  test('it should render charValidator success', () => {
+    const wrapper = mount(
+      <Input
+        withCharValidator={true}
+        charValidatorShowAt={4}
+        charValidatorLimit={9}
+        value="12345678"
+      />
+    )
+    expect(wrapper.find(CharValidatorUI).length).toEqual(1)
+    const badge = wrapper.find(Badge)
+    expect(badge.props().status).toEqual('success')
+  })
+  test('it should render charValidator error', () => {
+    const wrapper = mount(
+      <Input
+        withCharValidator={true}
+        charValidatorShowAt={4}
+        charValidatorLimit={7}
+        value="12345678"
+      />
+    )
+    expect(wrapper.find(CharValidatorUI).length).toEqual(1)
+    const badge = wrapper.find(Badge)
+    expect(badge.props().status).toEqual('error')
   })
 })

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -4,6 +4,7 @@ import { mount, shallow, render } from 'enzyme'
 import Input from '../Input'
 import Resizer from '../Input.Resizer'
 import Badge from '../../Badge'
+import Animate from '../../Animate'
 import { CharValidatorUI } from '../styles/Input.css'
 
 jest.useFakeTimers()
@@ -1144,8 +1145,10 @@ describe('charValidator', () => {
         value="12345678"
       />
     )
-    expect(wrapper.find(CharValidatorUI).length).toEqual(0)
-    expect(wrapper.find(Badge).length).toEqual(0)
+    expect(wrapper.find(CharValidatorUI).length).toEqual(1)
+    const component = wrapper.find(Animate)
+    expect(component.props().in).toEqual(false)
+    expect(component.length).toEqual(1)
   })
   test('it should render charValidator success', () => {
     const wrapper = mount(
@@ -1153,12 +1156,13 @@ describe('charValidator', () => {
         withCharValidator={true}
         charValidatorShowAt={4}
         charValidatorLimit={9}
-        value="12345678"
+        value="1234567"
       />
     )
     expect(wrapper.find(CharValidatorUI).length).toEqual(1)
-    const badge = wrapper.find(Badge)
-    expect(badge.props().status).toEqual('success')
+    const component = wrapper.find(Animate)
+    expect(component.props().in).toEqual(true)
+    expect(component.length).toEqual(1)
   })
   test('it should render charValidator error', () => {
     const wrapper = mount(
@@ -1172,5 +1176,20 @@ describe('charValidator', () => {
     expect(wrapper.find(CharValidatorUI).length).toEqual(1)
     const badge = wrapper.find(Badge)
     expect(badge.props().status).toEqual('error')
+  })
+  test('it should trim the text', () => {
+    const wrapper = shallow(
+      <Input
+        withCharValidator={true}
+        charValidatorShowAt={4}
+        charValidatorLimit={7}
+        value=""
+      />
+    )
+    const result = wrapper
+      .instance()
+      .setValue('A very long string that should get trimmed')
+    expect(result).toEqual('A very ')
+    expect(result.length).toEqual(7)
   })
 })

--- a/src/components/Input/styles/Input.css.js
+++ b/src/components/Input/styles/Input.css.js
@@ -109,6 +109,14 @@ export const SuffixUI = styled(ItemUI)`
   }
 `
 
+export const CharValidatorUI = styled('div')`
+  margin-right: 15px;
+  bottom: 11px;
+  position: relative;
+  text-align: right;
+  z-index: 3;
+`
+
 export const InlinePrefixSuffixUI = styled('div')`
   ${baseStyles};
   opacity: 0.3;

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -115,29 +115,20 @@ stories.add('multiline + char validation', () => (
     <Input
       autoFocus
       multiline={3}
-      placeholder="This is a textarea!"
-      onResize={() => console.log('Resize')}
+      placeholder="Show at 0!"
       withCharValidator={true}
       charValidatorLimit={100}
       charValidatorShowAt={0}
+      resizable
     />
     <Input
       autoFocus
       multiline={3}
-      placeholder="This is a textarea!"
-      onResize={() => console.log('Resize')}
+      placeholder="Show at 20!"
       withCharValidator={true}
       charValidatorLimit={100}
-      charValidatorShowAt={5}
-    />
-    <Input
-      autoFocus
-      multiline={3}
-      placeholder="This is a textarea!"
-      onResize={() => console.log('Resize')}
-      withCharValidator={true}
-      charValidatorLimit={500}
-      charValidatorShowAt={250}
+      charValidatorShowAt={20}
+      resizable
     />
   </div>
 ))

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -127,7 +127,7 @@ stories.add('multiline + char validation', () => (
       placeholder="Show at 20!"
       withCharValidator={true}
       charValidatorLimit={100}
-      charValidatorShowAt={20}
+      charValidatorShowAt={5}
       resizable
     />
   </div>

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -110,6 +110,38 @@ stories.add('multiline', () => (
   </div>
 ))
 
+stories.add('multiline + char validation', () => (
+  <div>
+    <Input
+      autoFocus
+      multiline={3}
+      placeholder="This is a textarea!"
+      onResize={() => console.log('Resize')}
+      withCharValidator={true}
+      charValidatorLimit={100}
+      charValidatorShowAt={0}
+    />
+    <Input
+      autoFocus
+      multiline={3}
+      placeholder="This is a textarea!"
+      onResize={() => console.log('Resize')}
+      withCharValidator={true}
+      charValidatorLimit={100}
+      charValidatorShowAt={5}
+    />
+    <Input
+      autoFocus
+      multiline={3}
+      placeholder="This is a textarea!"
+      onResize={() => console.log('Resize')}
+      withCharValidator={true}
+      charValidatorLimit={500}
+      charValidatorShowAt={250}
+    />
+  </div>
+))
+
 stories.add('multiline + resizable', () => (
   <Input
     multiline={3}


### PR DESCRIPTION
https://trello.com/c/xfyBplpT/261-content-screen-tweak-error-verbiage-when-over-character-count

This adds a `charValidator` to the Input component.

![Screen Recording 2019-07-29 at 04 38 pm](https://user-images.githubusercontent.com/1704626/62084669-6f25f680-b21f-11e9-9d2b-03854f308a51.gif)

We added 3 props to the input:
- withCharValidator (a clause so that we can block from default input)
- charValidatorShowAt (determines when the charValidator becomes visible)
- charValidatorLimit (how many chars are allowed in the input)

cc: @digitaldesigner 