### PR TITLE
Upgrade to colorway 0.3.0 to update all yellow.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1682,13 +1682,15 @@
       }
     },
     "@helpscout/colorway": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@helpscout/colorway/-/colorway-0.0.11.tgz",
-      "integrity": "sha512-0OutxeVLTMjDEMw9lQFyzUJN+v000FxI7obVdvKA6w77iEJLBZYpyiiPzcsosCUBxL8A3A/eBWO1KVnP3SR/qw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@helpscout/colorway/-/colorway-0.3.0.tgz",
+      "integrity": "sha512-zf+Ci7z9B56FqV/lsbWkAiGzltRtKPS4pjRCqEHwf6OY+kGgTuZxUkBDdiYOAbbKWatitO8zasYqYCPJA8VfWg==",
       "dev": true,
       "requires": {
+        "fast-glob": "^2.2.6",
         "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1"
+        "mkdirp": "^0.5.1",
+        "nearest-color": "^0.4.4"
       },
       "dependencies": {
         "minimist": {
@@ -16977,6 +16979,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nearest-color": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/nearest-color/-/nearest-color-0.4.4.tgz",
+      "integrity": "sha512-orhcaIORC10tf41Ld2wwlcC+FaAavHG87JHWB3eHH5p7v2k9Tzym2XNEZzLAm5YJwGv6Q38WWc7SOb+Qfu/4NQ==",
       "dev": true
     },
     "nearley": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.0.0",
     "@helpscout/artboard": "0.2.0",
-    "@helpscout/colorway": "0.0.11",
+    "@helpscout/colorway": "0.3.0",
     "@helpscout/cyan": "0.12.1",
     "@helpscout/helix": "^0.1.0",
     "@helpscout/hsds-illos": "1.4.4",

--- a/src/styles/configs/_colorway.scss
+++ b/src/styles/configs/_colorway.scss
@@ -1,4 +1,4 @@
-// Generated with @helpscout/colorway (v0.0.11)
+// Generated with @helpscout/colorway (v0.3.0)
 //
 // This file was automatically generated with @helpscout/colorway
 // Please don't modify this file. Your changes will be overwritten.
@@ -20,6 +20,23 @@
       700: #005ca4,
       800: #034077,
       900: #002651,
+    ),
+  )
+);
+
+@include _color(
+  (
+    yellow: (
+      default: #ffc555,
+      100: #fff9ef,
+      200: #fff2d7,
+      300: #ffe7b8,
+      400: #fdd88e,
+      500: #ffc555,
+      600: #fab347,
+      700: #e89635,
+      800: #ce7129,
+      900: #b24319,
     ),
   )
 );

--- a/src/styles/configs/colorway.ts
+++ b/src/styles/configs/colorway.ts
@@ -1,4 +1,4 @@
-// Generated with @helpscout/colorway (v0.0.11)
+// Generated with @helpscout/colorway (v0.3.0)
 //
 // This file was automatically generated with @helpscout/colorway
 // Please don't modify this file. Your changes will be overwritten.
@@ -39,16 +39,16 @@ const palette = {
     default: '#d6dde3',
   },
   yellow: {
-    '100': '#fffdf6',
-    '200': '#fff6e2',
-    '300': '#ffe8b5',
-    '400': '#ffd56d',
-    '500': '#ffc646',
-    '600': '#f5b126',
-    '700': '#d79400',
-    '800': '#b37100',
-    '900': '#875200',
-    default: '#ffc646',
+    '100': '#FFF9EF',
+    '200': '#FFF2D7',
+    '300': '#FFE7B8',
+    '400': '#FDD88E',
+    '500': '#FFC555',
+    '600': '#FAB347',
+    '700': '#E89635',
+    '800': '#CE7129',
+    '900': '#B24319',
+    default: '#FFC555',
   },
   green: {
     '100': '#fafdfb',


### PR DESCRIPTION
<img width="307" alt="Image 2019-09-05 at 11 15 05 AM" src="https://user-images.githubusercontent.com/203992/64364361-a89d0f00-cfe0-11e9-9080-6d1dba1ac312.png">

This update upgrade colorway to v0.3.0. This version contain the latest yellow color palette.

**noote** 
At some point we'll have to update seed to a newest version to get the latest _SCSS_ colors. It was not done for the blue update so I am leaning toward waiting that all colors were migrate before upgrading seed