### PR TITLE
Dropdown V2 adjustments

### DIFF
--- a/src/components/Dropdown/V2/Dropdown.Container.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Container.tsx
@@ -24,6 +24,7 @@ import {
   updateIndex,
   updateInputValue,
   updateDropUp,
+  updateSelectedItem,
 } from './Dropdown.actions'
 import Trigger from './Dropdown.Trigger'
 import { createUniqueIDFactory } from '../../../utilities/id'
@@ -114,7 +115,7 @@ export class DropdownContainer extends React.PureComponent<Props, State> {
     // Batch updates to a single update
     let nextState = {}
 
-    // Update items + regenerate the indexMap if items chage
+    // Update items + regenerate the indexMap if items change
     if (nextProps.items !== state.items) {
       nextState = {
         ...nextState,
@@ -160,6 +161,14 @@ export class DropdownContainer extends React.PureComponent<Props, State> {
       }
     }
 
+    // Update selectedItem state, if changed externally
+    if (nextProps.selectedItem !== state.selectedItem) {
+      nextState = {
+        ...nextState,
+        ...updateSelectedItem(state, nextProps.selectedItem),
+      }
+    }
+
     const diffs = getShallowDiffs(this.props, nextProps)
     /* istanbul ignore else */
     if (diffs.diffs.length) {
@@ -174,7 +183,10 @@ export class DropdownContainer extends React.PureComponent<Props, State> {
       } = diffs.next
 
       if (Object.keys(changedProps).length) {
-        nextState = { ...nextState, ...changedProps }
+        nextState = {
+          ...nextState,
+          ...changedProps,
+        }
       }
     }
 

--- a/src/components/Dropdown/V2/Dropdown.Item.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Item.tsx
@@ -43,6 +43,7 @@ export interface Props {
   onBlur: (...args: any[]) => void
   onClick: (...args: any[]) => void
   onFocus: (...args: any[]) => void
+  preventSelect?: boolean
   renderItem?: (props: any) => void
   subMenuId?: string
   label: string
@@ -66,6 +67,7 @@ export class Item extends React.PureComponent<Props> {
     onBlur: noop,
     onClick: noop,
     onFocus: noop,
+    preventSelect: false,
     label: '',
     type: 'item',
     value: '',
@@ -84,10 +86,16 @@ export class Item extends React.PureComponent<Props> {
   }
 
   handleOnClick = (event: Event) => {
-    const { onClick } = this.props
+    const { label, onClick, preventSelect, value } = this.props
     const state: any = this.props.getState()
 
-    if (state && state.allowMultipleSelection && state.selectionClearer) {
+    if (preventSelect) {
+      onClick({ label, value }, event)
+    } else if (
+      state &&
+      state.allowMultipleSelection &&
+      state.selectionClearer
+    ) {
       onClick(state, event)
     } else {
       onClick(event, { hasSubMenu: this.hasSubMenu() })

--- a/src/components/Dropdown/V2/Dropdown.actionTypes.ts
+++ b/src/components/Dropdown/V2/Dropdown.actionTypes.ts
@@ -17,6 +17,7 @@ const actionTypes = [
   'UPDATE_INPUT_VALUE',
   'UPDATE_ITEMS',
   'UPDATE_OPEN',
+  'UPDATE_SELECTED_ITEM',
 ]
 
 export default createActionTypes(actionTypes, '@@HSDS/DROPDOWN')

--- a/src/components/Dropdown/V2/Dropdown.actions.ts
+++ b/src/components/Dropdown/V2/Dropdown.actions.ts
@@ -226,12 +226,26 @@ export const selectItem = (state, event: any, eventTarget?: any) => {
   const index = getIndexFromItemDOMNode(node)
   const itemValue = getValueFromItemDOMNode(node)
   const item = getItemFromCollection(items, itemValue)
+  const maybeCallItemOnClick = () => {
+    const isMouseEvent = isDefined(event.pageX)
+
+    if (item && item.onClick && !isMouseEvent) {
+      item.onClick(event)
+    }
+  }
 
   // Performance guard to prevent store from updating
   if (!index) return
   if (!item) return
   if (item.disabled) return
   if (item.items) return
+
+  // This allows dropdown items to be clickable, but
+  // not update the internal `selectedItem` state.
+  if (item.preventSelect) {
+    maybeCallItemOnClick()
+    return updateOpen(state, false)
+  }
 
   let selectedItem
 
@@ -261,13 +275,7 @@ export const selectItem = (state, event: any, eventTarget?: any) => {
     })
   }
 
-  // Trigger item.onClick callback
-  const isMouseEvent = isDefined(event.pageX)
-
-  if (item && item.onClick && !isMouseEvent) {
-    item.onClick(event)
-  }
-
+  maybeCallItemOnClick()
   closeAndRefocusTriggerNode(state)
 
   return dispatch(state, {

--- a/src/components/Dropdown/V2/Dropdown.actions.ts
+++ b/src/components/Dropdown/V2/Dropdown.actions.ts
@@ -314,6 +314,15 @@ export const clearSelection = (state, event) => {
   })
 }
 
+export const updateSelectedItem = (state, selectedItem) => {
+  return dispatch(state, {
+    type: actionTypes.UPDATE_SELECTED_ITEM,
+    payload: {
+      selectedItem,
+    },
+  })
+}
+
 export const updateIndex = (state, index) => {
   return dispatch(state, {
     type: actionTypes.UPDATE_INDEX,

--- a/src/components/Dropdown/V2/Dropdown.reducer.ts
+++ b/src/components/Dropdown/V2/Dropdown.reducer.ts
@@ -58,6 +58,14 @@ const reducer = (state = initialState, action: any = {}) => {
       }
       break
 
+    case actionTypes.UPDATE_SELECTED_ITEM:
+      nextState = {
+        ...state,
+        previousSelectedItem: state.selectedItem,
+        selectedItem: payload.selectedItem,
+      }
+      break
+
     case actionTypes.CLEAR_SELECTION:
       nextState = {
         ...payload,
@@ -94,6 +102,9 @@ const reducer = (state = initialState, action: any = {}) => {
 
     case actionTypes.UPDATE_DROPUP:
       nextState = { ...payload }
+      break
+    // This prevents eslint errors
+    default:
       break
   }
 

--- a/src/components/Dropdown/V2/__tests__/Dropdown.Item.test.tsx
+++ b/src/components/Dropdown/V2/__tests__/Dropdown.Item.test.tsx
@@ -231,9 +231,9 @@ describe('Events', () => {
     )
   })
 
-  test('onClick callback fires', () => {
+  test('onClick callback fires when `preventSelect` is true', () => {
     const spy = jest.fn()
-    const wrapper = mount(<Item onClick={spy} />)
+    const wrapper = mount(<Item onClick={spy} preventSelect />)
 
     wrapper.simulate('click')
 

--- a/src/components/Dropdown/V2/__tests__/Dropdown.actions.test.ts
+++ b/src/components/Dropdown/V2/__tests__/Dropdown.actions.test.ts
@@ -10,6 +10,7 @@ import {
   closeDropdown,
   selectItem,
   clearSelection,
+  updateSelectedItem,
 } from '../Dropdown.actions'
 
 const mockTriggerNode = {
@@ -367,6 +368,17 @@ describe('selectItem', () => {
     selectItem(state, event)
 
     expect(mockTriggerNode.focus).toHaveBeenCalled()
+  })
+})
+
+describe('updateSelectedItem', () => {
+  test('updates selectedItem state', () => {
+    const state = { selectedItem: 'Item 1' }
+    const newlySelectedItem = 'Item 2'
+
+    const nextState = updateSelectedItem(state, newlySelectedItem)
+
+    expect(nextState.selectedItem).toBe(newlySelectedItem)
   })
 })
 

--- a/src/components/Dropdown/V2/__tests__/Dropdown.reducer.test.ts
+++ b/src/components/Dropdown/V2/__tests__/Dropdown.reducer.test.ts
@@ -178,3 +178,18 @@ describe('SelectItem', () => {
     expect(nextState.isOpen).toBe(true)
   })
 })
+
+describe('UpdateItem', () => {
+  test('Can updated a selected item', () => {
+    const action = {
+      type: actionTypes.UPDATE_SELECTED_ITEM,
+      payload: {
+        selectedItem: '2',
+      },
+    }
+    const nextState = reducer({ ...initialState, selectedItem: '0' }, action)
+
+    expect(nextState.selectedItem).toBe('2')
+    expect(nextState.previousSelectedItem).toBe('0')
+  })
+})


### PR DESCRIPTION
## Changes

- ### Allow for a dropdown item to be clickable, but not update the dropdown’s internal selectedItem state

     The ideal usages for this would be when you have a set of items that should display as selected or not, along with items that might be present to trigger an external action, but not be set to the selectedItem. 

     An example is the following usage, where the statuses selected but items like `Your Profile` should not be set to the selected item, but just trigger a click event. 

     <img width="284" alt="Screen Shot 2019-08-21 at 5 53 29 PM" src="https://user-images.githubusercontent.com/7111256/63478032-d6108700-c43c-11e9-8ffb-49c84f6a3c16.png">

- ### Allow for the internal `selectedItem` state to be updated and controlled from outside the component. 