### PR TITLE
HSDS-77 Fixes for Truncate

### DIFF
--- a/src/components/Truncate/README.md
+++ b/src/components/Truncate/README.md
@@ -12,14 +12,14 @@ an email address.
 
 ## Props
 
-| Prop              | Type      | Description                                                                |
-| ----------------- | --------- | -------------------------------------------------------------------------- |
-| className         | `string`  | Custom class names to be added to the component.                           |
-| ellipsis          | `string`  | Characters to show during truncation.                                      |
-| limit             | `number`  | The amount of characters to keep before truncation.                        |
-| shouldShowTooltip | `boolean` | Renders a [Tooltip](../Tooltip) if content is truncated. Default `false`.  |
-| splitter          | `string`  | Char to split string on for truncating mid-string, `longEma...@email.com`. |
-| type              | `string`  | Location of truncation.                                                    |
+| Prop                  | Type      | Description                                                                |
+| --------------------- | --------- | -------------------------------------------------------------------------- |
+| className             | `string`  | Custom class names to be added to the component.                           |
+| ellipsis              | `string`  | Characters to show during truncation.                                      |
+| limit                 | `number`  | The amount of characters to keep before truncation.                        |
+| showTooltipOnTruncate | `boolean` | Renders a [Tooltip](../Tooltip) if content is truncated. Default `false`.  |
+| splitter              | `string`  | Char to split string on for truncating mid-string, `longEma...@email.com`. |
+| type                  | `string`  | Location of truncation.                                                    |
 
 ### `type`
 

--- a/src/components/Truncate/Truncate.tsx
+++ b/src/components/Truncate/Truncate.tsx
@@ -25,6 +25,7 @@ export class Truncate extends React.PureComponent<
   }
   node = null
   contentNode = null
+  _isMounted = false
 
   constructor(props: TruncateProps) {
     super(props)
@@ -34,16 +35,26 @@ export class Truncate extends React.PureComponent<
   }
 
   componentDidMount() {
-    if (this.props.type === 'auto') {
-      this.setState({
-        isTruncated: this.isTruncated(this.props),
-      })
-    }
+    this._isMounted = true
+
+    // The timeout is necessary to ensure the `isTruncated` calculation
+    // happens after the content has been rendered to the page. The
+    // _isMounted guard is necessary because sometimes the callback
+    // will run after the component has been unmounted, which results
+    // in a warning.
+    setTimeout(() => {
+      if (this.props.type === 'auto' && this._isMounted) {
+        this.setState({
+          isTruncated: this.isTruncated(this.props),
+        })
+      }
+    }, 0)
   }
 
   componentWillUnmount() {
     this.node = null
     this.contentNode = null
+    this._isMounted = false
   }
 
   componentWillReceiveProps(nextProps: TruncateProps) {
@@ -70,22 +81,22 @@ export class Truncate extends React.PureComponent<
       /* istanbul ignore next */
       if (!this.node || !this.contentNode) return false
 
-      // 1. Normalizes the display to allow for calculation
-      // TODO: fix typescript complains
-      // @ts-ignore
-      this.contentNode.style.display = 'initial'
-      // 2. Calculate the differences
-      const isContentTruncated =
-        // TODO: fix typescript complains
-        // @ts-ignore
-        this.contentNode.offsetWidth > this.node.offsetWidth
-      // 3. Resets the display
-      // TODO: fix typescript complains
-      // @ts-ignore
-      this.contentNode.style.display = null
+      const isContentTruncated = props.splitter
+        ? this.isSplitContentTruncated(this.contentNode, this.node)
+        : // TODO: fix typescript complains
+          // @ts-ignore
+          this.contentNode.scrollWidth > this.node.offsetWidth
 
       return isContentTruncated
     }
+  }
+
+  isSplitContentTruncated = (contentNode: any, node: any): boolean => {
+    return (
+      contentNode.offsetWidth <
+      node.querySelector(`.${TRUNCATED_CLASSNAMES.firstChunk}`).scrollWidth +
+        node.querySelector(`.${TRUNCATED_CLASSNAMES.secondChunk}`).scrollWidth
+    )
   }
 
   getText = (props: TruncateProps = this.props) => {
@@ -133,10 +144,8 @@ export class Truncate extends React.PureComponent<
           }`}
         >
           <span className={`${TRUNCATED_CLASSNAMES.firstChunk}`}>{first}</span>
-          <span className={`${TRUNCATED_CLASSNAMES.splitterChunk}`}>
-            {splitter}
-          </span>
           <span className={`${TRUNCATED_CLASSNAMES.secondChunk}`}>
+            {splitter}
             {second}
           </span>
         </TruncateWithSplitterUI>

--- a/src/components/Truncate/Truncate.utils.ts
+++ b/src/components/Truncate/Truncate.utils.ts
@@ -4,6 +4,5 @@ export const TRUNCATED_CLASSNAMES = {
   component: TRUNCATED_COMPONENT_KEY,
   withSplitter: 'with-splitter',
   firstChunk: `${TRUNCATED_COMPONENT_KEY}__first`,
-  splitterChunk: `${TRUNCATED_COMPONENT_KEY}__splitter`,
   secondChunk: `${TRUNCATED_COMPONENT_KEY}__second`,
 }

--- a/src/components/Truncate/styles/Truncate.WithSplitter.css.ts
+++ b/src/components/Truncate/styles/Truncate.WithSplitter.css.ts
@@ -5,12 +5,14 @@ export const TruncateWithSplitterUI = styled('div')`
   display: flex;
   width: 100%;
   max-width: 100%;
