### PR TITLE
Wrap words in MessageCard

### DIFF
--- a/src/components/MessageCard/styles/MessageCard.css.ts
+++ b/src/components/MessageCard/styles/MessageCard.css.ts
@@ -16,6 +16,7 @@ export const MessageCardUI = styled(Card)`
   border-radius: 8px;
   padding: 20px 20px 25px;
   width: 300px;
+  word-break: break-word;
 
   &.is-align-right {
     border-bottom-right-radius: 4px;


### PR DESCRIPTION
Pretty simple... 

The title, subtitle, and message body all overlapped the containing div if a long word was typed (German word, for example): https://trello.com/c/ivQZjg0M/275-demo-message-in-builder-long-strings-overlap

I just made word wrapping a thing throughout the MessageCard to apply to all elements.