### PR TITLE
Input Error and Tooltip Accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.76.0",
+  "version": "2.76.1-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.76.1-2",
+  "version": "2.76.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.76.1-1",
+  "version": "2.76.1-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.76.0",
+  "version": "2.76.1-1",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.76.1-2",
+  "version": "2.76.1",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.76.1-1",
+  "version": "2.76.1-2",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -527,7 +527,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
   }
 
   getErrorMarkup() {
-    const { errorIcon, errorMessage, state } = this.props
+    const { errorIcon, errorMessage, state, tabIndex = 0 } = this.props
     const shouldRenderError = state === STATES.error
 
     if (!shouldRenderError) return null
@@ -551,7 +551,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
             name={errorIcon}
             size={24}
             state={STATES.error}
-            tabIndex="0"
+            tabIndex={tabIndex}
           />
         </Tooltip>
       </InlinePrefixSuffixUI>
@@ -677,6 +677,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
       state: stateProp,
       style: styleProp,
       suffix,
+      tabIndex,
       type,
       typingThrottleInterval,
       typingTimeoutDelay,
@@ -732,6 +733,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
       placeholder,
       readOnly,
       style,
+      tabIndex,
       type,
       value,
     }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -792,8 +792,8 @@ export class Input extends React.PureComponent<InputProps, InputState> {
               {this.getInlinePrefixMarkup()}
               {this.getInputMarkup(props)}
               {this.getInlineSuffixMarkup()}
-              {this.getSuffixMarkup()}
               {this.getErrorMarkup()}
+              {this.getSuffixMarkup()}
               {this.getActionMarkup()}
               <Backdrop
                 className="c-Input__backdrop"

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -551,6 +551,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
             name={errorIcon}
             size={24}
             state={STATES.error}
+            tabIndex="0"
           />
         </Tooltip>
       </InlinePrefixSuffixUI>

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -79,6 +79,7 @@ export type InputProps = {
   state?: UIState
   style: Object
   suffix: any
+  tabIndex: number
   type: string
   typingThrottleInterval: number
   typingTimeoutDelay: number

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -803,6 +803,7 @@ describe('ErrorMessage', () => {
     const suffix = wrapper.find(ui.suffix).first()
 
     expect(error.length).toBe(1)
+    expect(error.props().tabIndex).toBe(0)
     expect(suffix.length).toBe(1)
   })
 
@@ -818,11 +819,12 @@ describe('ErrorMessage', () => {
 
   test('Can customize error Icon', () => {
     const wrapper = mount(
-      <Input suffix="Derek" state="error" errorIcon="chat" />
+      <Input suffix="Derek" state="error" errorIcon="chat" tabIndex={3} />
     )
     const el = wrapper.find('Icon')
 
     expect(el.props().name).toBe('chat')
+    expect(el.props().tabIndex).toBe(3)
   })
 })
 

--- a/src/components/Pop/Pop.tsx
+++ b/src/components/Pop/Pop.tsx
@@ -4,6 +4,7 @@ import Manager from './Manager'
 import Arrow from './Arrow'
 import Popper from './Popper'
 import Reference from './Reference'
+import Keys from '../../constants/Keys'
 import { classNames } from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import { createUniqueIDFactory } from '../../utilities/id'
@@ -116,7 +117,7 @@ class Pop extends React.Component<Props, State> {
   }
 
   handleKeyUp = event => {
-    if (event.keyCode === 13) {
+    if (event.keyCode === Keys.ENTER) {
       this.handleClick(event)
     }
   }

--- a/src/components/Pop/Pop.tsx
+++ b/src/components/Pop/Pop.tsx
@@ -122,6 +122,8 @@ class Pop extends React.Component<Props, State> {
   }
 
   handleBlur = event => {
+    // Whether the Pop was opened by focus or enter press,
+    // it should be closed on blur.
     if (this.state.isOpen) {
       this.safeSetState({ isOpen: false }, () => {
         this.props.onClose(this)
@@ -130,7 +132,10 @@ class Pop extends React.Component<Props, State> {
   }
 
   handleFocus = event => {
-    if (this.shouldHandleFocus()) {
+    // We do not always want to open the Pop on focus,
+    // as sometimes other interaction may be required
+    // to open it.
+    if (this.shouldHandleFocus() && !this.state.isOpen) {
       this.toggleOpen(event)
     }
   }

--- a/src/components/Pop/Pop.tsx
+++ b/src/components/Pop/Pop.tsx
@@ -115,6 +115,26 @@ class Pop extends React.Component<Props, State> {
     this.toggleOpen(event)
   }
 
+  handleKeyUp = event => {
+    if (event.keyCode === 13) {
+      this.handleClick(event)
+    }
+  }
+
+  handleBlur = event => {
+    if (this.state.isOpen) {
+      this.safeSetState({ isOpen: false }, () => {
+        this.props.onClose(this)
+      })
+    }
+  }
+
+  handleFocus = event => {
+    if (this.shouldHandleFocus()) {
+      this.toggleOpen(event)
+    }
+  }
+
   handleOnBodyClick = event => {
     if (!this.state.isOpen) return
     if (!this.shouldHandleHover() && !this.props.closeOnBodyClick) return
@@ -148,6 +168,8 @@ class Pop extends React.Component<Props, State> {
     if (!this.shouldHandleHover()) return
     this.close({ type: INTERACTION_TYPE.POPPER_MOUSE_LEAVE, props: { event } })
   }
+
+  shouldHandleFocus = () => this.props.triggerOn === 'hover'
 
   shouldHandleHover = () => this.props.triggerOn === 'hover'
 
@@ -207,44 +229,40 @@ class Pop extends React.Component<Props, State> {
       className
     )
 
-    const referenceMarkup = React.Children.map(
-      children,
-      child =>
-        child.type === Reference
-          ? React.cloneElement(child, {
-              'aria-describedby': id,
-              display,
-            })
-          : null
+    const referenceMarkup = React.Children.map(children, child =>
+      child.type === Reference
+        ? React.cloneElement(child, {
+            'aria-describedby': id,
+            display,
+          })
+        : null
     )
 
     /* istanbul ignore next */
     /**
      * Too difficult to text in Enzyme, due to createContext + Portal + cloning.
      */
-    const popperMarkup = React.Children.map(
-      children,
-      child =>
-        child.type === Popper
-          ? React.cloneElement(child, {
-              animationDelay,
-              animationDuration,
-              animationEasing,
-              animationSequence,
-              arrowSize,
-              className,
-              close: this.close,
-              'data-cy': `${this.props['data-cy']}Popper`,
-              id,
-              isOpen: this.state.isOpen,
-              onContentClick: this.handleOnContentClick,
-              onMouseLeave: this.handleOnPopperMouseLeave,
-              modifiers,
-              placement,
-              showArrow,
-              zIndex,
-            })
-          : null
+    const popperMarkup = React.Children.map(children, child =>
+      child.type === Popper
+        ? React.cloneElement(child, {
+            animationDelay,
+            animationDuration,
+            animationEasing,
+            animationSequence,
+            arrowSize,
+            className,
+            close: this.close,
+            'data-cy': `${this.props['data-cy']}Popper`,
+            id,
+            isOpen: this.state.isOpen,
+            onContentClick: this.handleOnContentClick,
+            onMouseLeave: this.handleOnPopperMouseLeave,
+            modifiers,
+            placement,
+            showArrow,
+            zIndex,
+          })
+        : null
     )
 
     return (
@@ -261,7 +279,10 @@ class Pop extends React.Component<Props, State> {
             innerRef={this.setNodeRef}
             onMouseMove={this.handleMouseMove}
             onMouseLeave={this.handleMouseLeave}
+            onBlur={this.handleBlur}
             onClick={this.handleClick}
+            onFocus={this.handleFocus}
+            onKeyUp={this.handleKeyUp}
           >
             {referenceMarkup}
             {popperMarkup}

--- a/src/components/Pop/__tests__/Pop.test.js
+++ b/src/components/Pop/__tests__/Pop.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import Pop from '../Pop'
+import Keys from '../../../constants/Keys'
 
 jest.mock('../Pop.Portal', () => {
   const Portal = ({ children }) => <div>{children}</div>
@@ -522,13 +523,13 @@ describe('Pop', () => {
   describe('Keyboard accessibility', () => {
     test('Fires onOpen/onClose on enter press for trigger on click', async () => {
       const nonEvent = {
-        keyCode: 74,
+        keyCode: Keys.KEY_J,
         preventDefault: () => {},
         stopPropagation: () => {},
       }
       const toggleEvent = {
         ...nonEvent,
-        keyCode: 13,
+        keyCode: Keys.ENTER,
       }
       const spyOpen = jest.fn()
       const spyClose = jest.fn()

--- a/src/components/Pop/__tests__/Pop.test.js
+++ b/src/components/Pop/__tests__/Pop.test.js
@@ -519,6 +519,79 @@ describe('Pop', () => {
     })
   })
 
+  describe('Keyboard accessibility', () => {
+    test('Fires onOpen/onClose on enter press for trigger on click', async () => {
+      const nonEvent = {
+        keyCode: 74,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      }
+      const toggleEvent = {
+        ...nonEvent,
+        keyCode: 13,
+      }
+      const spyOpen = jest.fn()
+      const spyClose = jest.fn()
+      const wrapper = shallow(
+        <Pop triggerOn="click" onOpen={spyOpen} onClose={spyClose}>
+          <Pop.Reference />
+        </Pop>
+      )
+      const el = wrapper.find(cx.node)
+
+      // Random key does not open closed pop
+      el.simulate('keyUp', nonEvent)
+      await timeout()
+      expect(spyOpen).not.toHaveBeenCalled()
+
+      // focus does not open closed pop
+      el.simulate('focus')
+      await timeout()
+      expect(spyOpen).not.toHaveBeenCalled()
+
+      // Enter key opens closed pop
+      el.simulate('keyUp', toggleEvent)
+      await timeout()
+      expect(spyOpen).toHaveBeenCalled()
+
+      // Random key does not close open pop
+      el.simulate('keyUp', nonEvent)
+      await timeout()
+      expect(spyClose).not.toHaveBeenCalled()
+
+      // Enter key closes open pop
+      el.simulate('keyUp', toggleEvent)
+      await timeout()
+      expect(spyClose).toHaveBeenCalled()
+    })
+
+    test('Fires onOpen/onClose on focus/blur for trigger on hover', async () => {
+      const spyOpen = jest.fn()
+      const spyClose = jest.fn()
+      const wrapper = shallow(
+        <Pop triggerOn="hover" onOpen={spyOpen} onClose={spyClose}>
+          <Pop.Reference />
+        </Pop>
+      )
+      const el = wrapper.find(cx.node)
+
+      // onClose does not get called when closed pop is blurred
+      el.simulate('blur')
+      await timeout()
+      expect(spyOpen).not.toHaveBeenCalled()
+
+      // focus opens closed pop
+      el.simulate('focus')
+      await timeout()
+      expect(spyOpen).toHaveBeenCalled()
+
+      // blur closes open pop
+      el.simulate('blur')
+      await timeout()
+      expect(spyClose).toHaveBeenCalled()
+    })
+  })
+
   describe('Closing mechanisms', () => {
     test('Closes on block click, if defined', async () => {
       const spy = jest.fn()

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -201,7 +201,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
   }
 
   getErrorMarkup = () => {
-    const { errorIcon, errorMessage, state } = this.props
+    const { errorIcon, errorMessage, state, tabIndex = 0 } = this.props
     const shouldRenderError = state === STATES.error
 
     if (!shouldRenderError) return null
@@ -215,6 +215,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
             name={errorIcon}
             state={STATES.error}
             className="c-Select__errorIcon"
+            tabIndex={tabIndex}
           />
         </Tooltip>
       </ItemUI>
@@ -310,6 +311,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
       state: stateProp,
       style: styleProp,
       success,
+      tabIndex,
       value,
       ...rest
     } = this.props
@@ -344,6 +346,7 @@ export class Select extends React.PureComponent<SelectProps, SelectState> {
         onChange={this.handleOnChange}
         onFocus={this.handleOnFocus}
         innerRef={this.setSelectNode}
+        tabIndex={tabIndex}
         value={selectedValue}
       >
         {placeholderMarkup}

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -54,6 +54,7 @@ export type SelectProps = {
   size: UISize
   state?: UIState
   success: boolean
+  tabIndex: number
   value: string
   width: number | string
 }

--- a/src/components/Select/__tests__/Select.test.js
+++ b/src/components/Select/__tests__/Select.test.js
@@ -517,6 +517,7 @@ describe('ErrorMessage', () => {
     const error = wrapper.find(ui.errorIcon)
 
     expect(error.length).toBeTruthy()
+    expect(error.first().props().tabIndex).toBe(0)
   })
 
   test('Renders a Tooltip, if error', () => {
@@ -528,10 +529,13 @@ describe('ErrorMessage', () => {
   })
 
   test('Can customize error Icon', () => {
-    const wrapper = mount(<Select state="error" errorIcon="chat" />)
+    const wrapper = mount(
+      <Select state="error" errorIcon="chat" tabIndex={3} />
+    )
     const el = wrapper.find('Icon')
 
     expect(el.props().name).toBe('chat')
+    expect(el.props().tabIndex).toBe(3)
   })
 })
 

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.76.0',
+  version: '2.76.1-1',
 }

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.76.1-1',
+  version: '2.76.1-2',
 }

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.76.1-2',
+  version: '2.76.1',
 }

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -5,6 +5,7 @@ import { boolean, select, text } from '@storybook/addon-knobs'
 import InputReadme from '../src/components/Input/README.md'
 import { jsxDecorator } from 'storybook-addon-jsx'
 import { Button, Flexy, Icon, Input, styled } from '../src/index'
+import { getColor } from '../src/styles/utilities/color'
 
 const stories = storiesOf('Input', module)
 
@@ -196,39 +197,61 @@ stories.add('prefix', () => (
   </div>
 ))
 
-stories.add('suffix', () => (
-  <div>
-    <p>
-      <Input
-        suffix={
-          <Button version={2} kind="secondary" size="lg" isLast>
-            Suffix
-          </Button>
-        }
-        value="Input Suffix"
-      />
-    </p>
-    <p>
-      <Input
-        errorMessage="This is incorrect!"
-        state="error"
-        suffix={
-          <Button
-            version={2}
-            size="lg"
-            kind="secondary"
-            isLast
-            state="danger"
-            disabled
-          >
-            Suffix
-          </Button>
-        }
-        value="Input Suffix"
-      />
-    </p>
-  </div>
-))
+stories.add('suffix', () => {
+  const StatefulButtonUI = ({ children, state = 'default', ...rest }) => (
+    <Button className={`is-state-${state}`} {...rest}>
+      {children}
+    </Button>
+  )
+
+  const StatefulButton = styled(Button)`
+    &.is-secondary.is-:disabled,
+    &.is-secondary[disabled] {
+      border-color: ${props =>
+        props.state === 'danger' && `${getColor('red.500')} !important`};
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+      cursor: not-allowed;
+      pointer-events: all;
+    }
+  `
+
+  return (
+    <div>
+      <p>
+        <Input
+          suffix={
+            <Button version={2} kind="secondary" size="lg" isLast>
+              Suffix
+            </Button>
+          }
+          value="Input Suffix"
+        />
+      </p>
+      <p>
+        <Input
+          errorMessage="This is incorrect!"
+          state="error"
+          suffix={
+            <StatefulButton
+              disabled
+              version={2}
+              size="lg"
+              state="danger"
+              kind="secondary"
+              isFirst
+              isLast
+              disabled
+            >
+              Suffix
+            </StatefulButton>
+          }
+          value="Input Suffix"
+        />
+      </p>
+    </div>
+  )
+})
 
 stories.add('seamless', () => <Input seamless autoFocus />)
 

--- a/stories/Input.stories.js
+++ b/stories/Input.stories.js
@@ -198,14 +198,35 @@ stories.add('prefix', () => (
 
 stories.add('suffix', () => (
   <div>
-    <Input
-      suffix={
-        <Button version={2} kind="secondary" size="lg" isLast>
-          Suffix
-        </Button>
-      }
-      value="Input Suffix"
-    />
+    <p>
+      <Input
+        suffix={
+          <Button version={2} kind="secondary" size="lg" isLast>
+            Suffix
+          </Button>
+        }
+        value="Input Suffix"
+      />
+    </p>
+    <p>
+      <Input
+        errorMessage="This is incorrect!"
+        state="error"
+        suffix={
+          <Button
+            version={2}
+            size="lg"
+            kind="secondary"
+            isLast
+            state="danger"
+            disabled
+          >
+            Suffix
+          </Button>
+        }
+        value="Input Suffix"
+      />
+    </p>
   </div>
 ))
 

--- a/stories/Popover.stories.js
+++ b/stories/Popover.stories.js
@@ -74,7 +74,7 @@ stories.add('Default', () => {
     <PropProvider value={{ Popover: { zIndex: 10 } }}>
       <div style={{ padding: '20%', textAlign: 'center' }}>
         <Popover {...props}>
-          <div>Popover Trigger</div>
+          <div tabIndex="0">Popover Trigger</div>
         </Popover>
       </div>
     </PropProvider>

--- a/stories/Tooltip.stories.js
+++ b/stories/Tooltip.stories.js
@@ -81,7 +81,7 @@ stories.add('Default', () => {
     <PropProvider value={{ Tooltip: { zIndex: 10 } }}>
       <div style={{ padding: '20%', textAlign: 'center' }}>
         <Tooltip {...props}>
-          <div>Tooltip Trigger</div>
+          <div tabIndex="0">Tooltip Trigger</div>
         </Tooltip>
       </div>
     </PropProvider>


### PR DESCRIPTION
*[HSDS-114](https://helpscout.atlassian.net/browse/HSDS-114)*

This update improves the accessibility of errors on the Input component as well as generally improves the accessibility of the Tooltip component.

The Tooltip component was updated to:

1. When the Tooltip is set to open on hover and close on mouse leave, the Tooltip will also open on focus and close on blur.
2. When the Tooltip is set to open on click and close on click, the Tooltip will also open on enter press and close on enter press. Clicking or blurring will also close an open Tooltip.

Try the Tooltip story [https://deploy-preview-763--hsds-react.netlify.com/?path=/story/tooltip--default](https://deploy-preview-763--hsds-react.netlify.com/?path=/story/tooltip--default) and change the knob configurations to see the impact the various settings have.

Also try the Input (state:error) story [https://deploy-preview-763--hsds-react.netlify.com/?path=/story/input--state-error](https://deploy-preview-763--hsds-react.netlify.com/).

Finally, try the Input (suffix) story [https://deploy-preview-763--hsds-react.netlify.com/?path=/story/input--suffix](https://deploy-preview-763--hsds-react.netlify.com/?path=/story/input--suffix)

Note: Because we are making pop accessibility, popover also inherits these same features that tooltip is inheriting. I updated the popover story to demo it as well.

https://deploy-preview-763--hsds-react.netlify.com/?path=/story/popover--default