### PR TITLE
Allow Dropdown Items to have a type of `header`

### DIFF
--- a/src/components/Dropdown/V2/Dropdown.Item.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Item.tsx
@@ -256,7 +256,7 @@ export class Item extends React.PureComponent<Props> {
       className
     )
 
-    if (type === 'group') return <Header {...this.props} />
+    if (type === 'group' || type === 'header') return <Header {...this.props} />
     if (type === 'divider') return <Divider />
 
     return (


### PR DESCRIPTION
This adds support for `Dropdown.Items` to have a type of `header`. This allows for a user to pass an item with the type of `header` in the array of items passed to the `Dropdown` component.

For example you can now:

```
const items = [ { type: 'header', label: 'Chat Status' }, ...items ]
```
