### PR TITLE
Fix Avatar background color & Add remove avatar animation

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -20,6 +20,8 @@ import {
   ActionUI,
   AvatarButtonUI,
   FocusUI,
+  BorderAnimationUI,
+  CircleAnimationUI,
 } from './styles/Avatar.css'
 import {
   COMPONENT_KEY,
@@ -32,6 +34,7 @@ import {
 export interface Props {
   animationDuration: number
   animationEasing: string
+  animateActionBorder?: boolean
   actionable?: boolean
   actionIcon?: string
   actionIconSize?: IconSize
@@ -47,6 +50,7 @@ export interface Props {
   onLoad?: () => void
   onError?: () => void
   onActionClick?: () => void
+  onBorderAnimationCompleted?: () => void
   outerBorderColor?: string
   showStatusBorderColor: boolean
   shape: AvatarShape
@@ -249,15 +253,40 @@ export class Avatar extends React.PureComponent<Props, State> {
   }
 
   renderFocusBorder = () => {
-    const { shape } = this.props
+    const {
+      shape,
+      animateActionBorder,
+      onBorderAnimationCompleted,
+    } = this.props
     const componentClassName = classNames(
       'c-Avatar__focusBorder',
+      animateActionBorder && 'is-animating',
       shape && `is-${shape}`
     )
 
-    return (
-      <FocusUI data-cy="Avatar.FocusBorder" className={componentClassName} />
+    const borderAnimationClassName = classNames(
+      'c-Avatar__borderAnimation',
+      animateActionBorder && 'is-animating',
+      this.getShapeClassNames()
     )
+
+    return [
+      <FocusUI
+        key="focusBorder"
+        data-cy="Avatar.FocusBorder"
+        className={componentClassName}
+      />,
+      <BorderAnimationUI
+        key="borderAnimation"
+        className={borderAnimationClassName}
+        data-cy="Avatar.BorderAnimation"
+      >
+        <CircleAnimationUI
+          id="anime"
+          onAnimationEnd={onBorderAnimationCompleted}
+        />
+      </BorderAnimationUI>,
+    ]
   }
 
   getStyles() {

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -37,13 +37,11 @@ export interface Props {
   actionIcon?: string
   actionIconSize?: IconSize
   active?: boolean
-  animationBorderImage: boolean
   animationDuration: number
   animationEasing: string
   borderColor?: string
   className?: string
   count?: number | string
-  deleteAnimation?: boolean
   fallbackImage?: string
   image?: string
   initials?: string
@@ -77,7 +75,6 @@ export class Avatar extends React.PureComponent<Props, State> {
     animationDuration: 160,
     animationEasing: 'ease',
     borderColor: 'transparent',
-    deleteAnimation: true,
     fallbackImage: null,
     light: false,
     name: '',

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -22,6 +22,8 @@ import {
   OuterBorderUI,
   StatusUI,
   TitleUI,
+  config,
+  getCircleProps,
 } from './styles/Avatar.css'
 
 import {
@@ -279,7 +281,7 @@ export class Avatar extends React.PureComponent<Props, State> {
   }
 
   renderFocusBorder = () => {
-    const { shape, onRemoveAnimationEnd } = this.props
+    const { shape, onRemoveAnimationEnd, size } = this.props
 
     const componentClassName = classNames(
       'c-Avatar__focusBorder',
@@ -290,6 +292,9 @@ export class Avatar extends React.PureComponent<Props, State> {
       'c-Avatar__borderAnimation',
       this.getShapeClassNames()
     )
+
+    const sz = config.size[size].size
+    const { size: svgSize, ...circleProps } = getCircleProps(sz)
 
     return [
       <FocusUI
@@ -302,7 +307,11 @@ export class Avatar extends React.PureComponent<Props, State> {
         className={borderAnimationClassName}
         data-cy="Avatar.BorderAnimation"
       >
-        <CircleAnimationUI id="anime" onAnimationEnd={onRemoveAnimationEnd} />
+        <CircleAnimationUI
+          id="anime"
+          onAnimationEnd={onRemoveAnimationEnd}
+          {...circleProps}
+        />
       </BorderAnimationUI>,
     ]
   }

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -22,27 +22,28 @@ This component can be themed using a [ThemeProvider](../styled).
 
 ## Props
 
-| Prop           | Type     | Description                                                   |
-| -------------- | -------- | ------------------------------------------------------------- |
-| borderColor    | `string` | Color for the Avatar border.                                  |
-| actionable     | `bool`   | Activate the action overlay that will appear on hover         |
-| actionIcon     | `string` | Name of the [Icon](../Icon) to render into the action overlay |
-| actionIconSize | `string` | Set the size of the action overlay icon                       |
-
-| className | `string` | Custom class names to be added to the component. |
-| count | `number`/`string` | Used to display an additional avatar count. |
-| image | `string` | URL of the image to display. |
-| light | `bool` | Applies a "light" style to the component. |
-| initials | `string` | Custom initials to display. |
-| name | `string` | Name of the user. Required. |
-| onActionClick | `function` | Callback when avatar overlay was clicked. |
-| onError | `function` | Callback when avatar image fails to load. |
-| onLoad | `function` | Callback when avatar image loads. |
-| outerBorderColor | `string` | Color for the Avatar's outer border. |
-| shape | `string` | Shape of the avatar. |
-| size | `string` | Size of the avatar. |
-| title | `string` | Text for the image `alt` and `title` attributes. |
-| showStatusBorderColor | `bool` | Renders the [StatusDot](../StatusDot) border. |
-| status | `string` | Renders a [StatusDot](../StatusDot) with the status type. |
-| statusIcon | `string` | Name of the [Icon](../Icon) to render into the [StatusDot](../StatusDot). |
-| version | `number` | Specifies the component version to render. |
+| Prop                    | Type              | Description                                                                                               |
+| ----------------------- | ----------------- | --------------------------------------------------------------------------------------------------------- |
+| actionable              | `bool`            | Activate the action overlay that will appear on hover                                                     |
+| actionIcon              | `string`          | Name of the [Icon](../Icon) to render into the action overlay                                             |
+| actionIconSize          | `string`          | Set the size of the action overlay icon                                                                   |
+| borderColor             | `string`          | Color for the Avatar border.                                                                              |
+| className               | `string`          | Custom class names to be added to the component.                                                          |
+| count                   | `number`/`string` | Used to display an additional avatar count.                                                               |
+| image                   | `string`          | URL of the image to display.                                                                              |
+| light                   | `bool`            | Applies a "light" style to the component.                                                                 |
+| initials                | `string`          | Custom initials to display.                                                                               |
+| name                    | `string`          | Name of the user. Required.                                                                               |
+| onActionClick           | `function`        | Callback when avatar overlay was clicked.                                                                 |
+| onError                 | `function`        | Callback when avatar image fails to load.                                                                 |
+| onLoad                  | `function`        | Callback when avatar image loads.                                                                         |
+| onRemoveAnimationEnd    | `function`        | Callback when the remove avatar animation has ended.                                                      |
+| outerBorderColor        | `string`          | Color for the Avatar's outer border.                                                                      |
+| removingAvatarAnimation | `bool`            | Activate an animation sequence that will remove the actual avatar and replace it will the fallback image. |
+| shape                   | `string`          | Shape of the avatar.                                                                                      |
+| size                    | `string`          | Size of the avatar.                                                                                       |
+| title                   | `string`          | Text for the image `alt` and `title` attributes.                                                          |
+| showStatusBorderColor   | `bool`            | Renders the [StatusDot](../StatusDot) border.                                                             |
+| status                  | `string`          | Renders a [StatusDot](../StatusDot) with the status type.                                                 |
+| statusIcon              | `string`          | Name of the [Icon](../Icon) to render into the [StatusDot](../StatusDot).                                 |
+| version                 | `number`          | Specifies the component version to render.                                                                |

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -22,26 +22,27 @@ This component can be themed using a [ThemeProvider](../styled).
 
 ## Props
 
-| Prop                  | Type              | Description                                                               |
-| --------------------- | ----------------- | ------------------------------------------------------------------------- |
-| borderColor           | `string`          | Color for the Avatar border.                                              |
-| actionable            | `bool`            | Activate the action overlay that will appear on hover                     |
-| actionIcon            | `string`          | Name of the [Icon](../Icon) to render into the action overlay             |
-| actionIconSize        | `string`          | Set the size of the action overlay icon                                   |
-| className             | `string`          | Custom class names to be added to the component.                          |
-| count                 | `number`/`string` | Used to display an additional avatar count.                               |
-| image                 | `string`          | URL of the image to display.                                              |
-| light                 | `bool`            | Applies a "light" style to the component.                                 |
-| initials              | `string`          | Custom initials to display.                                               |
-| name                  | `string`          | Name of the user. Required.                                               |
-| onActionClick         | `function`        | Callback when avatar overlay was clicked.                                 |
-| onError               | `function`        | Callback when avatar image fails to load.                                 |
-| onLoad                | `function`        | Callback when avatar image loads.                                         |
-| outerBorderColor      | `string`          | Color for the Avatar's outer border.                                      |
-| shape                 | `string`          | Shape of the avatar.                                                      |
-| size                  | `string`          | Size of the avatar.                                                       |
-| title                 | `string`          | Text for the image `alt` and `title` attributes.                          |
-| showStatusBorderColor | `bool`            | Renders the [StatusDot](../StatusDot) border.                             |
-| status                | `string`          | Renders a [StatusDot](../StatusDot) with the status type.                 |
-| statusIcon            | `string`          | Name of the [Icon](../Icon) to render into the [StatusDot](../StatusDot). |
-| version               | `number`          | Specifies the component version to render.                                |
+| Prop           | Type     | Description                                                   |
+| -------------- | -------- | ------------------------------------------------------------- |
+| borderColor    | `string` | Color for the Avatar border.                                  |
+| actionable     | `bool`   | Activate the action overlay that will appear on hover         |
+| actionIcon     | `string` | Name of the [Icon](../Icon) to render into the action overlay |
+| actionIconSize | `string` | Set the size of the action overlay icon                       |
+
+| className | `string` | Custom class names to be added to the component. |
+| count | `number`/`string` | Used to display an additional avatar count. |
+| image | `string` | URL of the image to display. |
+| light | `bool` | Applies a "light" style to the component. |
+| initials | `string` | Custom initials to display. |
+| name | `string` | Name of the user. Required. |
+| onActionClick | `function` | Callback when avatar overlay was clicked. |
+| onError | `function` | Callback when avatar image fails to load. |
+| onLoad | `function` | Callback when avatar image loads. |
+| outerBorderColor | `string` | Color for the Avatar's outer border. |
+| shape | `string` | Shape of the avatar. |
+| size | `string` | Size of the avatar. |
+| title | `string` | Text for the image `alt` and `title` attributes. |
+| showStatusBorderColor | `bool` | Renders the [StatusDot](../StatusDot) border. |
+| status | `string` | Renders a [StatusDot](../StatusDot) with the status type. |
+| statusIcon | `string` | Name of the [Icon](../Icon) to render into the [StatusDot](../StatusDot). |
+| version | `number` | Specifies the component version to render. |

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -429,6 +429,7 @@ describe('Action', () => {
     )
     expect(cy.getByCy('Avatar.BorderAnimation').exists()).toBeTruthy()
   })
+
   test('Evokes the callback when clicking on the Action component', () => {
     const fn = jest.fn()
     const wrapper = cy.render(
@@ -442,5 +443,39 @@ describe('Action', () => {
     )
     cy.getByCy('Avatar').click()
     expect(fn).toHaveBeenCalled()
+  })
+
+  test('Evokes the callback when clicking on the Action component only if the action exists', () => {
+    const fn = jest.fn()
+    const wrapper = cy.render(
+      <Avatar
+        name="Buddy"
+        size="sm"
+        actionable={true}
+        shape="rounded"
+        onActionClick={fn}
+      />
+    )
+    cy.getByCy('Avatar').click()
+    expect(fn).toHaveBeenCalled()
+
+    wrapper.setProps({ removingAvatarAnimation: true })
+    cy.getByCy('Avatar').click()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('Hide the action overlay when animating', () => {
+    const fn = jest.fn()
+    const wrapper = cy.render(
+      <Avatar
+        name="Buddy"
+        size="sm"
+        actionable={true}
+        shape="rounded"
+        onActionClick={fn}
+        removingAvatarAnimation={true}
+      />
+    )
+    expect(cy.getByCy('Avatar.Action').exists()).toBeFalsy()
   })
 })

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { cy } from '@helpscout/cyan'
 import { Avatar } from '../Avatar'
+import { getCircleProps } from '../styles/Avatar.css'
 import { StatusDot } from '../../index'
 
 const ui = {
@@ -477,5 +478,18 @@ describe('Action', () => {
       />
     )
     expect(cy.getByCy('Avatar.Action').exists()).toBeFalsy()
+  })
+
+  test('getCircleProps will return a full props object for svg circle', () => {
+    const size = 20
+    const props = getCircleProps(size)
+
+    expect(Object.keys(props).join('-')).toBe(
+      ['size', 'cx', 'cy', 'r'].join('-')
+    )
+    expect(props.size).toBe(28)
+    expect(props.cx).toBe(14)
+    expect(props.cy).toBe(14)
+    expect(props.r).toBe(13)
   })
 })

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -13,6 +13,8 @@ const ui = {
   initials: '.c-Avatar__title',
 }
 
+jest.useFakeTimers()
+
 describe('Name', () => {
   test('Uses the `initials` attribute if specified', () => {
     const wrapper = mount(<Avatar name="Ron Burgandy" initials="XY" />)
@@ -415,6 +417,18 @@ describe('Action', () => {
     expect(cy.getByCy('Avatar.FocusBorder').exists()).toBeTruthy()
   })
 
+  test('Renders an animate svg', () => {
+    const wrapper = cy.render(
+      <Avatar
+        name="Buddy"
+        size="sm"
+        actionable={true}
+        shape="rounded"
+        animateActionBorder={true}
+      />
+    )
+    expect(cy.getByCy('Avatar.BorderAnimation').exists()).toBeTruthy()
+  })
   test('Evokes the callback when clicking on the Action component', () => {
     const fn = jest.fn()
     const wrapper = cy.render(

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -284,21 +284,32 @@ function getSizeStyles(): string {
   })
 }
 
+export function getCircleProps(sz) {
+  const size = sz + config.borderWidth * 4
+  const c = size / 2
+  const r = (sz + config.borderWidth * 3) / 2
+
+  return {
+    size,
+    cx: c,
+    cy: c,
+    r,
+  }
+}
+
 function getBorderAnimationSizeStyles(): string {
   return forEach(config.size, (size, props) => {
     const { size: sz } = props
-    const svgSize = sz + config.borderWidth * 4
-    const c = svgSize / 2
-    const r = (sz + config.borderWidth * 3) / 2
+    const { size: svgSize, ...rest } = getCircleProps(sz)
     return `
       &.is-${size} {
         height: ${svgSize}px;
         width: ${svgSize}px;
 
         circle {
-          cx: ${c};
-          cy: ${c};
-          r: ${r};
+          cx: ${rest.cx};
+          cy: ${rest.cy};
+          r: ${rest.r};
         }
       }
     `

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -297,6 +297,7 @@ export const AvatarButtonUI = styled('button')`
   position: relative;
   width: ${config.size.md.size}px;
   outline: none;
+  background: transparent;
 
   ${props => getColorStyles(props)} &.is-light {
     color: ${getColor('grey.400')};

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -122,11 +122,19 @@ export const ImageWrapperUI = styled('div')`
   overflow: hidden;
   transform: translate3d(0, 0, 0) scale(1.0125);
   width: 100%;
+  position: relative;
+  z-index: 2;
+
+  &.c-Avatar__imageStaticWrapper {
+    position: absolute;
+    z-index: 1;
+  }
 
   ${getBorderRadiusStyles()};
 
   &.is-herbieFullyLoaded {
     opacity: 1;
+    transition-delay: 0.8s !important;
   }
 `
 
@@ -341,10 +349,6 @@ export const BorderAnimationUI = styled('svg')`
   transform: rotate(-90deg);
   display: none;
 
-  &.is-animating {
-    display: block;
-  }
-
   ${getBorderAnimationSizeStyles()};
 `
 
@@ -378,10 +382,10 @@ export const AvatarButtonUI = styled('button')`
     }
   }
 
-  &.is-active,
-  &:focus {
+  &.is-active:not(.is-animating),
+  &:not(.is-animating):focus {
     z-index: 2;
-    .c-Avatar__focusBorder:not(.is-animating) {
+    .c-Avatar__focusBorder {
       display: block;
     }
     .c-Avatar__outerBorder {
@@ -389,7 +393,7 @@ export const AvatarButtonUI = styled('button')`
     }
   }
 
-  &:focus {
+  &:not(.is-animating):focus {
     .c-Avatar__action:before {
       opacity: 1;
       transform: scale(1);
@@ -400,8 +404,17 @@ export const AvatarButtonUI = styled('button')`
     }
   }
 
-  &.is-active .c-Avatar__focusBorder:not(.is-animating) {
+  &:not(.is-animating).is-active .c-Avatar__focusBorder {
     animation: none;
     opacity: 1;
+  }
+
+  &.is-animating {
+    .c-Avatar__imageMainWrapper {
+      opacity: 0;
+    }
+    .c-Avatar__borderAnimation {
+      display: block;
+    }
   }
 `

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -276,6 +276,27 @@ function getSizeStyles(): string {
   })
 }
 
+function getBorderAnimationSizeStyles(): string {
+  return forEach(config.size, (size, props) => {
+    const { size: sz } = props
+    const svgSize = sz + config.borderWidth * 4
+    const c = svgSize / 2
+    const r = (sz + config.borderWidth * 3) / 2
+    return `
+      &.is-${size} {
+        height: ${svgSize}px;
+        width: ${svgSize}px;
+
+        circle {
+          cx: ${c};
+          cy: ${c};
+          r: ${r};
+        }
+      }
+    `
+  })
+}
+
 export const AvatarUI = styled('div')`
   ${baseStyles};
   height: ${config.size.md.size}px;
@@ -287,6 +308,44 @@ export const AvatarUI = styled('div')`
   }
 
   ${getSizeStyles()};
+`
+
+export const CircleAnimationUI = styled('circle')`
+  fill: transparent;
+  stroke: ${buttonConfig.focusOutlineColor};
+  stroke-width: ${config.borderWidth};
+  stroke-dasharray: 700;
+  stroke-dashoffset: 700;
+  animation: rotate 1.2s ease-out;
+  animation-iteration-count: 1;
+
+  @keyframes rotate {
+    to {
+      stroke-dashoffset: 0;
+    }
+    65% {
+      opacity: 1;
+    }
+    80%,
+    100% {
+      opacity: 0;
+    }
+  }
+`
+
+export const BorderAnimationUI = styled('svg')`
+  position: absolute;
+  top: -${config.borderWidth * 2}px;
+  left: -${config.borderWidth * 2}px;
+  transform-origin: center;
+  transform: rotate(-90deg);
+  display: none;
+
+  &.is-animating {
+    display: block;
+  }
+
+  ${getBorderAnimationSizeStyles()};
 `
 
 export const AvatarButtonUI = styled('button')`
@@ -322,7 +381,7 @@ export const AvatarButtonUI = styled('button')`
   &.is-active,
   &:focus {
     z-index: 2;
-    .c-Avatar__focusBorder {
+    .c-Avatar__focusBorder:not(.is-animating) {
       display: block;
     }
     .c-Avatar__outerBorder {
@@ -341,7 +400,7 @@ export const AvatarButtonUI = styled('button')`
     }
   }
 
-  &.is-active .c-Avatar__focusBorder {
+  &.is-active .c-Avatar__focusBorder:not(.is-animating) {
     animation: none;
     opacity: 1;
   }

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -330,6 +330,17 @@ export const AvatarButtonUI = styled('button')`
     }
   }
 
+  &:focus {
+    .c-Avatar__action:before {
+      opacity: 1;
+      transform: scale(1);
+    }
+    .c-Avatar__action .c-Icon {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
   &.is-active .c-Avatar__focusBorder {
     animation: none;
     opacity: 1;

--- a/stories/Avatar/Avatar.stories.js
+++ b/stories/Avatar/Avatar.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Avatar, Flexy } from '../../src/index'
+import { Avatar, Flexy, Button } from '../../src/index'
 import { ThemeProvider } from '../../src/components/styled'
 import AvatarSpec from './specs/Avatar'
 
@@ -188,6 +188,8 @@ const iconSize = [
   '48',
   '52',
 ]
+const avatarSize = ['lg', 'md', 'smmd', 'sm', 'xs', 'xxs']
+
 stories.add('with action', () => (
   <Flexy just="left">
     <Avatar
@@ -198,8 +200,57 @@ stories.add('with action', () => (
       animateActionBorder={boolean('Animate', false)}
       actionIcon={select('Icon', ['trash', 'plus-large', 'hyphen'], 'trash')}
       actionIconSize={select('Icon Size', iconSize, '24')}
+      size={select('Avatar Size', avatarSize, 'lg')}
       shape={select('Shape', ['circle', 'square', 'rounded'], 'circle')}
       onActionClick={action('handle click action')}
+      fallbackImage="https://d33v4339jhl8k0.cloudfront.net/customer-avatar/01.png"
     />
+  </Flexy>
+))
+
+class AnimationSequence extends React.Component {
+  state = {
+    showLoadingAnimation: false,
+    forceShowFallbackImage: false,
+    fadeOutMainImage: false,
+    actionable: true,
+  }
+
+  startAnimation = () => {
+    this.setState({
+      removingAvatarAnimation: true,
+    })
+  }
+
+  render() {
+    return (
+      <div>
+        <Avatar
+          name={fixture.name}
+          image={fixture.image}
+          actionable={this.state.actionable}
+          removingAvatarAnimation={this.state.removingAvatarAnimation}
+          size="xl"
+          onActionClick={this.startAnimation}
+          fallbackImage="https://d33v4339jhl8k0.cloudfront.net/customer-avatar/01.png"
+        />
+        <Button
+          version={2}
+          onClick={() =>
+            this.setState({
+              removingAvatarAnimation: false,
+            })
+          }
+        >
+          Reset animation
+        </Button>
+      </div>
+    )
+  }
+}
+
+stories.add('with animation sequence', () => (
+  <Flexy just="left">
+    <AnimationSequence />
   </Flexy>
 ))

--- a/stories/Avatar/Avatar.stories.js
+++ b/stories/Avatar/Avatar.stories.js
@@ -195,6 +195,7 @@ stories.add('with action', () => (
       image={fixture.image}
       active={boolean('Is Active', false)}
       actionable={boolean('Actionable', true)}
+      animateActionBorder={boolean('Animate', false)}
       actionIcon={select('Icon', ['trash', 'plus-large', 'hyphen'], 'trash')}
       actionIconSize={select('Icon Size', iconSize, '24')}
       shape={select('Shape', ['circle', 'square', 'rounded'], 'circle')}


### PR DESCRIPTION
This update fixes an issue with the avatar button background color. In #685 we add replace the `<div>` with a `<button>` when the `Avatar` component is actionable. By doing that the default button background was still present. Now it will be a transparent background. 
 
**Before**
<img width="79" alt="Image 2019-08-27 at 3 07 12 PM" src="https://user-images.githubusercontent.com/203992/63800770-e01f0380-c8dc-11e9-9945-e0cf4a76ffc3.png">

**After**
<img width="82" alt="Image 2019-08-27 at 3 06 38 PM" src="https://user-images.githubusercontent.com/203992/63800775-e3b28a80-c8dc-11e9-99a6-824cd578d6bf.png">

### Remove avatar animation
This update add an animation sequence to remove an avatar. It will add a border animation, force load the fallback image and fade out the actual avatar. When the animation is completed, the avatar will not be clickable anymore

![Screen Recording 2019-08-29 at 03 44 PM](https://user-images.githubusercontent.com/203992/63973119-180e7e00-ca78-11e9-8ffc-a40fd184c32c.gif)

Right now this animation is only valid for the circle shape.