### PR TITLE
Change way Dropdown ItemUI is created

### DIFF
--- a/src/components/Dropdown/V2/Dropdown.Item.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Item.tsx
@@ -10,7 +10,7 @@ import Menu from './Dropdown.Menu'
 import {
   ActionUI,
   ActionContentUI,
-  makeItemUI,
+  ItemUI,
   SubMenuIncidatorUI,
   WrapperUI,
 } from './Dropdown.css.js'
@@ -260,10 +260,10 @@ export class Item extends React.PureComponent<Props> {
     if (type === 'group' || type === 'header') return <Header {...this.props} />
     if (type === 'divider') return <Divider />
 
-    const ItemUI = href ? makeItemUI('a') : makeItemUI('div')
+    const DDItemUI = href ? ItemUI.withComponent('a') : ItemUI
 
     return (
-      <ItemUI
+      <DDItemUI
         {...getValidProps(this.props)}
         className={componentClassName}
         aria-disabled={disabled}
@@ -273,7 +273,7 @@ export class Item extends React.PureComponent<Props> {
       >
         {this.renderContent()}
         {this.renderSubMenu()}
-      </ItemUI>
+      </DDItemUI>
     )
   }
 }

--- a/src/components/Dropdown/V2/Dropdown.css.js
+++ b/src/components/Dropdown/V2/Dropdown.css.js
@@ -125,85 +125,79 @@ export const ActionContentUI = styled('div')`
   max-width: 100%;
 `
 
-export const makeItemUI = element => {
-  const ItemUI = styled(element)`
-    ${baseStyles};
-    background-color: ${rgba(getColor('grey.400'), 0)};
-    border-radius: 0 !important;
-    color: ${getColor('charcoal.400')};
-    cursor: pointer;
-    display: block;
-    outline: none;
-    position: static;
-    text-decoration: none;
-    transition: background-color 0.1s ease;
-    user-select: none;
+export const ItemUI = styled('div')`
+  ${baseStyles};
+  background-color: ${rgba(getColor('grey.400'), 0)};
+  border-radius: 0 !important;
+  color: ${getColor('charcoal.400')};
+  cursor: pointer;
+  display: block;
+  outline: none;
+  position: static;
+  text-decoration: none;
+  transition: background-color 0.1s ease;
+  user-select: none;
 
-    &.is-option {
-      padding: 8px 16px;
-    }
-
-    &.is-active {
-      > ${ActionUI}, &.is-option {
-        font-weight: 500;
-      }
-    }
-
-    &.c-SelectionClearerItem + .c-DropdownV2Item {
-      padding-top: 12px;
-    }
-
-    &:focus {
-      ${MenuUI} {
-        color: initial;
-      }
-    }
-
-    &:hover {
-      text-decoration: none;
-    }
-
-    &:last-child {
-      border: none;
-    }
-
-    ${WrapperUI} {
-      position: absolute;
-      padding-left: 20px;
-      padding-right: 20px;
-      margin-left: -20px;
-      margin-right: -20px;
-    }
-
-    &.is-focused {
-      > ${ActionUI}, &.is-option {
-        background-color: ${rgba(getColor('grey.300'), 1)};
-        color: ${getColor('link.base')};
-      }
-    }
-    &.is-focused:hover,
-    &.is-open {
-      > ${WrapperUI} {
-        visibility: visible;
-        pointer-events: auto;
-      }
-    }
-
-    &.is-disabled {
-      cursor: initial;
-      pointer-events: none;
-      opacity: 0.4;
-    }
-  `
-
-  ItemUI.defaultProps = {
-    [SELECTORS.itemAttribute]: true,
+  &.is-option {
+    padding: 8px 16px;
   }
 
-  return ItemUI
-}
+  &.is-active {
+    > ${ActionUI}, &.is-option {
+      font-weight: 500;
+    }
+  }
 
-export const ItemUI = makeItemUI('div')
+  &.c-SelectionClearerItem + .c-DropdownV2Item {
+    padding-top: 12px;
+  }
+
+  &:focus {
+    ${MenuUI} {
+      color: initial;
+    }
+  }
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:last-child {
+    border: none;
+  }
+
+  ${WrapperUI} {
+    position: absolute;
+    padding-left: 20px;
+    padding-right: 20px;
+    margin-left: -20px;
+    margin-right: -20px;
+  }
+
+  &.is-focused {
+    > ${ActionUI}, &.is-option {
+      background-color: ${rgba(getColor('grey.300'), 1)};
+      color: ${getColor('link.base')};
+    }
+  }
+  &.is-focused:hover,
+  &.is-open {
+    > ${WrapperUI} {
+      visibility: visible;
+      pointer-events: auto;
+    }
+  }
+
+  &.is-disabled {
+    cursor: initial;
+    pointer-events: none;
+    opacity: 0.4;
+  }
+`
+
+ItemUI.defaultProps = {
+  [SELECTORS.itemAttribute]: true,
+}
 
 export const GroupUI = styled('div')`
   margin-top: 0;


### PR DESCRIPTION
In https://github.com/helpscout/hsds-react/pull/738 we made a change so that a Dropdown.Item could be rendered as an `a` tag instead of a `div` if the item had an `href` prop.

This worked fine, except in Chat UI. The items were being rendered as `div` components still, but most of the time, required two clicks for the `onClick` handler to fire.

To be honest, I'm not sure why this happened. The only thing we did here was change `ItemUI` to a factory that returns the ItemUI as a `div` or `a` tag. 

Nonetheless, reverting that fixed the problem. We can use the `withComponent` API method on a Fancy StyledComponent to dynamically change the div to an `a` when there is an `href` prop and this works.

In essence, we're doing the same thing, but one solution causes problems and the other does not. 