### PR TITLE
Fix input disabled state in storybook to reflect HSDS

### DIFF
--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -214,7 +214,7 @@ stories.add('suffix', () => (
 
 stories.add('seamless', () => <Input seamless autoFocus />)
 
-stories.add('disabled', () => <Input disabled autoFocus />)
+stories.add('disabled', () => <Input disabled />)
 
 stories.add('readonly', () => (
   <Input readOnly autoFocus value={`I can't turn left`} />


### PR DESCRIPTION
**Problem**
The storybook's input disabled state is in focus and does not match the HSDS spec. A disabled input by definition should not be "focusable".

Storybook: https://hsds-react.netlify.com/?path=/story/input--disabled
HSDS: https://helpscout.slab.com/posts/hsds-product-ui-7l7onzj2#forms

**Solution**
Remove the **autofocus** attribute from the input.

**Background**
For context, please see Jared's comment in this PR: https://github.com/helpscout/hs-app/pull/7236#issuecomment-522842380