### PR TITLE
Update Dropdown Component `window` reference

### DIFF
--- a/src/components/Dropdown/V2/Dropdown.Container.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Container.tsx
@@ -80,6 +80,10 @@ export class DropdownContainer extends React.PureComponent<Props, State> {
     const initialState = {
       ...this.props,
       envNode: getDocumentFromComponent(this),
+      // When displaying the dropdown component in an `iframe` (e.g. Beacon),
+      // this scopes the window reference to the `iframe`, instead of the main
+      // window. When undefined the default window object will be set.
+      contentWindow: props.contentWindow || window,
       id,
       menuId,
       triggerId,

--- a/src/components/Dropdown/V2/Dropdown.Item.tsx
+++ b/src/components/Dropdown/V2/Dropdown.Item.tsx
@@ -28,6 +28,7 @@ import ItemSelectedCheck from './Dropdown.ItemSelectedCheck'
 export interface Props {
   actionId?: string
   className?: string
+  contentWindow: any
   disabled: boolean
   dropRight: boolean
   dropUp: boolean
@@ -54,6 +55,7 @@ export interface Props {
 
 export class Item extends React.PureComponent<Props> {
   static defaultProps = {
+    contentWindow: window,
     getState: noop,
     disabled: false,
     index: '0',
@@ -112,13 +114,14 @@ export class Item extends React.PureComponent<Props> {
   renderMenu() {
     if (!this.hasSubMenu()) return
 
-    const { dropRight, dropUp } = this.props
+    const { contentWindow, dropRight, dropUp } = this.props
 
     // Async call to coordinate with Portal adjustments
     requestAnimationFrame(() => {
       /* istanbul ignore else */
       if (this.menuNode && this.wrapperNode && this.node && this.actionNode) {
         setMenuPositionStyles({
+          contentWindow,
           dropRight,
           dropUp,
           menuNode: this.menuNode,
@@ -284,9 +287,10 @@ const PropConnectedComponent = propConnect(COMPONENT_KEY.Item)(Item)
 const ConnectedItem: any = connect(
   // mapStateToProps
   (state: any) => {
-    const { getState, renderItem, selectedItem } = state
+    const { contentWindow, getState, renderItem, selectedItem } = state
 
     return {
+      contentWindow,
       getState,
       renderItem,
       selectedItem,

--- a/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
+++ b/src/components/Dropdown/V2/Dropdown.MenuContainer.tsx
@@ -45,6 +45,7 @@ export class MenuContainer extends React.PureComponent<
     animationDuration: 80,
     animationSequence: 'fade down',
     closeDropdown: noop,
+    contentWindow: window,
     dropRight: true,
     dropUp: false,
     forceDropDown: false,
@@ -90,15 +91,16 @@ export class MenuContainer extends React.PureComponent<
   // Skipping coverage for this method as it does almost exclusively DOM
   // calculations, which isn't a JSDOM's forte.
   shouldDropUp(): boolean {
+    const { contentWindow, dropUp } = this.props
     // Always return true, if dropUp
-    if (this.props.dropUp) return true
+    if (dropUp) return true
 
     if (!this.node || !this.wrapperNode) return false
 
     const { top } = this.wrapperNode.getBoundingClientRect()
     const { clientHeight: height } = this.node
 
-    const hasWindowBottomOverflow = top + height > window.innerHeight
+    const hasWindowBottomOverflow = top + height > contentWindow.innerHeight
     const hasWindowTopOverflow = top - height < 0
 
     if (hasWindowBottomOverflow) {
@@ -281,9 +283,10 @@ export class MenuContainer extends React.PureComponent<
   }
 
   getStylePosition = (): any => {
+    const { contentWindow } = this.props
     const targetNode = this.getTargetNode()
 
-    const rect = getComputedClientRect(targetNode)
+    const rect = getComputedClientRect(targetNode, contentWindow)
     const { top, left } = rect
 
     return {
@@ -493,6 +496,7 @@ const ConnectedMenuContainer: any = connect(
   (state: any) => {
     const {
       allowMultipleSelection,
+      contentWindow,
       dropUp,
       forceDropDown,
       getState,
@@ -515,6 +519,7 @@ const ConnectedMenuContainer: any = connect(
 
     return {
       allowMultipleSelection,
+      contentWindow,
       dropRight: isDropRight(state),
       dropUp,
       forceDropDown,

--- a/src/components/Dropdown/V2/Dropdown.MenuContainer.utils.ts
+++ b/src/components/Dropdown/V2/Dropdown.MenuContainer.utils.ts
@@ -4,7 +4,10 @@ type ClientRect = {
   top: number
 }
 
-export const getComputedClientRect = (node: HTMLElement): ClientRect => {
+export const getComputedClientRect = (
+  node: HTMLElement,
+  contentWindow: any
+): ClientRect => {
   const defaultRect = {
     height: 0,
     left: 0,
@@ -20,8 +23,8 @@ export const getComputedClientRect = (node: HTMLElement): ClientRect => {
   // within JSDOM. Manually tested in the browser, and the calculations are
   // correct.
   /* istanbul ignore next */
-  const computedTop = top + height + window.scrollY
-  const computedLeft = left + window.scrollX
+  const computedTop = top + height + contentWindow.scrollY
+  const computedLeft = left + contentWindow.scrollX
 
   return {
     left: computedLeft,

--- a/src/components/Dropdown/V2/Dropdown.renderUtils.ts
+++ b/src/components/Dropdown/V2/Dropdown.renderUtils.ts
@@ -120,6 +120,7 @@ export const didCloseSubMenu = (
 // Going to be ignoring chunks of this from test coverage, since DOM related
 // calculations are difficult to mock/test within JSDOM.
 export const setMenuPositionStyles = (props: {
+  contentWindow: any
   dropRight?: boolean
   dropUp?: boolean
   menuNode: HTMLElement | null
@@ -132,7 +133,15 @@ export const setMenuPositionStyles = (props: {
     dropUp: false,
   }
 
-  const { dropRight, dropUp, menuNode, itemNode, wrapperNode, triggerNode } = {
+  const {
+    contentWindow,
+    dropRight,
+    dropUp,
+    menuNode,
+    itemNode,
+    wrapperNode,
+    triggerNode,
+  } = {
     ...defaultProps,
     ...props,
   }
@@ -162,7 +171,8 @@ export const setMenuPositionStyles = (props: {
 
   /* istanbul ignore next */
   const shouldDropUp =
-    window.innerHeight < predictedOffsetBottom && predictedFlippedOffsetTop > 0
+    contentWindow.innerHeight < predictedOffsetBottom &&
+    predictedFlippedOffsetTop > 0
 
   /* istanbul ignore next */
   if (!dropRight) {

--- a/src/components/Dropdown/V2/Dropdown.tsx
+++ b/src/components/Dropdown/V2/Dropdown.tsx
@@ -25,6 +25,7 @@ export class Dropdown extends React.PureComponent<DropdownProps, State> {
   static defaultProps = {
     ...initialState,
     allowMultipleSelection: false,
+    contentWindow: window,
     'data-cy': 'Dropdown',
     disabled: false,
     innerRef: noop,
@@ -45,9 +46,17 @@ export class Dropdown extends React.PureComponent<DropdownProps, State> {
     const targetNode = event.target
 
     /* istanbul ignore else */
-    if (targetNode instanceof Element) {
-      if (this.menuNode.contains(targetNode) || targetNode === this.triggerNode)
+    // When the component is displayed in an `iframe` (e.g. Beacon) we need
+    // to do an instanceof check based on the `iframe`#Element class type,
+    // using the `contentWindow` prop. https://stackoverflow.com/a/26251098
+    if (targetNode instanceof this.props.contentWindow.Element) {
+      if (
+        // @ts-ignore
+        this.menuNode.contains(targetNode) ||
+        targetNode === this.triggerNode
+      ) {
         return
+      }
 
       this.closeMenu()
     }
@@ -165,8 +174,9 @@ const PropConnectedComponent = propConnect(COMPONENT_KEY.Dropdown)(Dropdown)
 const ConnectedDropdown: any = connect(
   // mapStateToProps
   (state: any) => {
-    const { envNode, id, isOpen, getState } = state
+    const { contentWindow, envNode, id, isOpen, getState } = state
     return {
+      contentWindow,
       envNode,
       id,
       isOpen,

--- a/src/components/Dropdown/V2/Dropdown.types.ts
+++ b/src/components/Dropdown/V2/Dropdown.types.ts
@@ -32,6 +32,7 @@ export interface DropdownMenuContainerProps {
   className?: string
   clearSelection: (...args: any[]) => void
   closeDropdown: () => void
+  contentWindow: any
   dropRight: boolean
   dropUp: boolean
   forceDropDown: boolean
@@ -67,6 +68,7 @@ export interface DropdownProps extends DropdownMenuDimensions {
   clearOnSelect: boolean
   closeDropdown: () => void
   closeOnSelect: boolean
+  contentWindow: any
   direction: 'left' | 'right'
   disabled: boolean
   dropUp: boolean

--- a/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.utils.test.ts
+++ b/src/components/Dropdown/V2/__tests__/Dropdown.MenuContainer.utils.test.ts
@@ -3,7 +3,7 @@ import { getComputedClientRect } from '../Dropdown.MenuContainer.utils'
 describe('getComputedClientRect', () => {
   test('Returns zero values if invalid node', () => {
     // @ts-ignore
-    const results = getComputedClientRect()
+    const results = getComputedClientRect(null, window)
 
     expect(results.height).toBe(0)
     expect(results.left).toBe(0)
@@ -19,7 +19,7 @@ describe('getComputedClientRect', () => {
       }),
     } as HTMLElement
 
-    const results = getComputedClientRect(node)
+    const results = getComputedClientRect(node, window)
 
     expect(results.height).toBe(42)
     expect(results.top).toBe(332 + 42)

--- a/src/components/Dropdown/V2/docs/Dropdown.md
+++ b/src/components/Dropdown/V2/docs/Dropdown.md
@@ -47,6 +47,7 @@ This component supports async rendering of items. Render the `Dropdown` as you w
 | cardBorderColor           | `string`                 |              | Customize the Dropdown Card border color.                                                                    |
 | clearOnSelect             | `boolean`                | `true`       | Removes selected item on select.                                                                             |
 | closeOnSelect             | `boolean`                | `true`       | Closes Dropdown on select.                                                                                   |
+| contentWindow             | `window/object`          | `window`     | Custom window object (e.g. iframe window object)                                                             |
 | children                  | `Function`               |              | Render prop to customize the Dropdown contents.                                                              |
 | direction                 | `string`                 | `right`      | Preferred horizontal drop direction for the menu.                                                            |
 | disabled                  | `bool`                   | `false`      | Disable the dropdown trigger so it can't be clicked.                                                         |


### PR DESCRIPTION
This adds support for a `customWindow` prop in the Dropdown Component. 

This is needed to allow for use of the component in Beacon. Because Beacon is shown in an `iframe` element, we need to be able to override the `window` reference in the component to use the `iframe`'s `window` object and not the `host`'s.

## Example of Emoji Picker in Beacon 

### Before 
![Screen Recording 2019-11-25 at 16 08](https://user-images.githubusercontent.com/7111256/69582280-de2d1500-0f9d-11ea-887e-6b8797ea1c79.gif)


### After

![Screen Recording 2019-11-25 at 15 14](https://user-images.githubusercontent.com/7111256/69581405-12073b00-0f9c-11ea-8f25-a91af1ce1adf.gif)

Testing:

- That no regressions were introduced into the Dropdown V2 functionality
- That the scrolling issue displayed in the gifs above are fixed. You can check out this [PR](https://github.com/helpscout/beacon2/pull/771) which has a  beta release of the this work installed. 