-
   .${TRUNCATED_CLASSNAMES.firstChunk} {
     flex-shrink: 2;
-    min-width: 21px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+  .${TRUNCATED_CLASSNAMES.secondChunk} {
+    max-width: 90%;
+    flex-shrink: 0;
   }
 `

--- a/stories/Truncate.stories.js
+++ b/stories/Truncate.stories.js
@@ -37,9 +37,16 @@ stories.add('default', () => (
       </Truncate>
     </p>
     <p>
-      Truncate by Splitter:
+      Truncate by Splitter - resize display window:
       <br />
-      <Truncate splitter="@">longemailaddress@gmail.com</Truncate>
+      <Truncate splitter="@">a@hello.com</Truncate>
+      <Truncate splitter="@">art_vandelay@vandelayindustries.com</Truncate>
+      <Truncate splitter="@">john_locke@dharma.org</Truncate>
+      <Truncate splitter="@">pennypacker@kramerica.com</Truncate>
+      <Truncate splitter="@">this_is_kind_of_long@annoyingemails.com</Truncate>
+      <Truncate splitter="@">
+        this_is_kind_of_long@evenmoreannoyingemails.com
+      </Truncate>
     </p>
     <br />
   </div>
@@ -71,6 +78,13 @@ stories.add('tooltip', () => (
       <br />
       <Truncate showTooltipOnTruncate type="end" limit={limit}>
         {fixture.generate()}
+      </Truncate>
+    </p>
+    <p>
+      Truncate by Splitter - resize display window:
+      <br />
+      <Truncate showTooltipOnTruncate splitter="@">
+        longemailaddress@gmail.com
       </Truncate>
     </p>
     <br />


### PR DESCRIPTION
JIRA: https://helpscout.atlassian.net/browse/HSDS-77

Note: This is largely the same PR as the one previously reviewed for HSDS-77 that I had to revert: #717 . Updates include:
1. Addition of `_isMounted` variable ([see commit](https://github.com/helpscout/hsds-react/pull/727/commits/6b7378437d70e76f45bd40b65a621b32cafeefbd))
2. Addition of setTimeout in componentDidMount to prevent issue where calculation for `isTruncate` is performed using `0` for `offsetWidth` and `scrollWidth`.
3. Removing some manipulation of the contentNode styles - I don't see the removal causing a problem in Storybook or hs-app. 
4. Updated tests that broke as a result of the `setTimeout` in `componentDidMount`.

### Problem 
1. When using `<Truncate />` with a splitter prop so you can truncate email addresses, the tooltip feature isn't working. It should show the non-truncated email address on hover.

2. If you have an email address like `g@example.com`, with the splitter prop set, it renders out as `g @example.com`. This is because the first span has a min-width of 21px, which is wider than a character.

3. After addressing #1 and testing a beta release, when using this component within more complex apps than the Storybook environment, tooltips were still not showing up on the truncated emails on initial page load because of an issue where the calculation for isTruncated was being run at a point where the widths of the contentNode and node were 0. This caused "isTruncated" in state to be false, which prevented the tooltip from appearing. 

### Solution
#### Tooltip feature:
The `<Tooltip />` component will wrap around the truncated content if a) the `showTooltipOnTruncate` prop is true and b) `this.state.isTruncated` is true. The latter makes sure that we only show the Tooltip if the content has been truncated. 
  
For content that isn't using a splitter, one parent `<span>` wraps around the content, and we can easily compare the length of the content to the width of the span and see if it overflows using `this.contentNode.offsetWidth > this.node.offsetWidth`. However, content that IS being truncated based of the presence of the splitter has a different HTML structure and the width of the two spans containing the pre- and post- splitter content is very nested. 

This PR gains access to those nested spans to compare their combined width to that of their container in order to accurately update `this.state.isTruncated` and allow the `<Tooltip />` to wrap the truncated text.

#### Spacing issue
A solution to the spacing problem has already been implemented by Juan Pablo in [this PR](https://github.com/helpscout/hsds-react/pull/710/files#diff-ee19278829622bce00200f9b5ecd5584R8-R20) and has been reimplemented here.

#### Tooltips missing when used outside of Storybook
Adding a setTimeout to componentDidMount allows the calculationa to occur once the content exists on the page.

### Testing
I've updated the Truncated => Tooltips story to include an email address. 
* [ ] There should be no tooltip if the email is not truncated. 
* [ ] There should be a tooltip if the email is truncated
https://share.getcloudapp.com/o0ux4wQR

I've updated the Truncated => default story to include an email address with a one character user name.
* [ ] There should be no space between the username and the `@` sign, e.g. `a@domain.com`.

Note:
In testing, I noticed an issue that exists in EditableFields as well. https://share.getcloudapp.com/p9uzEgBO 
An email will truncate, then as the width of the display gets even smaller it displays the first few letters without truncation and things appear awkwardly cut off. This may be related to the fact that the domain names in these examples are very long, so even with truncating the username, the text still spills over. 

A possible solution is to truncate the domain name as well, but this might end up looking even more awkward: `a...@....com`, `a...@along....com`, `a...@along...`. I'll bring this up to Design, but as it's not a regression with this PR it shouldn't be a blocker here.