### PR TITLE
Fix bug in ChatList story

### DIFF
--- a/stories/ChatList/ChatList.stories.js
+++ b/stories/ChatList/ChatList.stories.js
@@ -8,7 +8,9 @@ import ChatListItemStateExample from './ChatListItemStateExample'
 const avatars = AvatarSpec.generate(8)
 const fixtures = ChatSpec.generate(8)
 
-const itemMarkup = fixtures.map((item, index) => {
+const itemMarkup = Object.keys(fixtures).forEach((key, index) => {
+  const item = fixtures[key]
+
   const avatar = (
     <Avatar
       image={avatars[4].image}


### PR DESCRIPTION
I’m not sure what changed here, but `fixtures` is an `object` and not an `array`.

<img width="1233" alt="Screen Shot 2019-11-07 at 13 32 28" src="https://user-images.githubusercontent.com/7111256/68420987-11c90c00-0163-11ea-8d67-5a4ce706fad6.png">
