### PR TITLE
Fix remaining pill issues

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -581,7 +581,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
         >
           <Badge
             status={isTooMuch ? 'error' : 'success'}
-            style={{ fontWeight: 100 }}
+            style={{ fontWeight: 100, minWidth: 75 }}
           >
             {this.state.charValidatorText}
           </Badge>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -772,8 +772,8 @@ export class Input extends React.PureComponent<InputProps, InputState> {
                 state={state}
               />
               {this.getResizerMarkup()}
+              {this.getCharValidatorMarkup()}
             </InputUI>
-            {this.getCharValidatorMarkup()}
             {this.getHintTextMarkup()}
           </InputWrapperUI>
         )}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -562,6 +562,13 @@ export class Input extends React.PureComponent<InputProps, InputState> {
       charValidatorShowAt === 0 || (count > 0 && count >= charValidatorShowAt)
     const currentCount = charValidatorLimit - count
     const isTooMuch = count !== 0 && count >= charValidatorLimit
+
+    if (isVisible) {
+      this.setState({
+        charValidatorText: `${count} / ${charValidatorLimit}`,
+      })
+    }
+
     return (
       <CharValidatorUI>
         <Animate
@@ -576,7 +583,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
             status={isTooMuch ? 'error' : 'success'}
             style={{ fontWeight: 100 }}
           >
-            {count} / {charValidatorLimit}
+            {this.state.charValidatorText}
           </Badge>
         </Animate>
       </CharValidatorUI>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -103,6 +103,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
     super(props)
 
     this.state = {
+      charValidatorText: '',
       id: props.id || uniqueID(),
       isFocused: props.isFocused,
       state: props.state,

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -92,6 +92,7 @@ export type InputState = {
   isFocused: boolean
   height?: number
   state?: UIState
+  charValidatorText: string
   typingThrottle: number | undefined
   typingTimeout: number | undefined
   value: InputValue

--- a/src/components/Input/styles/Input.css.js
+++ b/src/components/Input/styles/Input.css.js
@@ -110,9 +110,9 @@ export const SuffixUI = styled(ItemUI)`
 `
 
 export const CharValidatorUI = styled('div')`
-  margin-right: 15px;
-  bottom: 11px;
-  position: relative;
+  right: 15px;
+  bottom: -7px;
+  position: absolute;
   text-align: right;
   z-index: 3;
 `

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -124,10 +124,19 @@ stories.add('multiline + char validation', () => (
     <Input
       autoFocus
       multiline={3}
-      placeholder="Show at 20!"
+      placeholder="Show at 5!"
       withCharValidator={true}
       charValidatorLimit={100}
       charValidatorShowAt={5}
+      resizable
+    />
+    <Input
+      autoFocus
+      multiline={3}
+      placeholder="Show at 250"
+      withCharValidator={true}
+      charValidatorLimit={500}
+      charValidatorShowAt={250}
       resizable
     />
   </div>

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -121,6 +121,7 @@ stories.add('multiline + char validation', () => (
       charValidatorShowAt={0}
       resizable
     />
+    <br />
     <Input
       autoFocus
       multiline={3}
@@ -130,6 +131,7 @@ stories.add('multiline + char validation', () => (
       charValidatorShowAt={5}
       resizable
     />
+    <br />
     <Input
       autoFocus
       multiline={3}


### PR DESCRIPTION
After @tjbo expertly created and implemented the pill for character counting on Form Inputs, we noticed a few issues to address in this follow up.

1. When the pill appears, all the content below is pushed down: http://c.hlp.sc/281f55b675ca
2. When the pill first appears, there's a staggered effect: http://c.hlp.sc/04b2ad07a850
3. When reducing the character count to less than 250, the new count is briefly shown before the pill disappears. The pill should just disappear without displaying the new count: http://c.hlp.sc/281f55b675ca

To address 1) @ryan-mulrooney moved the pill `div` inside the InputUI component, and then `position: absolute`
2) and 3) is @tjbo's bag :)