### PR TITLE
Table collapse and custom expander text

### DIFF
--- a/src/components/Table/README.md
+++ b/src/components/Table/README.md
@@ -35,19 +35,20 @@ Use `<Pagination>` in HSDS together with `<Table>`, see `TableWithPagination.js`
 
 ## Props
 
-| Prop             | Type                                         | Description                                                                                                    |
-| ---------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| className        | `string`                                     | Custom class names to be added to the component top level element.                                             |
-| tableClassName   | `string`                                     | Custom class names to be added to the `<table>` element.                                                       |
-| columns          | `array[{ columnKey: string}]`                | List of columns, see [Columns.md](/src/components/Table/docs/Columns.md)                                       |
-| data             | `array[{}]`                                  | List of Rows, which are objects, see [Columns.md](/src/components/Table/docs/Columns.md)                       |
-| maxRowsToDisplay | `number`                                     | When provided the Table will olnly show this number of rows and and expander to see the rest                   |
-| containerWidth   | `string`                                     | The table wrapper width (if `tableWidth` is larger, the component scrolls horizontally)                        |
-| tableWidth       | `object{ min: string, max: string }`         | The `<table>` width                                                                                            |
-| skin             | `object`                                     | An object to customize the visual appearance of the table. See [Skins.md](/src/components/Table/docs/Skins.md) |
-| isLoading        | `boolean`                                    | Adds the 'is-loading' class to the component                                                                   |
-| isScrollLocked   | `boolean`                                    | Whether to use `ScrollLock` with `direction="x"` on the Table.                                                 |
-| sortedInfo       | `object{ columnKey: string, order: string }` | When sortable, indicates which column tha table is sorted by, and in which order (ascending or descending)     |
-| onRowClick       | `function`                                   | Callback function when a row is clicked. Arguments are the event and the row clicked.                          |
-| tableRef         | `function`                                   | Retrieves the `<table>` node.                                                                                  |
-| wrapperRef       | `function`                                   | Retrieves the table wrapper node.                                                                              |
+| Prop             | Type                                            | Description                                                                                                    |
+| ---------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| className        | `string`                                        | Custom class names to be added to the component top level element.                                             |
+| tableClassName   | `string`                                        | Custom class names to be added to the `<table>` element.                                                       |
+| columns          | `array[{ columnKey: string}]`                   | List of columns, see [Columns.md](/src/components/Table/docs/Columns.md)                                       |
+| data             | `array[{}]`                                     | List of Rows, which are objects, see [Columns.md](/src/components/Table/docs/Columns.md)                       |
+| maxRowsToDisplay | `number`                                        | When provided the Table will olnly show this number of rows and and expander to see the rest                   |
+| expanderText     | `object{ expanded: string, collapsed: string }` | The text for the "expander" button when table is either collapsed or expanded                                  |
+| containerWidth   | `string`                                        | The table wrapper width (if `tableWidth` is larger, the component scrolls horizontally)                        |
+| tableWidth       | `object{ min: string, max: string }`            | The `<table>` width                                                                                            |
+| skin             | `object`                                        | An object to customize the visual appearance of the table. See [Skins.md](/src/components/Table/docs/Skins.md) |
+| isLoading        | `boolean`                                       | Adds the 'is-loading' class to the component                                                                   |
+| isScrollLocked   | `boolean`                                       | Whether to use `ScrollLock` with `direction="x"` on the Table.                                                 |
+| sortedInfo       | `object{ columnKey: string, order: string }`    | When sortable, indicates which column tha table is sorted by, and in which order (ascending or descending)     |
+| onRowClick       | `function`                                      | Callback function when a row is clicked. Arguments are the event and the row clicked.                          |
+| tableRef         | `function`                                      | Retrieves the `<table>` node.                                                                                  |
+| wrapperRef       | `function`                                      | Retrieves the table wrapper node.                                                                              |

