### PR TITLE
Fix Avatar that was flashing when loading was completed

### DIFF
--- a/src/components/Avatar/Avatar.Crop.tsx
+++ b/src/components/Avatar/Avatar.Crop.tsx
@@ -9,7 +9,6 @@ export const AvatarCrop = props => {
     animationEasing,
     className,
     children,
-    hasImage,
     isImageLoaded,
     withShadow,
   } = props
@@ -22,12 +21,12 @@ export const AvatarCrop = props => {
   )
 
   const styles = {
-    backgroundColor: isImageLoaded ? 'transparent' : 'currentColor',
+    // backgroundColor: isImageLoaded ? 'transparent' : 'currentColor',
     transition: `background-color ${animationDuration}ms ${getEasingTiming(
       animationEasing
     )}`,
   }
-
+  console.log(styles)
   return (
     <CropUI className={componentClassName} style={styles}>
       {children}

--- a/src/components/Avatar/Avatar.Crop.tsx
+++ b/src/components/Avatar/Avatar.Crop.tsx
@@ -21,12 +21,11 @@ export const AvatarCrop = props => {
   )
 
   const styles = {
-    // backgroundColor: isImageLoaded ? 'transparent' : 'currentColor',
     transition: `background-color ${animationDuration}ms ${getEasingTiming(
       animationEasing
     )}`,
   }
-  console.log(styles)
+
   return (
     <CropUI className={componentClassName} style={styles}>
       {children}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -93,6 +93,11 @@ export class Avatar extends React.PureComponent<Props, State> {
     imageLoaded: IMAGE_STATES.loading,
   }
 
+  shouldComponentUpdate(newProps, newState) {
+    console.log('shouldComponentUpdate', newProps, newState)
+    return true
+  }
+
   onImageLoadedError = () => {
     const { imageLoaded } = this.state
 
@@ -106,6 +111,7 @@ export class Avatar extends React.PureComponent<Props, State> {
     this.setState({
       imageLoaded: newImageLoaded,
     })
+    console.log('onImageLoaonImageLoadedErrordedSuccess', newImageLoaded)
     this.props.onError && this.props.onError()
   }
 
@@ -117,6 +123,10 @@ export class Avatar extends React.PureComponent<Props, State> {
         ? IMAGE_STATES.fallbackLoaded
         : IMAGE_STATES.loaded,
     })
+    console.log(
+      'onImageLoadedSuccess',
+      isFallbackLoading ? IMAGE_STATES.fallbackLoaded : IMAGE_STATES.loaded
+    )
     this.props.onLoad && this.props.onLoad()
   }
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -93,11 +93,6 @@ export class Avatar extends React.PureComponent<Props, State> {
     imageLoaded: IMAGE_STATES.loading,
   }
 
-  shouldComponentUpdate(newProps, newState) {
-    console.log('shouldComponentUpdate', newProps, newState)
-    return true
-  }
-
   onImageLoadedError = () => {
     const { imageLoaded } = this.state
 
@@ -111,7 +106,6 @@ export class Avatar extends React.PureComponent<Props, State> {
     this.setState({
       imageLoaded: newImageLoaded,
     })
-    console.log('onImageLoaonImageLoadedErrordedSuccess', newImageLoaded)
     this.props.onError && this.props.onError()
   }
 
@@ -123,10 +117,7 @@ export class Avatar extends React.PureComponent<Props, State> {
         ? IMAGE_STATES.fallbackLoaded
         : IMAGE_STATES.loaded,
     })
-    console.log(
-      'onImageLoadedSuccess',
-      isFallbackLoading ? IMAGE_STATES.fallbackLoaded : IMAGE_STATES.loaded
-    )
+
     this.props.onLoad && this.props.onLoad()
   }
 

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -68,11 +68,11 @@ describe('Image', () => {
   })
 
   test('Background is currentColor to prevent flash of color before image loads', () => {
-    const wrapper = mount(<Avatar name="Buddy the Elf" image="buddy.jpg" />)
-    const crop = wrapper.find(`div${ui.crop}`)
+    cy.render(<Avatar name="Buddy the Elf" image="buddy.jpg" />)
+    const crop = cy.get(`div${ui.crop}`)
 
     expect(crop.exists()).toBeTruthy()
-    expect(crop.prop('style').backgroundColor).toEqual('currentColor')
+    expect(crop.getComputedStyle().backgroundColor).toEqual('currentColor')
   })
 
   test('Do not render image if image prop is specified but image is loading', () => {

--- a/stories/Avatar/Avatar.stories.js
+++ b/stories/Avatar/Avatar.stories.js
@@ -5,13 +5,8 @@ import { ThemeProvider } from '../../src/components/styled'
 import AvatarSpec from './specs/Avatar'
 
 import { action } from '@storybook/addon-actions'
-import {
-  withKnobs,
-  boolean,
-  number,
-  text,
-  select,
-} from '@storybook/addon-knobs'
+import { getColor } from '../../src/styles/utilities/color'
+import { withKnobs, boolean, select } from '@storybook/addon-knobs'
 
 const stories = storiesOf('Avatar', module)
 
@@ -24,7 +19,9 @@ stories.addDecorator(
 const fixture = AvatarSpec.generate()
 
 stories.add('default', () => (
-  <Avatar name={fixture.name} image={fixture.image} />
+  <ThemeProvider theme={{ brandColor: { brandColor: getColor('grey.300') } }}>
+    <Avatar name={fixture.name} image={fixture.image} />
+  </ThemeProvider>
 ))
 
 stories.add('failed', () => (


### PR DESCRIPTION
The avatar component was flashing when updating the state from loading to loaded. It was cause by the Avatar.Crop component changing his background image to currentColor to transparent.

By removing that line we make sure the avatar will fade in on top of the placeholder color

![Screen Recording 2019-09-16 at 10 54 AM](https://user-images.githubusercontent.com/203992/64968799-be2bf780-d870-11e9-8a3f-b4e6d5775f6d.gif)
