### PR TITLE
COMMS-299: Truncate the select dropdown labels when they're really long

### DIFF
--- a/src/components/SelectDropdown/styles/SelectDropdown.css.ts
+++ b/src/components/SelectDropdown/styles/SelectDropdown.css.ts
@@ -42,6 +42,7 @@ export const LabelUI = styled('div')`
   --BlueConfigGlobalFontSize: 14px;
   font-size: 14px;
   color: #2a3b47;
+  max-width: 100%;
   padding-right: 20px;
   position: relative;
   text-decoration: none !important;

--- a/stories/SelectDropdown.stories.js
+++ b/stories/SelectDropdown.stories.js
@@ -45,6 +45,26 @@ stories.add('Default', () => {
   return <SelectDropdown {...props} />
 })
 
+stories.add('Really long items', () => {
+  const props = {
+    items: [
+      {
+        label:
+          'Will has a really really really really really really really really really really really really really really really long name',
+        value: '1',
+      },
+      {
+        label:
+          'Ron has a really really really really really really really really really really really really really really really long name',
+        value: '2',
+      },
+    ],
+    value: null,
+  }
+
+  return <SelectDropdown {...props} />
+})
+
 stories.add('Statefully controlled', () => {
   class Example extends React.Component {
     state = {


### PR DESCRIPTION
https://helpscout.atlassian.net/browse/COMMS-299

Before:

![Screen Shot 2019-10-02 at 15 11 16](https://user-images.githubusercontent.com/6132043/66051690-2e03d880-e527-11e9-8796-00a78dc94451.png)

After:

![Screen Shot 2019-10-02 at 15 09 11](https://user-images.githubusercontent.com/6132043/66051699-31975f80-e527-11e9-9f11-aece43da8209.png)
