### PR TITLE
EditableField: Fixes email type UI glitches

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,6 @@ module.exports = {
     'no-dupe-class-members': 'off',
 
     // Add TypeScript specific rules (and turn off ESLint equivalents)
-    '@typescript-eslint/no-angle-bracket-type-assertion': 'warn',
     'no-array-constructor': 'off',
     '@typescript-eslint/no-array-constructor': 'warn',
     '@typescript-eslint/no-namespace': 'error',

--- a/src/components/EditableField/EditableField.Input.tsx
+++ b/src/components/EditableField/EditableField.Input.tsx
@@ -326,7 +326,7 @@ export class EditableFieldInput extends React.Component<InputProps> {
             innerRef={this.setInputNode}
             name={name}
             placeholder={placeholder}
-            type={type}
+            type={type === 'email' ? 'text' : type}
             value={fieldValue.value}
             onBlur={this.handleInputBlur}
             onChange={this.handleChange}

--- a/src/components/EditableField/EditableField.Truncated.tsx
+++ b/src/components/EditableField/EditableField.Truncated.tsx
@@ -17,10 +17,10 @@ const Truncated = ({ string, splitter }: TruncateProps) => {
         }`}
       >
         <span className={`${TRUNCATED_CLASSNAMES.firstChunk}`}>{first}</span>
-        <span className={`${TRUNCATED_CLASSNAMES.splitterChunk}`}>
+        <span className={`${TRUNCATED_CLASSNAMES.secondChunk}`}>
           {splitter}
+          {second}
         </span>
-        <span className={`${TRUNCATED_CLASSNAMES.secondChunk}`}>{second}</span>
       </TruncatedUI>
     )
   }

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -28,7 +28,6 @@ import {
 } from './EditableField.utils'
 import { key } from '../../constants/Keys'
 import { noop } from '../../utilities/other'
-// import { createUniqueIDFactory } from '../../utilities/id'
 import { isArray, isFunction } from '../../utilities/is'
 import { find } from '../../utilities/arrays'
 

--- a/src/components/EditableField/EditableField.utils.ts
+++ b/src/components/EditableField/EditableField.utils.ts
@@ -243,7 +243,6 @@ export const TRUNCATED_CLASSNAMES = {
   component: TRUNCATED_COMPONENT_KEY,
   withSplitter: 'withSplitter',
   firstChunk: `${TRUNCATED_COMPONENT_KEY}__firstChunk`,
-  splitterChunk: `${TRUNCATED_COMPONENT_KEY}__splitterChunk`,
   secondChunk: `${TRUNCATED_COMPONENT_KEY}__secondChunk`,
 }
 

--- a/src/components/EditableField/__tests__/EditableField.Mask.test.tsx
+++ b/src/components/EditableField/__tests__/EditableField.Mask.test.tsx
@@ -57,14 +57,10 @@ describe('email type', () => {
       cy.get(`.${TRUNCATED_CLASSNAMES.withSplitter}`).exists()
     ).toBeTruthy()
     expect(cy.get(`.${TRUNCATED_CLASSNAMES.firstChunk}`).exists()).toBeTruthy()
-    expect(
-      cy.get(`.${TRUNCATED_CLASSNAMES.splitterChunk}`).exists()
-    ).toBeTruthy()
     expect(cy.get(`.${TRUNCATED_CLASSNAMES.secondChunk}`).exists()).toBeTruthy()
     expect(cy.get(`.${TRUNCATED_CLASSNAMES.firstChunk}`).text()).toBe('email')
-    expect(cy.get(`.${TRUNCATED_CLASSNAMES.splitterChunk}`).text()).toBe('@')
     expect(cy.get(`.${TRUNCATED_CLASSNAMES.secondChunk}`).text()).toBe(
-      'somethingcool.com'
+      '@somethingcool.com'
     )
   })
 })

--- a/src/components/EditableField/__tests__/EditableField.test.tsx
+++ b/src/components/EditableField/__tests__/EditableField.test.tsx
@@ -40,6 +40,13 @@ describe('HTML props', () => {
 
     expect(el.exists()).toBeTruthy()
   })
+
+  test('email type should have input text type', () => {
+    cy.render(<EditableField type="email" name="company" />)
+    const el = cy.get('input')
+
+    expect(el.getAttribute('type')).toBe('text')
+  })
 })
 
 describe('Label', () => {

--- a/src/components/EditableField/__tests__/EditableField.truncated.test.tsx
+++ b/src/components/EditableField/__tests__/EditableField.truncated.test.tsx
@@ -17,14 +17,10 @@ describe('Editable Field truncate', () => {
       cy.get(`.${TRUNCATED_CLASSNAMES.withSplitter}`).exists()
     ).toBeTruthy()
     expect(cy.get(`.${TRUNCATED_CLASSNAMES.firstChunk}`).exists()).toBeTruthy()
-    expect(
-      cy.get(`.${TRUNCATED_CLASSNAMES.splitterChunk}`).exists()
-    ).toBeTruthy()
     expect(cy.get(`.${TRUNCATED_CLASSNAMES.secondChunk}`).exists()).toBeTruthy()
     expect(cy.get(`.${TRUNCATED_CLASSNAMES.firstChunk}`).text()).toBe('email')
-    expect(cy.get(`.${TRUNCATED_CLASSNAMES.splitterChunk}`).text()).toBe('@')
     expect(cy.get(`.${TRUNCATED_CLASSNAMES.secondChunk}`).text()).toBe(
-      'something.com'
+      '@something.com'
     )
   })
 })

--- a/src/components/EditableField/styles/EditableField.Mask.css.ts
+++ b/src/components/EditableField/styles/EditableField.Mask.css.ts
@@ -154,7 +154,6 @@ export const MaskValueUI = styled('span')`
   }
 
   &:focus {
-    width: auto;
     outline: 0;
     border-bottom: 1px dashed ${COLOURS.mask.focused};
 

--- a/src/components/EditableField/styles/EditableField.Truncated.css.ts
+++ b/src/components/EditableField/styles/EditableField.Truncated.css.ts
@@ -5,12 +5,17 @@ export const TruncatedUI = styled('div')`
   display: flex;
   width: 100%;
   max-width: 100%;
+  overflow: hidden;
 
   .${TRUNCATED_CLASSNAMES.firstChunk} {
     flex-shrink: 2;
-    min-width: 20px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .${TRUNCATED_CLASSNAMES.secondChunk} {
+    max-width: 90%;
+    flex-shrink: 0;
   }
 `

--- a/stories/EditableField.stories.js
+++ b/stories/EditableField.stories.js
@@ -158,6 +158,7 @@ stories.add('Email Multiple', () => (
       placeholder="Add your email"
       type="email"
       value={[
+        'a@hello.com',
         'art_vandelay@vandelayindustries.com',
         'john_locke@dharma.org',
         'pennypacker@kramerica.com',


### PR DESCRIPTION
## Problems

There were a couple of visual bugs on email type fields reported by Jared:
1. Extra spacing: http://c.hlp.sc/ac63799be531
2. Weird deletion behaviour when space present in value: http://c.hlp.sc/7a4b054a1277

## Solutions

### 1. Extra spacing

Before, I had a minimum width on the "first chunk" (the part before the _@_), which in cases like a single letter name, would be too much and show extra space.

I removed the minimum width and instead applied a couple of rules to the second chunk (the domain), I also simplified the markup and included the _@_ in the second chunk to avoid some cases in which I noticed there was some extra space added to the first chunk because of how flexbox behaves.

### 2. Character deletion when spaces present

This was a Chrome only bug, present when adding an "email" type to the input, I'm not sure why exactly, but the solution was to give the input a type of text even when given an email type, this shouldn't be a problem because we are using our own validation and not the browser bundled one.