### PR TITLE
Prevent pointer events from DropdownTrigger children

### DIFF
--- a/src/components/Dropdown/V2/Dropdown.css.js
+++ b/src/components/Dropdown/V2/Dropdown.css.js
@@ -238,6 +238,10 @@ export const TriggerUI = styled('span')`
   &.is-open {
     color: ${getColor('blue.700')};
   }
+
+  & > * {
+    pointer-events: none;
+  }
 `
 
 TriggerUI.defaultProps = {


### PR DESCRIPTION
 When a custom trigger is passed to the Dropdown V2 component, click events from the custom element could trigger extra events in the MS Edge browser.

Since the Dropdown Trigger is explicitly handling events on itself and not using the click events from children, we can fix this problem by suppressing all events from the children. 

This of course needs to be tested in the MS Edge browser, but please test in all other browsers as well. 

Affected Components that pass `renderTrigger` props

- EditableField 
    - “On Commit” story
- Emoji Picker
- Select Dropdown
- SideNavigation
    - with dropdown header
    - with long list dropdown
- Split Button
- AutoDropdown
    - “Multiple instances” story
- AvatarSelector
- TabBar 
    - “with secondary content dropdown” story
