### PR TITLE
Fix Input Width if is Error

### DIFF
--- a/src/components/Input/styles/Input.css.js
+++ b/src/components/Input/styles/Input.css.js
@@ -224,6 +224,10 @@ export function makeFieldStyles() {
     width: 100%;
     z-index: 1;
 
+    &.is-error {
+      width: calc(100% - 24px);
+    }
+
     &:focus {
       outline: none;
     }

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -242,6 +242,10 @@ stories.add('states', () => (
 
 stories.add('state: error', () => (
   <div>
+    <div style={{ width: 100 }}>
+      <Input state="error" errorMessage="This is incorrect!" />
+    </div>
+    <br />
     <Input state="error" errorMessage="This is incorrect!" />
     <br />
     <Input state="error" inlineSuffix=".00" errorMessage="This is incorrect!" />


### PR DESCRIPTION
This PR fixes a bug with Error states in the Input Component.

In condition builder in Messages we were having a problem in FireFox with slimmer inputs. This fixes that problem, so that the width of the input is calculated if there is an error.

http://c.hlp.sc/997ff0c21c71