### PR TITLE
Fix dropdown active item color

### DIFF
--- a/src/components/Dropdown/V2/Dropdown.css.js
+++ b/src/components/Dropdown/V2/Dropdown.css.js
@@ -145,6 +145,7 @@ export const ItemUI = styled('div')`
   &.is-active {
     > ${ActionUI}, &.is-option {
       font-weight: 500;
+      color: ${getColor('charcoal.600')};
     }
   }
 


### PR DESCRIPTION
Bumps the active item color up so it's seen better when visual looking at it.

@digitaldesigner 