### PR TITLE
Fixes the IntersectionObserver guard for Safari 10, others

### DIFF
--- a/src/components/Page/Page.StickyActions.tsx
+++ b/src/components/Page/Page.StickyActions.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { StickyActionsUI } from './styles/Page.StickyActions.css'
 import { PageStickyActionsProps, PageStickyActionsState } from './Page.types'
 import { noop } from '../../utilities/other'
+import { isIntersectionObserverSupported } from './Page.utils'
 
 class StickyActions extends React.PureComponent<
   PageStickyActionsProps,
@@ -33,7 +34,7 @@ class StickyActions extends React.PureComponent<
 
   observerStart() {
     /* istanbul ignore next */
-    if (!IntersectionObserver) return
+    if (!isIntersectionObserverSupported()) return
 
     const { offset } = this.props
     const observerOptions = {
@@ -50,7 +51,7 @@ class StickyActions extends React.PureComponent<
 
   observerStop() {
     /* istanbul ignore next */
-    if (!IntersectionObserver) return
+    if (!isIntersectionObserverSupported()) return
 
     this.observer.unobserve(this.node)
     this.observer.disconnect()

--- a/src/components/Page/Page.utils.ts
+++ b/src/components/Page/Page.utils.ts
@@ -7,3 +7,12 @@ export const COMPONENT_KEY = {
   Heading: 'PageHeading',
   Section: 'PageSection',
 }
+
+export function isIntersectionObserverSupported() {
+  /* istanbul ignore next */
+  if (typeof window === 'object' && 'IntersectionObserver' in window) {
+    return true
+  }
+  /* istanbul ignore next */
+  return false
+}


### PR DESCRIPTION
The current "guard" to check if `IntersectionObserver` is present is brittle and does not work in all browsers (Safari 10).

This PR adds a proper check and has been tested on Safari 10

![Screenshot](http://c.hlp.sc/e3bb3772460d/Dashboard%202019-08-02%2012-43-39.png)