### PR TITLE
Update Truncate documentation

### DIFF
--- a/src/components/Truncate/README.md
+++ b/src/components/Truncate/README.md
@@ -1,6 +1,8 @@
 # Truncate
 
 A truncate component is a light-weight text wrapper with the ability to truncate text at the start, middle, or end.
+It will also allow you to truncate a section of a string based on the presence of a splitter prop, like the `@` in
+an email address.
 
 ## Example
 
@@ -10,13 +12,14 @@ A truncate component is a light-weight text wrapper with the ability to truncate
 
 ## Props
 
-| Prop              | Type      | Description                                                               |
-| ----------------- | --------- | ------------------------------------------------------------------------- |
-| className         | `string`  | Custom class names to be added to the component.                          |
-| ellipsis          | `string`  | Characters to show during truncation.                                     |
-| limit             | `number`  | The amount of characters to keep before truncation.                       |
-| shouldShowTooltip | `boolean` | Renders a [Tooltip](../Tooltip) if content is truncated. Default `false`. |
-| type              | `string`  | Location of truncation.                                                   |
+| Prop              | Type      | Description                                                                |
+| ----------------- | --------- | -------------------------------------------------------------------------- |
+| className         | `string`  | Custom class names to be added to the component.                           |
+| ellipsis          | `string`  | Characters to show during truncation.                                      |
+| limit             | `number`  | The amount of characters to keep before truncation.                        |
+| shouldShowTooltip | `boolean` | Renders a [Tooltip](../Tooltip) if content is truncated. Default `false`.  |
+| splitter          | `string`  | Char to split string on for truncating mid-string, `longEma...@email.com`. |
+| type              | `string`  | Location of truncation.                                                    |
 
 ### `type`
 

--- a/stories/Truncate.stories.js
+++ b/stories/Truncate.stories.js
@@ -36,12 +36,10 @@ stories.add('default', () => (
         {fixture.generate()}
       </Truncate>
     </p>
-    <p style={{ width: '25%' }}>
+    <p>
       Truncate by Splitter:
       <br />
-      <Truncate type="start" limit={limit} splitter="@">
-        longemailaddress@gmail.com
-      </Truncate>
+      <Truncate splitter="@">longemailaddress@gmail.com</Truncate>
     </p>
     <br />
   </div>


### PR DESCRIPTION
Documentation updates that got left out of #703 accidentally:

This PR updates the `<Truncate />` documentation to include the new `splitter` prop, and removes some unnecessary props from the new splitter example in the Truncate story. 