### PR TITLE
Revert "HSDS-77 Fix Truncate component to show tooltip when truncated on splitter'"

### DIFF
--- a/src/components/Truncate/README.md
+++ b/src/components/Truncate/README.md
@@ -12,14 +12,14 @@ an email address.
 
 ## Props
 
-| Prop                  | Type      | Description                                                                |
-| --------------------- | --------- | -------------------------------------------------------------------------- |
-| className             | `string`  | Custom class names to be added to the component.                           |
-| ellipsis              | `string`  | Characters to show during truncation.                                      |
-| limit                 | `number`  | The amount of characters to keep before truncation.                        |
-| showTooltipOnTruncate | `boolean` | Renders a [Tooltip](../Tooltip) if content is truncated. Default `false`.  |
-| splitter              | `string`  | Char to split string on for truncating mid-string, `longEma...@email.com`. |
-| type                  | `string`  | Location of truncation.                                                    |
+| Prop              | Type      | Description                                                                |
+| ----------------- | --------- | -------------------------------------------------------------------------- |
+| className         | `string`  | Custom class names to be added to the component.                           |
+| ellipsis          | `string`  | Characters to show during truncation.                                      |
+| limit             | `number`  | The amount of characters to keep before truncation.                        |
+| shouldShowTooltip | `boolean` | Renders a [Tooltip](../Tooltip) if content is truncated. Default `false`.  |
+| splitter          | `string`  | Char to split string on for truncating mid-string, `longEma...@email.com`. |
+| type              | `string`  | Location of truncation.                                                    |
 
 ### `type`
 

--- a/src/components/Truncate/Truncate.tsx
+++ b/src/components/Truncate/Truncate.tsx
@@ -76,25 +76,16 @@ export class Truncate extends React.PureComponent<
       this.contentNode.style.display = 'initial'
       // 2. Calculate the differences
       const isContentTruncated =
-        props.splitter && props.showTooltipOnTruncate
-          ? this.isSplitContentTruncated(this.contentNode, this.node)
-          : // TODO: fix typescript complains
-            // @ts-ignore
-            this.contentNode.offsetWidth > this.node.offsetWidth
+        // TODO: fix typescript complains
+        // @ts-ignore
+        this.contentNode.offsetWidth > this.node.offsetWidth
       // 3. Resets the display
       // TODO: fix typescript complains
       // @ts-ignore
+      this.contentNode.style.display = null
 
       return isContentTruncated
     }
-  }
-
-  isSplitContentTruncated = (contentNode: any, node: any): boolean => {
-    return (
-      contentNode.offsetWidth <
-      node.querySelector(`.${TRUNCATED_CLASSNAMES.firstChunk}`).scrollWidth +
-        node.querySelector(`.${TRUNCATED_CLASSNAMES.secondChunk}`).scrollWidth
-    )
   }
 
   getText = (props: TruncateProps = this.props) => {
@@ -142,8 +133,10 @@ export class Truncate extends React.PureComponent<
           }`}
         >
           <span className={`${TRUNCATED_CLASSNAMES.firstChunk}`}>{first}</span>
-          <span className={`${TRUNCATED_CLASSNAMES.secondChunk}`}>
+          <span className={`${TRUNCATED_CLASSNAMES.splitterChunk}`}>
             {splitter}
+          </span>
+          <span className={`${TRUNCATED_CLASSNAMES.secondChunk}`}>
             {second}
           </span>
         </TruncateWithSplitterUI>

--- a/src/components/Truncate/Truncate.utils.ts
+++ b/src/components/Truncate/Truncate.utils.ts
@@ -4,5 +4,6 @@ export const TRUNCATED_CLASSNAMES = {
   component: TRUNCATED_COMPONENT_KEY,
   withSplitter: 'with-splitter',
   firstChunk: `${TRUNCATED_COMPONENT_KEY}__first`,
+  splitterChunk: `${TRUNCATED_COMPONENT_KEY}__splitter`,
   secondChunk: `${TRUNCATED_COMPONENT_KEY}__second`,
 }

--- a/src/components/Truncate/__tests__/Truncate.test.js
+++ b/src/components/Truncate/__tests__/Truncate.test.js
@@ -66,8 +66,11 @@ describe('splitter', () => {
     expect(wrapper.find(`.${TRUNCATED_CLASSNAMES.firstChunk}`).text()).toBe(
       'longemailaddress'
     )
+    expect(wrapper.find(`.${TRUNCATED_CLASSNAMES.splitterChunk}`).text()).toBe(
+      '@'
+    )
     expect(wrapper.find(`.${TRUNCATED_CLASSNAMES.secondChunk}`).text()).toBe(
-      '@gmail.com'
+      'gmail.com'
     )
   })
 })
@@ -236,19 +239,6 @@ describe('Truncate: Check', () => {
 describe('Tooltip', () => {
   test('Renders tooltip if truncated', () => {
     const wrapper = mount(<Truncate showTooltipOnTruncate>Words</Truncate>)
-    wrapper.setState({ isTruncated: false })
-    expect(wrapper.find(Tooltip).length).toBe(0)
-
-    wrapper.setState({ isTruncated: true })
-    expect(wrapper.find(Tooltip).length).toBe(1)
-  })
-
-  test('Renders tooltip if truncated using splitter prop', () => {
-    const wrapper = mount(
-      <Truncate showTooltipOnTruncate splitter="@">
-        averylongemailaddress@gmail.com
-      </Truncate>
-    )
     wrapper.setState({ isTruncated: false })
     expect(wrapper.find(Tooltip).length).toBe(0)
 

--- a/src/components/Truncate/styles/Truncate.WithSplitter.css.ts
+++ b/src/components/Truncate/styles/Truncate.WithSplitter.css.ts
@@ -8,13 +8,9 @@ export const TruncateWithSplitterUI = styled('div')`
 
   .${TRUNCATED_CLASSNAMES.firstChunk} {
     flex-shrink: 2;
+    min-width: 21px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  .${TRUNCATED_CLASSNAMES.secondChunk} {
-    max-width: 90%;
-    flex-shrink: 0;
   }
 `

--- a/stories/Truncate.stories.js
+++ b/stories/Truncate.stories.js
@@ -37,16 +37,9 @@ stories.add('default', () => (
       </Truncate>
     </p>
     <p>
-      Truncate by Splitter - resize display window:
+      Truncate by Splitter:
       <br />
-      <Truncate splitter="@">a@hello.com</Truncate>
-      <Truncate splitter="@">art_vandelay@vandelayindustries.com</Truncate>
-      <Truncate splitter="@">john_locke@dharma.org</Truncate>
-      <Truncate splitter="@">pennypacker@kramerica.com</Truncate>
-      <Truncate splitter="@">this_is_kind_of_long@annoyingemails.com</Truncate>
-      <Truncate splitter="@">
-        this_is_kind_of_long@evenmoreannoyingemails.com
-      </Truncate>
+      <Truncate splitter="@">longemailaddress@gmail.com</Truncate>
     </p>
     <br />
   </div>
@@ -78,13 +71,6 @@ stories.add('tooltip', () => (
       <br />
       <Truncate showTooltipOnTruncate type="end" limit={limit}>
         {fixture.generate()}
-      </Truncate>
-    </p>
-    <p>
-      Truncate by Splitter - resize display window:
-      <br />
-      <Truncate showTooltipOnTruncate splitter="@">
-        longemailaddress@gmail.com
       </Truncate>
     </p>
     <br />


### PR DESCRIPTION
Reverts helpscout/hsds-react#717

In prod, but not in Storybook, tooltips are showing up even when an email is not truncated.