### PR TITLE
Modify default color for Avatars

### DIFF
--- a/src/components/Avatar/styles/Avatar.css.ts
+++ b/src/components/Avatar/styles/Avatar.css.ts
@@ -9,7 +9,7 @@ export const config = {
   borderRadius: 3,
   borderWidth: 2,
   boxShadow: '0 5px 8px rgba(0, 0, 0, 0.2)',
-  color: getColor('blue.500'),
+  color: getColor('grey.600'),
   position: 'relative',
   size: {
     xl: {
@@ -322,7 +322,9 @@ export const AvatarUI = styled('div')`
   position: relative;
   width: ${config.size.md.size}px;
 
-  ${props => getColorStyles(props)} &.is-light {
+  ${props => getColorStyles(props)}
+
+  &.is-light {
     color: ${getColor('grey.400')};
   }
 


### PR DESCRIPTION
[Jira Ticket ](https://helpscout.atlassian.net/browse/COMMS-353)


This changes the default color for the Avatar component, when an image is not available.

<img width="101" alt="Screen Shot 2019-10-31 at 17 36 27" src="https://user-images.githubusercontent.com/7111256/67990940-789b7200-fc05-11e9-9e6f-447201d5980d.png">

