### PR TITLE
Fix z-index issue in Avatar/Status UI

### DIFF
--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -159,7 +159,7 @@ export const TitleUI = styled('div')`
 
 export const StatusUI = styled('div')`
   position: absolute;
-  z-index: 1;
+  z-index: 2;
 
   &.is-withBorder {
     transform: translate(-${config.borderWidth}px, -${config.borderWidth}px);


### PR DESCRIPTION
This fixes an `z-index` introduced in: https://github.com/helpscout/hsds-react/pull/691

## Before:

<img width="419" alt="Screen Shot 2019-09-04 at 10 00 05 PM" src="https://user-images.githubusercontent.com/7111256/64313365-4270a780-cf60-11e9-9f78-5bdea37edf96.png">

## After
<img width="299" alt="Screen Shot 2019-09-04 at 10 08 13 PM" src="https://user-images.githubusercontent.com/7111256/64313449-82378f00-cf60-11e9-825c-afacc5d71e34.png">

