### PR TITLE
Add Avatar action overlay

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -18,6 +18,8 @@ import {
   StatusUI,
   TitleUI,
   ActionUI,
+  AvatarButtonUI,
+  FocusUI,
 } from './styles/Avatar.css'
 import {
   COMPONENT_KEY,
@@ -60,7 +62,7 @@ export interface State {
 
 export class Avatar extends React.PureComponent<Props, State> {
   static defaultProps = {
-    actionable: true,
+    actionable: false,
     actionIcon: 'trash',
     actionIconSize: '24',
     animationDuration: 160,
@@ -116,7 +118,7 @@ export class Avatar extends React.PureComponent<Props, State> {
   }
 
   renderAction() {
-    const { actionable, actionIcon, actionIconSize, onActionClick } = this.props
+    const { actionable, actionIcon, actionIconSize } = this.props
 
     if (!actionable) {
       return null
@@ -128,11 +130,7 @@ export class Avatar extends React.PureComponent<Props, State> {
     )
 
     return (
-      <ActionUI
-        data-cy="Avatar.Action"
-        className={actionClassName}
-        onClick={onActionClick}
-      >
+      <ActionUI data-cy="Avatar.Action" className={actionClassName}>
         <Icon name={actionIcon} size={actionIconSize} />
       </ActionUI>
     )
@@ -228,11 +226,9 @@ export class Avatar extends React.PureComponent<Props, State> {
       shape && `is-${shape}`
     )
 
-    const styles = {
-      borderColor,
-    }
-
-    return <CropBorderUI className={componentClassName} style={styles} />
+    return (
+      <CropBorderUI className={componentClassName} borderColor={borderColor} />
+    )
   }
 
   renderOuterBorder = () => {
@@ -242,11 +238,24 @@ export class Avatar extends React.PureComponent<Props, State> {
       shape && `is-${shape}`
     )
 
-    const styles = {
-      borderColor: outerBorderColor,
-    }
+    return (
+      <OuterBorderUI
+        className={componentClassName}
+        borderColor={outerBorderColor}
+      />
+    )
+  }
 
-    return <OuterBorderUI className={componentClassName} style={styles} />
+  renderFocusBorder = () => {
+    const { shape } = this.props
+    const componentClassName = classNames(
+      'c-Avatar__focusBorder',
+      shape && `is-${shape}`
+    )
+
+    return (
+      <FocusUI data-cy="Avatar.FocusBorder" className={componentClassName} />
+    )
   }
 
   getStyles() {
@@ -263,6 +272,7 @@ export class Avatar extends React.PureComponent<Props, State> {
 
   render() {
     const {
+      actionable,
       borderColor,
       className,
       count,
@@ -279,6 +289,7 @@ export class Avatar extends React.PureComponent<Props, State> {
       statusIcon,
       withShadow,
       fallbackImage,
+      onActionClick,
       ...rest
     } = this.props
 
@@ -292,22 +303,30 @@ export class Avatar extends React.PureComponent<Props, State> {
       light && 'is-light',
       outerBorderColor && 'has-outerBorderColor',
       status && `is-${status}`,
+      actionable && `has-action`,
       this.getShapeClassNames(),
       className
     )
 
+    const Component = actionable ? AvatarButtonUI : AvatarUI
+
+    const extraProps = actionable ? { onClick: onActionClick } : {}
+
     return (
-      <AvatarUI
+      <Component
         {...getValidProps(rest)}
+        data-cy="Avatar"
         className={componentClassName}
         style={this.getStyles()}
         title={name}
+        {...extraProps}
       >
         {this.renderCrop()}
         {this.renderStatus()}
         {this.renderCropBorder()}
         {this.renderOuterBorder()}
-      </AvatarUI>
+        {actionable && this.renderFocusBorder()}
+      </Component>
     )
   }
 }

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -4,6 +4,8 @@ import propConnect from '../PropProvider/propConnect'
 import { StatusDotStatus } from '../StatusDot/StatusDot.types'
 import { AvatarShape, AvatarSize } from './Avatar.types'
 import StatusDot from '../StatusDot'
+import Icon from '../Icon'
+import { IconSize } from '../Icon/Icon.types'
 import { getEasingTiming } from '../../utilities/easing'
 import { classNames } from '../../utilities/classNames'
 import { nameToInitials } from '../../utilities/strings'
@@ -15,6 +17,7 @@ import {
   OuterBorderUI,
   StatusUI,
   TitleUI,
+  ActionUI,
 } from './styles/Avatar.css'
 import {
   COMPONENT_KEY,
@@ -27,6 +30,9 @@ import {
 export interface Props {
   animationDuration: number
   animationEasing: string
+  actionable?: boolean
+  actionIcon?: string
+  actionIconSize?: IconSize
   borderColor?: string
   className?: string
   count?: number | string
@@ -37,6 +43,7 @@ export interface Props {
   name: string
   onLoad?: () => void
   onError?: () => void
+  onActionClick?: () => void
   outerBorderColor?: string
   showStatusBorderColor: boolean
   shape: AvatarShape
@@ -53,6 +60,9 @@ export interface State {
 
 export class Avatar extends React.PureComponent<Props, State> {
   static defaultProps = {
+    actionable: true,
+    actionIcon: 'trash',
+    actionIconSize: '24',
     animationDuration: 160,
     animationEasing: 'ease',
     borderColor: 'transparent',
@@ -105,6 +115,29 @@ export class Avatar extends React.PureComponent<Props, State> {
     return classNames(shape && `is-${shape}`, size && `is-${size}`)
   }
 
+  renderAction() {
+    const { actionable, actionIcon, actionIconSize, onActionClick } = this.props
+
+    if (!actionable) {
+      return null
+    }
+
+    const actionClassName = classNames(
+      'c-Avatar__action',
+      this.getShapeClassNames()
+    )
+
+    return (
+      <ActionUI
+        data-cy="Avatar.Action"
+        className={actionClassName}
+        onClick={onActionClick}
+      >
+        <Icon name={actionIcon} size={actionIconSize} />
+      </ActionUI>
+    )
+  }
+
   renderCrop = () => {
     const { animationDuration, animationEasing, name, withShadow } = this.props
 
@@ -135,6 +168,7 @@ export class Avatar extends React.PureComponent<Props, State> {
           onError={this.onImageLoadedError}
           onLoad={this.onImageLoadedSuccess}
         />
+        {this.renderAction()}
       </AvatarCrop>
     )
   }

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -35,6 +35,7 @@ export interface Props {
   actionable?: boolean
   actionIcon?: string
   actionIconSize?: IconSize
+  active?: boolean
   borderColor?: string
   className?: string
   count?: number | string
@@ -65,6 +66,7 @@ export class Avatar extends React.PureComponent<Props, State> {
     actionable: false,
     actionIcon: 'trash',
     actionIconSize: '24',
+    active: false,
     animationDuration: 160,
     animationEasing: 'ease',
     borderColor: 'transparent',
@@ -273,6 +275,7 @@ export class Avatar extends React.PureComponent<Props, State> {
   render() {
     const {
       actionable,
+      active,
       borderColor,
       className,
       count,
@@ -301,6 +304,7 @@ export class Avatar extends React.PureComponent<Props, State> {
       _hasImage && 'has-image',
       statusIcon && 'has-statusIcon',
       light && 'is-light',
+      active && 'is-active',
       outerBorderColor && 'has-outerBorderColor',
       status && `is-${status}`,
       actionable && `has-action`,

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -25,12 +25,16 @@ This component can be themed using a [ThemeProvider](../styled).
 | Prop                  | Type              | Description                                                               |
 | --------------------- | ----------------- | ------------------------------------------------------------------------- |
 | borderColor           | `string`          | Color for the Avatar border.                                              |
+| actionable            | `bool`            | Activate the action overlay that will appear on hover                     |
+| actionIcon            | `string`          | Name of the [Icon](../Icon) to render into the action overlay             |
+| actionIconSize        | `string`          | Set the size of the action overlay icon                                   |
 | className             | `string`          | Custom class names to be added to the component.                          |
 | count                 | `number`/`string` | Used to display an additional avatar count.                               |
 | image                 | `string`          | URL of the image to display.                                              |
 | light                 | `bool`            | Applies a "light" style to the component.                                 |
 | initials              | `string`          | Custom initials to display.                                               |
 | name                  | `string`          | Name of the user. Required.                                               |
+| onActionClick         | `function`        | Callback when avatar overlay was clicked.                                 |
 | onError               | `function`        | Callback when avatar image fails to load.                                 |
 | onLoad                | `function`        | Callback when avatar image loads.                                         |
 | outerBorderColor      | `string`          | Color for the Avatar's outer border.                                      |

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -189,6 +189,13 @@ describe('ClassNames', () => {
         .prop('className')
     ).toContain('is-light')
   })
+
+  test('Add active classname to component', () => {
+    const wrapper = mount(<Avatar name="Buddy" active={true} />)
+    const root = wrapper.find(`div${ui.root}`)
+
+    expect(root.props().className).toContain('is-active')
+  })
 })
 
 describe('Border color', () => {

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -193,20 +193,17 @@ describe('ClassNames', () => {
 
 describe('Border color', () => {
   test('Can apply borderColor', () => {
-    const wrapper = mount(<Avatar name="Buddy" borderColor="green" />)
-    const crop = wrapper.find(`div${ui.cropBorder}`)
-    const style = crop.props().style
+    const wrapper = cy.render(<Avatar name="Buddy" borderColor="green" />)
+    const crop = cy.get(`div${ui.cropBorder}`)
 
-    expect(style).toBeTruthy()
-    expect(style.borderColor).toBe('green')
+    expect(crop.getComputedStyle().borderColor).toBe('green')
   })
 
   test('Does not have a border by default', () => {
-    const wrapper = mount(<Avatar name="Buddy" />)
-    const crop = wrapper.find(`div${ui.cropBorder}`)
-    const style = crop.props().style
+    const wrapper = cy.render(<Avatar name="Buddy" />)
+    const crop = cy.get(`div${ui.cropBorder}`)
 
-    expect(style.borderColor).toBe('transparent')
+    expect(crop.getComputedStyle().borderColor).toBe('transparent')
   })
 
   test('CropBorder UI renders Avatar shape', () => {
@@ -249,20 +246,20 @@ describe('Border color', () => {
 
 describe('Outer border color', () => {
   test('Does not apply outerBorderColor by default', () => {
-    const wrapper = mount(<Avatar name="Buddy" />)
-    const el = wrapper.find(`div${ui.outerBorder}`)
-    const style = el.props().style
+    const wrapper = cy.render(<Avatar name="Buddy" />)
+    const el = cy.get(`div${ui.outerBorder}`)
 
-    expect(style.borderColor).toBe('transparent')
+    expect(el.getComputedStyle().borderColor).toBe('transparent')
   })
 
   test('Can apply outerBorderColor', () => {
-    const wrapper = mount(<Avatar name="Buddy" outerBorderColor="green" />)
-    const el = wrapper.find(`div${ui.outerBorder}`)
-    const style = el.props().style
+    const wrapper = cy.render(
+      <Avatar name="Buddy" outerBorderColor="green" shape="circle" />
+    )
+    const el = cy.get(`div${ui.outerBorder}`)
 
-    expect(style.borderColor).toContain('green')
-    expect(el.props().className).toContain(wrapper.prop('shape'))
+    expect(el.getComputedStyle().borderColor).toBe('green')
+    expect(el.hasClassName('is-circle')).toBeTruthy()
   })
 
   test('OuterBorder UI renders Avatar shape', () => {
@@ -373,6 +370,14 @@ describe('Action', () => {
     expect(cy.getByCy('Avatar.Action').exists()).toBeTruthy()
   })
 
+  test('Renders as a button element', () => {
+    const wrapper = cy.render(
+      <Avatar name="Buddy" size="sm" actionable={true} />
+    )
+    expect(cy.getByCy('Avatar').exists()).toBeTruthy()
+    expect(cy.getByCy('Avatar').is('button')).toBeTruthy()
+  })
+
   test('Renders action default trash icon', () => {
     const wrapper = cy.render(
       <Avatar name="Buddy" size="sm" actionable={true} />
@@ -396,6 +401,13 @@ describe('Action', () => {
     expect(cy.getByCy('Avatar.Action').hasClassName('is-rounded')).toBeTruthy()
   })
 
+  test('Renders a focus border', () => {
+    const wrapper = cy.render(
+      <Avatar name="Buddy" size="sm" actionable={true} shape="rounded" />
+    )
+    expect(cy.getByCy('Avatar.FocusBorder').exists()).toBeTruthy()
+  })
+
   test('Evokes the callback when clicking on the Action component', () => {
     const fn = jest.fn()
     const wrapper = cy.render(
@@ -407,7 +419,7 @@ describe('Action', () => {
         onActionClick={fn}
       />
     )
-    cy.getByCy('Avatar.Action').click()
+    cy.getByCy('Avatar').click()
     expect(fn).toHaveBeenCalled()
   })
 })

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import { cy } from '@helpscout/cyan'
 import { Avatar } from '../Avatar'
 import { StatusDot } from '../../index'
 
@@ -352,5 +353,61 @@ describe('onLoad', () => {
     const img = wrapper.find('img').first()
     img.simulate('load')
     expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('Action', () => {
+  test("Doesn't render the action", () => {
+    const wrapper = cy.render(
+      <Avatar name="Buddy" size="sm" actionable={false} />
+    )
+    expect(wrapper.exists()).toBeTruthy()
+    expect(cy.getByCy('Avatar.Action').exists()).toBeFalsy()
+  })
+
+  test('Adds action to Avatar', () => {
+    const wrapper = cy.render(
+      <Avatar name="Buddy" size="sm" actionable={true} />
+    )
+    expect(wrapper.exists()).toBeTruthy()
+    expect(cy.getByCy('Avatar.Action').exists()).toBeTruthy()
+  })
+
+  test('Renders action default trash icon', () => {
+    const wrapper = cy.render(
+      <Avatar name="Buddy" size="sm" actionable={true} />
+    )
+    expect(cy.get('.c-Icon').exists()).toBeTruthy()
+    expect(cy.get('.c-Icon').hasClassName('is-iconName-trash')).toBeTruthy()
+  })
+
+  test('Renders custom action icon', () => {
+    const wrapper = cy.render(
+      <Avatar name="Buddy" size="sm" actionable={true} actionIcon="plus" />
+    )
+    expect(cy.get('.c-Icon').exists()).toBeTruthy()
+    expect(cy.get('.c-Icon').hasClassName('is-iconName-plus')).toBeTruthy()
+  })
+
+  test('Updates the shape of the Action based on parent prop', () => {
+    const wrapper = cy.render(
+      <Avatar name="Buddy" size="sm" actionable={true} shape="rounded" />
+    )
+    expect(cy.getByCy('Avatar.Action').hasClassName('is-rounded')).toBeTruthy()
+  })
+
+  test('Evokes the callback when clicking on the Action component', () => {
+    const fn = jest.fn()
+    const wrapper = cy.render(
+      <Avatar
+        name="Buddy"
+        size="sm"
+        actionable={true}
+        shape="rounded"
+        onActionClick={fn}
+      />
+    )
+    cy.getByCy('Avatar.Action').click()
+    expect(fn).toHaveBeenCalled()
   })
 })

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -328,4 +328,9 @@ export const AvatarButtonUI = styled('button')`
       opacity: 0;
     }
   }
+
+  &.is-active .c-Avatar__focusBorder {
+    animation: none;
+    opacity: 1;
+  }
 `

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -42,6 +42,54 @@ export const config = {
   },
 }
 
+export const ActionUI = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  cursor: pointer;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: rgb(255, 255, 255);
+
+  &:before {
+    content: '';
+    opacity: 0;
+    background: rgba(0, 0, 0, 0.3);
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 3;
+    transition: transform ease-in-out 0.15s;
+    transform: scale(0);
+  }
+
+  ${getBorderRadiusStyles({ suffix: ':before' })};
+
+  .c-Icon {
+    opacity: 0;
+    transform: translateY(3px);
+    transition: opacity 0.2s, transform 0.3s;
+    position: relative;
+    z-index: 5;
+  }
+
+  &:hover:before {
+    opacity: 1;
+    transform: scale(1);
+  }
+  &:hover .c-Icon {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`
+
 export const AvatarUI = styled('div')`
   ${baseStyles};
   height: ${config.size.md.size}px;
@@ -64,6 +112,7 @@ export const CropUI = styled('div')`
   justify-content: center;
   overflow: hidden;
   width: 100%;
+  position: relative;
 
   ${getBorderRadiusStyles()};
 
@@ -184,15 +233,15 @@ function getColorStyles(props: Object): string {
   `
 }
 
-function getBorderRadiusStyles(): string {
+function getBorderRadiusStyles({ suffix = '' } = {}): string {
   return `
-    &.is-circle {
+    &.is-circle${suffix} {
       border-radius: 200%;
     }
-    &.is-rounded {
+    &.is-rounded${suffix} {
       border-radius: ${config.borderRadius}px;
     }
-    &.is-square {
+    &.is-square${suffix} {
       border-radius: 0;
     }
   `

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -4,6 +4,8 @@ import forEach from '../../../styles/utilities/forEach'
 import variableFontSize from '../../../styles/utilities/variableFontSize'
 import styled from '../../styled'
 
+import { config as buttonConfig } from '../../Button/styles/Button.css'
+
 export const config = {
   borderRadius: 3,
   borderWidth: 2,
@@ -88,19 +90,6 @@ export const ActionUI = styled('div')`
     opacity: 1;
     transform: translateY(0);
   }
-`
-
-export const AvatarUI = styled('div')`
-  ${baseStyles};
-  height: ${config.size.md.size}px;
-  position: relative;
-  width: ${config.size.md.size}px;
-
-  ${props => getColorStyles(props)} &.is-light {
-    color: ${getColor('grey.400')};
-  }
-
-  ${getSizeStyles()};
 `
 
 export const CropUI = styled('div')`
@@ -216,6 +205,32 @@ export const CropBorderUI = styled('div')`
   right: -${config.borderWidth}px;
   border-style: solid;
   border-width: ${config.borderWidth}px;
+  border-color: ${props =>
+    props.borderColor ? props.borderColor : 'transparent'};
+  ${getBorderRadiusStyles()};
+`
+
+export const FocusUI = styled('span')`
+  position: absolute;
+  top: -${config.borderWidth}px;
+  bottom: -${config.borderWidth}px;
+  left: -${config.borderWidth}px;
+  right: -${config.borderWidth}px;
+
+  animation: FocusFadeIn 200ms;
+  box-shadow: 0 0 0 ${buttonConfig.focusOutlineWidth}px
+    ${buttonConfig.focusOutlineColor};
+  display: none;
+  pointer-events: none;
+
+  @keyframes FocusFadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
 
   ${getBorderRadiusStyles()};
 `
@@ -260,3 +275,57 @@ function getSizeStyles(): string {
     `
   })
 }
+
+export const AvatarUI = styled('div')`
+  ${baseStyles};
+  height: ${config.size.md.size}px;
+  position: relative;
+  width: ${config.size.md.size}px;
+
+  ${props => getColorStyles(props)} &.is-light {
+    color: ${getColor('grey.400')};
+  }
+
+  ${getSizeStyles()};
+`
+
+export const AvatarButtonUI = styled('button')`
+  ${baseStyles};
+  padding: 0;
+  border: none;
+  height: ${config.size.md.size}px;
+  position: relative;
+  width: ${config.size.md.size}px;
+  outline: none;
+
+  ${props => getColorStyles(props)} &.is-light {
+    color: ${getColor('grey.400')};
+  }
+
+  ${getSizeStyles()};
+
+  &:hover,
+  &:active,
+  &:focus {
+    outline: none;
+    text-decoration: none;
+  }
+
+  &:active,
+  &:active:focus {
+    .c-Avatar__focusBorder {
+      display: none;
+    }
+  }
+
+  &.is-active,
+  &:focus {
+    z-index: 2;
+    .c-Avatar__focusBorder {
+      display: block;
+    }
+    .c-Avatar__outerBorder {
+      opacity: 0;
+    }
+  }
+`

--- a/stories/Avatar/Avatar.stories.js
+++ b/stories/Avatar/Avatar.stories.js
@@ -4,7 +4,23 @@ import { Avatar, Flexy } from '../../src/index'
 import { ThemeProvider } from '../../src/components/styled'
 import AvatarSpec from './specs/Avatar'
 
+import { action } from '@storybook/addon-actions'
+import {
+  withKnobs,
+  boolean,
+  number,
+  text,
+  select,
+} from '@storybook/addon-knobs'
+
 const stories = storiesOf('Avatar', module)
+
+stories.addDecorator(
+  withKnobs({
+    escapeHTML: false,
+  })
+)
+
 const fixture = AvatarSpec.generate()
 
 stories.add('default', () => (
@@ -155,4 +171,33 @@ stories.add('border', () => (
       status="online"
     />
   </div>
+))
+
+const iconSize = [
+  '8',
+  '10',
+  '12',
+  '13',
+  '14',
+  '15',
+  '16',
+  '18',
+  '20',
+  '24',
+  '32',
+  '48',
+  '52',
+]
+stories.add('with action', () => (
+  <Flexy just="left">
+    <Avatar
+      name={fixture.name}
+      image={fixture.image}
+      actionable={boolean('Actionable', true)}
+      actionIcon={select('Icon', ['trash', 'plus-large', 'hyphen'], 'trash')}
+      actionIconSize={select('Icon Size', iconSize, '24')}
+      shape={select('Shape', ['circle', 'square', 'rounded'], 'circle')}
+      onActionClick={action('handle click action')}
+    />
+  </Flexy>
 ))

--- a/stories/Avatar/Avatar.stories.js
+++ b/stories/Avatar/Avatar.stories.js
@@ -193,6 +193,7 @@ stories.add('with action', () => (
     <Avatar
       name={fixture.name}
       image={fixture.image}
+      active={boolean('Is Active', false)}
       actionable={boolean('Actionable', true)}
       actionIcon={select('Icon', ['trash', 'plus-large', 'hyphen'], 'trash')}
       actionIconSize={select('Icon Size', iconSize, '24')}


### PR DESCRIPTION
This update adds a new overlay when hovering an avatar.

![Screen Recording 2019-08-20 at 04 53 PM](https://user-images.githubusercontent.com/203992/63444176-19023880-c404-11e9-9694-52cb8f74e75c.gif)

This overlay is fully customizable and will follow the shape of the avatar (circle, rounded or square).

The Avatar dom element will be a button when it is `actionable`. This will add a focus state to the avatar

![Screen Recording 2019-08-21 at 03 23 PM](https://user-images.githubusercontent.com/203992/63465294-f1749580-c42e-11e9-8ab3-479c7cc38f14.gif)

It adds 4 new props to the `<Avatar />` component:

* **actionable** Activate the action overlay
* **actionIcon** Change the actual icon of the overlay (default to the `trash`icon)
* **actionIconSize** Set the size of the overlay icon
* **onActionClick** Callback for then the overlay was clicked