### PR TITLE
Fix: Inline FilteredList

### DIFF
--- a/src/components/FilteredList/FilteredList.tsx
+++ b/src/components/FilteredList/FilteredList.tsx
@@ -100,7 +100,7 @@ export class FilteredList extends React.Component<Props> {
     const isListFiltered = limit && items.length > limit
 
     return itemsList.map((item, index) => {
-      const isLastItem = index + 1 >= limit
+      const isLastItem = index + 1 >= itemsList.length
       const isBadgeVisible = isListFiltered && isLastItem
       const isSeparatorVisible = !isLastItem && inline
       const value = this.getItemValue(item)

--- a/src/components/FilteredList/__tests__/FilteredList.test.js
+++ b/src/components/FilteredList/__tests__/FilteredList.test.js
@@ -66,6 +66,12 @@ describe('Inlined', () => {
 
     expect(wrapper.find(SeparatorUI).length).toBeTruthy()
   })
+
+  it('Does not render separator when length of list is exceeded', () => {
+    const items = ['test@test.com']
+    const wrapper = mount(<FilteredList inline items={items} limit={3} />)
+    expect(wrapper.find(SeparatorUI).length).toEqual(0)
+  })
 })
 
 describe('Badge', () => {

--- a/stories/FilteredList.stories.js
+++ b/stories/FilteredList.stories.js
@@ -23,6 +23,12 @@ stories.add('with Limit', () => (
 stories.add('inline', () => (
   <FilteredList items={items} limit={number('limit', 2)} inline />
 ))
+stories.add('inline (multiple)', () => (
+  <FilteredList items={items.slice(0, 2)} inline />
+))
+stories.add('inline (single)', () => (
+  <FilteredList items={items.slice(0, 1)} inline />
+))
 
 stories.add('custom renderer', () => {
   const items = [


### PR DESCRIPTION
This update fixes a bug in the inline version of the FilteredList component. If the length of the number of items to be rendered was less than n-1 then the separator would be rendered after every item in the list, including the last item.

![Example](http://c.hlp.sc/11802cf55621/Image%2525202019-08-20%252520at%2525205.49.44%252520PM.png)

The reason why was the original logic determined if we were on the last item by checking if the next item was after the limit. However, in the case where we have, for example 1 item and a limit of 3, when on the first item the next item would not exceed the limit according to this logic. That meant the separator would be rendered even though nothing was to follow.

This update changes the logic to determine if we are on the last item by checking if the next item exceeds the length of the list of items to be rendered.

![Solution](http://c.hlp.sc/0b6631e937df/Image%2525202019-08-20%252520at%2525205.51.19%252520PM.png)