--- a/src/components/Table/Table.Body.tsx
+++ b/src/components/Table/Table.Body.tsx
@@ -10,7 +10,10 @@ export default class Body extends React.Component<BodyProps, BodyState> {
   columnsCache = this.getColumnsCache(this.props.columns)
 
   static getDerivedStateFromProps(nextProps, prevState) {
+    /* istanbul ignore else */
     if (!equal(nextProps.rows, prevState.rows)) {
+      return { rows: Body.getRows(nextProps) }
+    } else if (nextProps.isTableCollapsed) {
       return { rows: Body.getRows(nextProps) }
     }
     return null

--- a/src/components/Table/Table.Body.tsx
+++ b/src/components/Table/Table.Body.tsx
@@ -11,11 +11,10 @@ export default class Body extends React.Component<BodyProps, BodyState> {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     /* istanbul ignore else */
-    if (!equal(nextProps.rows, prevState.rows)) {
-      return { rows: Body.getRows(nextProps) }
-    } else if (nextProps.isTableCollapsed) {
+    if (!equal(nextProps.rows, prevState.rows) || nextProps.isTableCollapsed) {
       return { rows: Body.getRows(nextProps) }
     }
+
     return null
   }
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -122,8 +122,9 @@ export class Table extends React.Component<TableProps, TableState> {
     const {
       className,
       tableClassName,
-      data,
       columns,
+      data,
+      expanderText,
       maxRowsToDisplay,
       tableWidth,
       containerWidth,
@@ -179,7 +180,7 @@ export class Table extends React.Component<TableProps, TableState> {
 
           {isLoading && <LoadingUI className={`${TABLE_CLASSNAME}__Loading`} />}
 
-          {isTableCollapsed ? (
+          {maxRowsToDisplay && isTableCollapsed ? (
             <Button
               version={2}
               style={{ marginLeft: '14px' }}
@@ -187,7 +188,19 @@ export class Table extends React.Component<TableProps, TableState> {
               className={`${TABLE_CLASSNAME}__Expander`}
               onClick={this.handleExpanderClick}
             >
-              View all
+              {expanderText ? expanderText.collapsed : 'View All'}
+            </Button>
+          ) : null}
+
+          {maxRowsToDisplay && !isTableCollapsed ? (
+            <Button
+              version={2}
+              style={{ marginLeft: '14px' }}
+              kind="link"
+              className={`${TABLE_CLASSNAME}__Expander`}
+              onClick={this.handleExpanderClick}
+            >
+              {expanderText ? expanderText.expanded : 'Collapse'}
             </Button>
           ) : null}
         </TableWrapperUI>

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -43,6 +43,7 @@ export interface TableProps {
   tableClassName?: string
   columns: Column[]
   data: Data[]
+  expanderText?: any
   maxRowsToDisplay?: number
   containerWidth?: string
   tableWidth?: TableWidth

--- a/src/components/Table/__tests__/Table.test.js
+++ b/src/components/Table/__tests__/Table.test.js
@@ -336,7 +336,7 @@ describe('Expandable', () => {
     expect(rows.length).toBe(4)
   })
 
-  test('Table expands on click of Expander', () => {
+  test('Table expands/collapses on click of Expander', () => {
     const wrapper = mount(
       <Table
         columns={defaultColumns}
@@ -345,14 +345,44 @@ describe('Expandable', () => {
       />
     )
     const expander = wrapper.find(`.${TABLE_CLASSNAME}__Expander`).first()
-
     expander.simulate('click')
-
     const tbody = wrapper.find('tbody')
     const rows = tbody.find('tr')
 
     expect(wrapper.state('isTableCollapsed')).toBeFalsy()
     expect(rows.length).toBe(10)
+    expect(expander.text()).toBe('View All')
+
+    const expander2 = wrapper.find(`.${TABLE_CLASSNAME}__Expander`).first()
+    expander2.simulate('click')
+    const rows2 = wrapper.find('tbody').find('tr')
+
+    expect(wrapper.state('isTableCollapsed')).toBeTruthy()
+    expect(rows2.length).toBe(4)
+    expect(expander2.text()).toBe('Collapse')
+  })
+
+  test('Table expands/collapses on click of Expander (custom text)', () => {
+    const wrapper = mount(
+      <Table
+        columns={defaultColumns}
+        data={createFakeCustomers({ amount: 10 })}
+        maxRowsToDisplay={4}
+        expanderText={{
+          collapsed: 'Show me all',
+          expanded: 'Show me the top 4',
+        }}
+      />
+    )
+    const expander = wrapper.find(`.${TABLE_CLASSNAME}__Expander`).first()
+    expander.simulate('click')
+
+    expect(expander.text()).toBe('Show me all')
+
+    const expander2 = wrapper.find(`.${TABLE_CLASSNAME}__Expander`).first()
+    expander2.simulate('click')
+
+    expect(expander2.text()).toBe('Show me the top 4')
   })
 
   test('Table fires onExpand on click of Expander', () => {

--- a/stories/Table/Table.stories.js
+++ b/stories/Table/Table.stories.js
@@ -184,11 +184,29 @@ stories.add('with row click', () => (
 ))
 
 stories.add('expandable', () => (
-  <Table
-    columns={defaultColumns}
-    data={createFakeCustomers({ amount: 10 })}
-    maxRowsToDisplay={4}
-  />
+  <div>
+    <Heading size="h4" style={{ marginBottom: '20px' }}>
+      Default expander text
+    </Heading>
+    <Table
+      columns={defaultColumns}
+      data={createFakeCustomers({ amount: 10 })}
+      maxRowsToDisplay={4}
+      style={{ marginBottom: '40px' }}
+    />
+    <Heading size="h4" style={{ marginBottom: '20px' }}>
+      Custom expander text
+    </Heading>
+    <Table
+      columns={defaultColumns}
+      data={createFakeCustomers({ amount: 10 })}
+      maxRowsToDisplay={4}
+      expanderText={{
+        collapsed: 'Show me all',
+        expanded: 'Show me the top 4',
+      }}
+    />
+  </div>
 ))
 
 stories.add('playground', () => <TablePlayground />)


### PR DESCRIPTION
This PR adds the ability for the Table to be collapsed after it has been expanded and use custom text for the "expander" button.

![Screen](https://p-zkF42X.t2.n0.cdn.getcloudapp.com/items/8LuZvO8p/expander.gif?v=b1ecb3173845d2b8632060ec72f4baca)

📚 [Story](https://deploy-preview-760--hsds-react.netlify.com/?path=/story/table--expandable)