### PR TITLE
Truncated Button text

### DIFF
--- a/src/components/MessageCard/styles/MessageCard.css.ts
+++ b/src/components/MessageCard/styles/MessageCard.css.ts
@@ -55,4 +55,5 @@ export const ActionUI = styled('div')`
 
 export const ActionButtonUI = styled(Button)`
   ${setFontSize(14)};
+  line-height: normal !important;
 `


### PR DESCRIPTION
https://helpscout.atlassian.net/browse/COMMS-206

Descenders are being cropped when Truncate is nested within a Button. The default `line-height: normal` is being overwritten with `line-height: 1`.

I just changed the style back to `line-height: normal` for the MessageCard button in case `line-height:1` is required elsewhere for other buttons.