### PR TITLE
Fixes accessibility issues on empty Editable Textareas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.68.0-0",
+  "version": "2.68.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.68.0-0",
+  "version": "2.68.0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/EditableTextarea/EditableTextarea.tsx
+++ b/src/components/EditableTextarea/EditableTextarea.tsx
@@ -347,14 +347,16 @@ export class EditableTextarea extends React.PureComponent<
     const { clamped, readOnly, value, validationInfo } = this.state
 
     const textAreaClasses = classNames(
+      'EditableTextarea__Textarea',
       'field',
-      readOnly && !Boolean(value) && 'hide'
+      readOnly && !Boolean(value) && 'is-placeholder'
     )
+
     const maskClasses = classNames(
       'EditableTextarea__Mask',
-      (!readOnly || Boolean(value)) && !floatingLabels && 'hide',
-      readOnly && !Boolean(value) && 'inline',
-      'field'
+      'field',
+      (!readOnly || Boolean(value)) && !floatingLabels && 'is-hidden',
+      readOnly && !Boolean(value) && 'is-inline'
     )
 
     return (

--- a/src/components/EditableTextarea/styles/EditableTextarea.css.ts
+++ b/src/components/EditableTextarea/styles/EditableTextarea.css.ts
@@ -57,10 +57,11 @@ export const EditableTextareaUI = styled('div')`
   }
 
   &.with-placeholder.is-readonly {
-    .field:not(.hide) {
+    .field:not(.is-hidden):not(.EditableTextarea__Textarea) {
       border-bottom: 1px dashed ${COLOURS.mask.border};
       &:hover {
         border-bottom: 1px dashed ${COLOURS.mask.placeholder.border.hover};
+        cursor: pointer;
       }
     }
   }
@@ -114,17 +115,17 @@ export const EditableTextareaUI = styled('div')`
     box-shadow: none;
     scrollbar-width: thin;
 
-    &:not(.hide):not(.inline) {
+    &:not(.is-hidden):not(.is-inline):not(.EditableTextarea__Textarea) {
       border-bottom: 1px solid transparent;
     }
 
-    &.hide {
+    &.is-hidden {
       display: none;
     }
 
-    &.inline {
+    &.is-inline {
       display: inline-block;
-      height: 21px;
+      height: 20px;
       width: auto;
       padding: 0;
       color: ${COLOURS.mask.placeholder.regular};
@@ -132,7 +133,20 @@ export const EditableTextareaUI = styled('div')`
     }
   }
 
-  textarea {
+  .EditableTextarea__Textarea {
+    &.is-placeholder {
+      position: absolute;
+      top: 0;
+      left: 0;
+      border: 0;
+      transform: scaleX(0.1);
+      transform-origin: top left;
+
+      &::placeholder {
+        color: ${COLOURS.invisible};
+      }
+    }
+
     &:hover,
     &:focus {
       overflow-y: auto;

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.68.0-0',
+  version: '2.68.0',
 }


### PR DESCRIPTION
Currently, when empty, Editable Textareas are not focusable with normal usage (tab or shift+tab) or programmatically due to having a `display: none` rule applied.

This PR fixes the issue by using a different way to hide the `textarea` from view.
