### PR TITLE
Tweak accordion styles

### DIFF
--- a/src/components/Accordion/Accordion.Title.tsx
+++ b/src/components/Accordion/Accordion.Title.tsx
@@ -121,13 +121,11 @@ class Title extends React.Component<TitleProps> {
       name = 'caret-right'
     }
 
-    const size = isLink ? 14 : 18
-
     const iconProps = {
       className: classNameStrings.iconCaretClassName,
       faint: !isOpen,
       name,
-      size,
+      size: 14,
     }
 
     return <Icon {...iconProps} />

--- a/src/components/Accordion/__tests__/Accordion.Title.test.js
+++ b/src/components/Accordion/__tests__/Accordion.Title.test.js
@@ -167,7 +167,7 @@ describe('Link', () => {
     const wrapper = mount(<Title />)
     let icon = wrapper.find('Icon').first()
 
-    expect(icon.prop('size')).not.toBe(14)
+    expect(icon.prop('size')).toBe(14)
 
     wrapper.setProps({ href: '/' })
     icon = wrapper.find('Icon').first()

--- a/src/components/Accordion/styles/Accordion.css.ts
+++ b/src/components/Accordion/styles/Accordion.css.ts
@@ -36,22 +36,22 @@ export const BodyUI = styled('div')`
 
   display: block;
   overflow: hidden;
-  padding: 24px 20px;
+  padding: 0px 20px 20px 20px;
 
   .is-closed & {
     display: none;
   }
 
   &.is-md {
-    padding: 20px 20px;
+    padding: 0 20px 20px 20px;
   }
 
   &.is-sm {
-    padding: 16px 20px;
+    padding: 0 20px 16px 20px;
   }
 
   &.is-xs {
-    padding: 14px 20px;
+    padding: 0 20px 14px 20px;
   }
 
   &.is-seamless {

--- a/src/components/Accordion/styles/Accordion.css.ts
+++ b/src/components/Accordion/styles/Accordion.css.ts
@@ -96,7 +96,6 @@ export const makeTitleUI = (selector: 'div') => {
     &:hover,
     &:focus,
     &.is-open {
-      background-color: ${getColor('grey.200')};
       color: currentColor;
       text-decoration: none;
     }
@@ -106,8 +105,6 @@ export const makeTitleUI = (selector: 'div') => {
     }
 
     &.is-open {
-      border-bottom: 1px solid ${getColor('border')};
-
       &.is-link {
         border-bottom: none;
       }


### PR DESCRIPTION
In this PR we update the Accordion styles to:

1 - have smaller carets
2 - have no background or border on the section title row

I back channeled with @digitaldesigner  and he is aware of the places (SavedReplies, CustomProperties, TranslateBeaconSettings) where this will be updated in HSAPP, and he wants it to be a global change.

Before:
<img width="1427" alt="Image 2020-01-07 at 5 15 25 pm" src="https://user-images.githubusercontent.com/1704626/71933947-4e1fe500-3171-11ea-82e8-f21f21e08753.png">

After:
<img width="1429" alt="Image 2020-01-07 at 5 14 53 pm" src="https://user-images.githubusercontent.com/1704626/71933918-3a747e80-3171-11ea-979d-b2172222f8bb.png">

CC: @digitaldesigner 
