### PR TITLE
Fix avatar styles

### DIFF
--- a/src/components/Avatar/Avatar.Crop.tsx
+++ b/src/components/Avatar/Avatar.Crop.tsx
@@ -21,7 +21,6 @@ export const AvatarCrop = props => {
   )
 
   const styles = {
-    color: 'transparent',
     transition: `background-color ${animationDuration}ms ${getEasingTiming(
       animationEasing
     )}`,

--- a/src/components/Avatar/Avatar.Crop.tsx
+++ b/src/components/Avatar/Avatar.Crop.tsx
@@ -9,6 +9,7 @@ export const AvatarCrop = props => {
     animationEasing,
     className,
     children,
+    hasImage,
     isImageLoaded,
     withShadow,
   } = props
@@ -27,7 +28,7 @@ export const AvatarCrop = props => {
   }
 
   return (
-    <CropUI className={componentClassName} style={styles}>
+    <CropUI className={componentClassName} hasImage={hasImage} style={styles}>
       {children}
     </CropUI>
   )

--- a/src/components/Avatar/Avatar.Crop.tsx
+++ b/src/components/Avatar/Avatar.Crop.tsx
@@ -21,6 +21,7 @@ export const AvatarCrop = props => {
   )
 
   const styles = {
+    color: 'transparent',
     transition: `background-color ${animationDuration}ms ${getEasingTiming(
       animationEasing
     )}`,

--- a/src/components/Avatar/Avatar.Image.tsx
+++ b/src/components/Avatar/Avatar.Image.tsx
@@ -28,6 +28,7 @@ export const AvatarImage = props => {
   const backgroundImage = isImageLoaded ? `url('${image}')` : null
 
   const imageStyle = {
+    transform: 'none',
     transition: `opacity ${animationDuration}ms ${getEasingTiming(
       animationEasing
     )}`,

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -68,11 +68,21 @@ describe('Image', () => {
   })
 
   test('Background is currentColor to prevent flash of color before image loads', () => {
-    cy.render(<Avatar name="Buddy the Elf" image="buddy.jpg" />)
+    cy.render(<Avatar name="Buddy the Elf" image="buddy.jpg" image="" />)
     const crop = cy.get(`div${ui.crop}`)
 
     expect(crop.exists()).toBeTruthy()
     expect(crop.getComputedStyle().backgroundColor).toEqual('currentColor')
+  })
+
+  test('Background is transparent if there is an image', () => {
+    cy.render(
+      <Avatar name="Buddy the Elf" image="buddy.jpg" image="buddy.jpg" />
+    )
+    const crop = cy.get(`div${ui.crop}`)
+
+    expect(crop.exists()).toBeTruthy()
+    expect(crop.getComputedStyle().backgroundColor).toEqual('transparent')
   })
 
   test('Do not render image if image prop is specified but image is loading', () => {

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -95,7 +95,7 @@ export const ActionUI = styled('div')`
 export const CropUI = styled('div')`
   align-items: center;
   background-color: ${({ hasImage }) =>
-    hasImage ? 'tranparent' : 'currentColor'};
+    hasImage ? 'transparent' : 'currentColor'};
   border-radius: 200%;
   display: flex;
   height: 100%;

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -109,6 +109,7 @@ export const CropUI = styled('div')`
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0) inset, ${config.boxShadow};
 
     &.is-imageLoaded {
+      color: 'transparent';
       box-shadow: 0 0 0 1px rgba(255, 255, 255, 1) inset, ${config.boxShadow};
     }
   }

--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -94,7 +94,8 @@ export const ActionUI = styled('div')`
 
 export const CropUI = styled('div')`
   align-items: center;
-  background-color: currentColor;
+  background-color: ${({ hasImage }) =>
+    hasImage ? 'tranparent' : 'currentColor'};
   border-radius: 200%;
   display: flex;
   height: 100%;
@@ -109,7 +110,6 @@ export const CropUI = styled('div')`
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0) inset, ${config.boxShadow};
 
     &.is-imageLoaded {
-      color: 'transparent';
       box-shadow: 0 0 0 1px rgba(255, 255, 255, 1) inset, ${config.boxShadow};
     }
   }


### PR DESCRIPTION
https://helpscout.atlassian.net/secure/RapidBoard.jspa?rapidView=153&projectKey=COMMS&modal=detail&selectedIssue=COMMS-330

The user avatars shown on the Chat blank screen are A) blurry and B) have very subtle but noticeable blue pixelation around the image — both of which make them look bad.

This ticket fixes that by adding some styles.