### PR TITLE
EditableField: Disabling multiple fields at the same time

### DIFF
--- a/src/components/EditableField/EditableField.Mask.tsx
+++ b/src/components/EditableField/EditableField.Mask.tsx
@@ -47,10 +47,13 @@ export class EditableFieldMask extends React.Component<MaskProps> {
     const { name, maskTabIndex } = this.props
     const valueNode = this.valueRef
 
-    if (prevProps.maskTabIndex == null && maskTabIndex === name) {
+    if (prevProps.maskTabIndex !== maskTabIndex && maskTabIndex === name) {
       valueNode.setAttribute('tabindex', '0')
       valueNode.focus()
-    } else if (prevProps.maskTabIndex === name && maskTabIndex == null) {
+    } else if (
+      prevProps.maskTabIndex === name &&
+      (maskTabIndex == null || maskTabIndex === prevProps.maskTabIndex)
+    ) {
       valueNode && valueNode.removeAttribute('tabindex')
       valueNode.blur()
     }

--- a/src/components/EditableField/EditableField.tsx
+++ b/src/components/EditableField/EditableField.tsx
@@ -965,7 +965,7 @@ export class EditableField extends React.Component<
               />
               {actions &&
               Boolean(val.value) &&
-              disabledItem.indexOf(val.id) !== -1 &&
+              disabledItem.indexOf(val.id) === -1 &&
               !disabled ? (
                 <Actions
                   actions={actions}

--- a/src/components/EditableField/EditableField.types.ts
+++ b/src/components/EditableField/EditableField.types.ts
@@ -128,7 +128,7 @@ export interface EditableFieldState {
   actions?: FieldAction[]
   activeField: string
   defaultOption: string | null
-  disabledItem: string
+  disabledItem: string[]
   fieldValue: FieldValue[]
   initialFieldValue: FieldValue[]
   maskTabIndex: string | null

--- a/src/components/EditableField/__tests__/EditableField.test.tsx
+++ b/src/components/EditableField/__tests__/EditableField.test.tsx
@@ -1261,7 +1261,7 @@ describe('should component update', () => {
       ...actualState,
     }
     const newStateChanged = {
-      maskTabIndex: ['something'],
+      maskTabIndex: 'something',
     }
 
     expect(

--- a/src/components/EditableField/__tests__/EditableField.test.tsx
+++ b/src/components/EditableField/__tests__/EditableField.test.tsx
@@ -1261,7 +1261,7 @@ describe('should component update', () => {
       ...actualState,
     }
     const newStateChanged = {
-      maskTabIndex: 'something',
+      maskTabIndex: ['something'],
     }
 
     expect(
@@ -1285,7 +1285,7 @@ describe('should component update', () => {
       ...actualState,
     }
     const newStateChanged = {
-      disabledItem: 'something',
+      disabledItem: ['something'],
     }
 
     expect(

--- a/stories/EditableField.stories.js
+++ b/stories/EditableField.stories.js
@@ -329,58 +329,129 @@ stories.add('Disabled', () => (
   </ContainerUI>
 ))
 
-stories.add('Validation', () => (
-  <ContainerUI
-    onSubmit={e => {
-      e.preventDefault()
-    }}
-  >
-    <NoteUI>
-      Type:
-      <ul>
-        <li>
-          <strong>"off"</strong> to get the error style
-        </li>
-        <li>
-          <strong>"warn"</strong> to get a warning style
-        </li>
-        <li>
-          <strong>"other"</strong> to get a custom validation style
-        </li>
-      </ul>
-    </NoteUI>
-    <EditableField
-      label="team"
-      name="team"
-      placeholder="Add a team name"
-      type="text"
-      value="atlas"
-      validate={validateFieldValue}
-    />
-    <EditableField
-      label="Musicians"
-      name="musicians"
-      type="text"
-      placeholder="Add a musician name"
-      value={['George Harrison', 'Neil Young']}
-      validate={validateFieldValue}
-    />
+class ValidationApp extends React.Component {
+  state = { timeout: 100 }
 
-    <EditableField
-      label="Favourite Paint Colour"
-      name="paint"
-      placeholder="Add a colour"
-      type="text"
-      valueOptions={PAINT_OPTIONS}
-      value={[
-        { option: PAINT_OPTIONS[0], value: 'Anthraquinone Blue PB60' },
-        { option: PAINT_OPTIONS[3], value: 'Ultramarine Violet' },
-        { option: PAINT_OPTIONS[1], value: 'Bismuth Yellow' },
-      ]}
-      validate={validateFieldValue}
-    />
-  </ContainerUI>
-))
+  validateFieldValue = payload => {
+    const { name, value } = payload
+    let isValid = value !== 'off' && value !== 'other' && value !== 'warn'
+
+    return new Promise(resolve => {
+      setTimeout(function() {
+        if (isValid) {
+          resolve({ isValid, name, value })
+        } else {
+          if (value === 'off') {
+            resolve({
+              isValid,
+              name,
+              value,
+              type: 'error',
+              message: 'That is definitely not right',
+            })
+          } else if (value === 'warn') {
+            resolve({
+              isValid,
+              name,
+              value,
+              type: 'warning',
+              message: "That's it, you have been warned",
+            })
+          } else if (value === 'other') {
+            resolve({
+              isValid,
+              name,
+              value,
+              type: 'other',
+              message: "I don't know what you're talking about, have a trophy",
+              color: '#57c28d',
+              icon: 'activity',
+            })
+          }
+        }
+      }, this.state.timeout)
+    })
+  }
+
+  render() {
+    const { timeout } = this.state
+
+    return (
+      <ContainerUI
+        onSubmit={e => {
+          e.preventDefault()
+        }}
+      >
+        <NoteUI>
+          Type:
+          <ul>
+            <li>
+              <strong>"off"</strong> to get the error style
+            </li>
+            <li>
+              <strong>"warn"</strong> to get a warning style
+            </li>
+            <li>
+              <strong>"other"</strong> to get a custom validation style
+            </li>
+          </ul>
+          <p>Delay the time it takes for the validation to resolve:</p>
+          <label htmlFor="timoeut">
+            Timeout:
+            <input
+              style={{
+                marginLeft: '10px',
+                width: '70px',
+                padding: '3px',
+                textAlign: 'right',
+                borderRadius: '3px',
+                border: '0',
+              }}
+              type="number"
+              value={timeout}
+              onChange={event => {
+                this.setState({ timeout: event.target.value })
+              }}
+            />{' '}
+            ms
+          </label>
+        </NoteUI>
+        <EditableField
+          label="team"
+          name="team"
+          placeholder="Add a team name"
+          type="text"
+          value="atlas"
+          validate={this.validateFieldValue}
+        />
+        <EditableField
+          label="Musicians"
+          name="musicians"
+          type="text"
+          placeholder="Add a musician name"
+          value={['George Harrison', 'Neil Young']}
+          validate={this.validateFieldValue}
+        />
+
+        <EditableField
+          label="Favourite Paint Colour"
+          name="paint"
+          placeholder="Add a colour"
+          type="text"
+          valueOptions={PAINT_OPTIONS}
+          value={[
+            { option: PAINT_OPTIONS[0], value: 'Anthraquinone Blue PB60' },
+            { option: PAINT_OPTIONS[3], value: 'Ultramarine Violet' },
+            { option: PAINT_OPTIONS[1], value: 'Bismuth Yellow' },
+          ]}
+          validate={this.validateFieldValue}
+        />
+      </ContainerUI>
+    )
+  }
+}
+
+stories.add('Validation', () => <ValidationApp />)
 
 stories.add('Key Events', () => (
   <ContainerUI
@@ -397,45 +468,6 @@ stories.add('Key Events', () => (
     />
   </ContainerUI>
 ))
-
-function validateFieldValue(payload) {
-  const { name, value } = payload
-  let isValid = value !== 'off' && value !== 'other' && value !== 'warn'
-
-  return new Promise(resolve => {
-    if (isValid) {
-      resolve({ isValid, name, value })
-    } else {
-      if (value === 'off') {
-        resolve({
-          isValid,
-          name,
-          value,
-          type: 'error',
-          message: 'That is definitely not right',
-        })
-      } else if (value === 'warn') {
-        resolve({
-          isValid,
-          name,
-          value,
-          type: 'warning',
-          message: "That's it, you have been warned",
-        })
-      } else if (value === 'other') {
-        resolve({
-          isValid,
-          name,
-          value,
-          type: 'other',
-          message: "I don't know what you're talking about, have a trophy",
-          color: '#57c28d',
-          icon: 'activity',
-        })
-      }
-    }
-  })
-}
 
 class ValuePropsApp extends React.Component {
   state = {


### PR DESCRIPTION
This PR addresses @knicklabs suggestion:

> When we are validating a field asynchronously we disable it and we keep track of the disabled item in the local state. I believe the disabled item should be an array of fields, not a single field, since it is possible that more than one field could be validating at one time.

I updated the validation story 📚 , it includes a field to enter a number in ms to delay the resolving of the validation promise (makes it easier to visualize how the disabling is behaving)