### PR TITLE
Messages mobile 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.68.7",
+  "version": "2.68.8-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.68.7",
+  "version": "2.68.8-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/MessageCard/MessageCard.tsx
+++ b/src/components/MessageCard/MessageCard.tsx
@@ -26,6 +26,7 @@ export interface Props {
   children?: any
   innerRef: (node: HTMLElement) => void
   in: boolean
+  isMobile: boolean
   isWithBoxShadow: boolean
   subtitle?: string
   title?: string
@@ -38,17 +39,19 @@ export class MessageCard extends React.PureComponent<Props> {
     animationSequence: '',
     innerRef: noop,
     in: true,
+    isMobile: false,
     isWithBoxShadow: true,
   }
 
   static Button = Button
 
   getClassName() {
-    const { align, className, isWithBoxShadow } = this.props
+    const { align, className, isMobile, isWithBoxShadow } = this.props
     return classNames(
       MessageCard.className,
       align && `is-align-${align}`,
       className,
+      isMobile && 'is-mobile',
       isWithBoxShadow && `is-with-box-shadow`
     )
   }

--- a/src/components/MessageCard/__tests__/MessageCard.test.tsx
+++ b/src/components/MessageCard/__tests__/MessageCard.test.tsx
@@ -26,6 +26,22 @@ describe('className', () => {
   })
 })
 
+describe('Mobile', () => {
+  test('Should not have mobile styles by default', () => {
+    const wrapper = mount(<MessageCard />)
+    const el = wrapper.find('div.c-MessageCard')
+
+    expect(el.getDOMNode().classList.contains('is-mobile')).toBeFalsy()
+  })
+
+  test('Should have mobile styles if specified', () => {
+    const wrapper = mount(<MessageCard isMobile />)
+    const el = wrapper.find('div.c-MessageCard')
+
+    expect(el.getDOMNode().classList.contains('is-mobile')).toBeTruthy()
+  })
+})
+
 describe('Align', () => {
   test('Has default alignment of right', () => {
     const wrapper = mount(<MessageCard />)

--- a/src/components/MessageCard/styles/MessageCard.css.ts
+++ b/src/components/MessageCard/styles/MessageCard.css.ts
@@ -27,9 +27,30 @@ export const MessageCardUI = styled(Card)`
   &.is-with-box-shadow {
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 4px 6px rgba(0, 0, 0, 0.15);
   }
-
-  @media (max-width: 400px) {
+  &.is-mobile {
     width: 100%;
+
+    .is-h4 {
+      font-size: 20px !important;
+      line-height: 24px !important;
+    }
+
+    .is-h5 {
+      font-size: 14px !important;
+      margin-top: 10px;
+    }
+
+    .c-Text {
+      font-size: 14px !important;
+      line-height: 22px;
+      margin-top: 20px;
+    }
+
+    .c-ButtonV2 {
+      margin-top: 30px;
+      font-size: 16px !important;
+      height: 65px !important;
+    }
   }
 `
 
@@ -37,22 +58,12 @@ export const TitleUI = styled(Heading)`
   ${fontFamily};
   line-height: 22px !important;
   margin-top: 5px;
-
-  @media (max-width: 400px) {
-    font-size: 20px !important;
-    line-height: 24px !important;
-  }
 `
 
 export const SubtitleUI = styled(Heading)`
   ${setFontSize(12)};
   line-height: 18px !important;
   margin-top: 6px;
-
-  @media (max-width: 400px) {
-    font-size: 14px !important;
-    margin-top: 10px;
-  }
 `
 
 export const BodyUI = styled(Text)`
@@ -60,29 +71,14 @@ export const BodyUI = styled(Text)`
   line-height: 20px;
   margin-top: ${({ withMargin }) => (withMargin ? '12px' : '0')};
   white-space: pre-wrap;
-
-  @media (max-width: 400px) {
-    font-size: 14px !important;
-    line-height: 22px;
-    margin-top: 20px;
-  }
 `
 
 export const ActionUI = styled('div')`
   margin-bottom: -5px;
   margin-top: 20px;
-
-  @media (max-width: 400px) {
-    margin-top: 30px;
-  }
 `
 
 export const ActionButtonUI = styled(Button)`
   ${setFontSize(14)};
   line-height: normal !important;
-
-  @media (max-width: 400px) {
-    font-size: 16px !important;
-    height: 65px !important;
-  }
 `

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.68.7',
+  version: '2.68.8-0',
 }

--- a/stories/MessageCard.stories.js
+++ b/stories/MessageCard.stories.js
@@ -58,6 +58,7 @@ class Story extends React.Component {
 
     const props = {
       in: show,
+      isMobile: boolean('isMobile', false),
       isWithBoxShadow: boolean('isWithBoxShadow', true),
       action: actionProp,
       animationDuration: number('animationDuration', 300),


### PR DESCRIPTION
## Problem

On #730 I've added styles for the MessageCard component on mobile. It was using media queries to determine if it should use the mobile styles or not, which worked well but didn't quite work on Beacon Embed because, since the component was rendered inside an iframe that was approx 350px wide, it was ALWAYS using the mobile styles, independently of the window's viewport size.

## Solution

I tried to look for a way to tell the media query to use the window's size instead of the iframe's, but there doesn't seem to be a good way to go about it, so the styles are now applied using an `isMobile` flag.

## How to test

Go to the [MessageCard story](https://deploy-preview-735--hsds-react.netlify.com/?path=/story/messagecard--default) in Storybook and check/uncheck the isMobile checkbox: https://share.getcloudapp.com/4gu7PmJk