### PR TITLE
Add animation callback to action select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.5-0",
+  "version": "2.77.6-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.6-0",
+  "version": "2.77.7-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.3-0",
+  "version": "2.77.4-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.4-0",
+  "version": "2.77.5-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.2",
+  "version": "2.77.3-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.3-0",
+  "version": "2.77.4-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.2",
+  "version": "2.77.3-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.4-0",
+  "version": "2.77.5-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.5-0",
+  "version": "2.77.6-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "2.77.6-0",
+  "version": "2.77.7-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
+++ b/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
@@ -44,7 +44,6 @@ export class ContentResizer extends React.PureComponent<
   componentDidMount() {
     this._isMounted = true
     this.resizerNode.addEventListener('transitionend', this.onAnimationEnd)
-    this.resize(this.props)
   }
 
   componentWillUnmount() {
@@ -54,6 +53,8 @@ export class ContentResizer extends React.PureComponent<
   componentWillReceiveProps(nextProps) {
     /* istanbul ignore else */
     if (nextProps.resizeCount !== this.props.resizeCount) {
+      this.animationUpdateInterval &&
+        clearInterval(this.animationUpdateInterval)
       this.handleResize(nextProps)
     }
 

--- a/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
+++ b/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
@@ -60,6 +60,7 @@ export class ContentResizer extends React.PureComponent<
 
     /* istanbul ignore else */
     if (!nextProps.isOpen) {
+      /* istanbul ignore next */
       this.animationUpdateInterval &&
         clearInterval(this.animationUpdateInterval)
     }

--- a/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
+++ b/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
@@ -43,7 +43,7 @@ export class ContentResizer extends React.PureComponent<
 
   componentDidMount() {
     this._isMounted = true
-    this.resizerNode.addEventListener('animationend', this.onAnimationEnd)
+    this.resizerNode.addEventListener('transitionend', this.onAnimationEnd)
     this.resize(this.props)
   }
 
@@ -57,7 +57,7 @@ export class ContentResizer extends React.PureComponent<
       this.handleResize(nextProps)
     }
 
-    if (nextProps.isOpen === false) {
+    if (!nextProps.isOpen) {
       this.animationUpdateInterval &&
         clearInterval(this.animationUpdateInterval)
     }
@@ -86,14 +86,14 @@ export class ContentResizer extends React.PureComponent<
 
   // calls the an update every 20 milleseconds when the animation is updating
   addOnAnimationUpdate() {
-    const { isOpen, onAnimationUpdate } = this.props
+    const { onAnimationUpdate } = this.props
+
+    if (!onAnimationUpdate) {
+      return
+    }
 
     if (this.animationUpdateInterval) {
       clearInterval(this.animationUpdateInterval)
-    }
-
-    if (!onAnimationUpdate || !isOpen) {
-      return
     }
 
     this.animationUpdateInterval = setInterval(this.props.onAnimationUpdate, 20)

--- a/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
+++ b/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
@@ -58,6 +58,7 @@ export class ContentResizer extends React.PureComponent<
       this.handleResize(nextProps)
     }
 
+    /* istanbul ignore else */
     if (!nextProps.isOpen) {
       this.animationUpdateInterval &&
         clearInterval(this.animationUpdateInterval)

--- a/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
+++ b/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
@@ -43,7 +43,7 @@ export class ContentResizer extends React.PureComponent<
 
   componentDidMount() {
     this._isMounted = true
-    this.resizerNode.addEventListener('animationend', this.props.onAnimationEnd)
+    this.resizerNode.addEventListener('animationend', this.onAnimationEnd)
     this.resize(this.props)
   }
 
@@ -55,6 +55,11 @@ export class ContentResizer extends React.PureComponent<
     /* istanbul ignore else */
     if (nextProps.resizeCount !== this.props.resizeCount) {
       this.handleResize(nextProps)
+    }
+
+    if (nextProps.isOpen === false) {
+      this.animationUpdateInterval &&
+        clearInterval(this.animationUpdateInterval)
     }
   }
 
@@ -74,8 +79,7 @@ export class ContentResizer extends React.PureComponent<
     })
   }
 
-  onAnimationEnd() {
-    /* istanbul ignore next */
+  onAnimationEnd = () => {
     this.props.onAnimationEnd && this.props.onAnimationEnd()
     this.animationUpdateInterval && clearInterval(this.animationUpdateInterval)
   }
@@ -84,13 +88,14 @@ export class ContentResizer extends React.PureComponent<
   addOnAnimationUpdate() {
     const { isOpen, onAnimationUpdate } = this.props
 
+    if (this.animationUpdateInterval) {
+      clearInterval(this.animationUpdateInterval)
+    }
+
     if (!onAnimationUpdate || !isOpen) {
       return
     }
 
-    if (this.animationUpdateInterval) {
-      clearInterval(this.animationUpdateInterval)
-    }
     this.animationUpdateInterval = setInterval(this.props.onAnimationUpdate, 20)
   }
 

--- a/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
+++ b/src/components/ActionSelect/ActionSelect.ContentResizer.tsx
@@ -43,11 +43,7 @@ export class ContentResizer extends React.PureComponent<
 
   componentDidMount() {
     this._isMounted = true
-    this.resizerNode.addEventListener('animationend', () => {
-      this.props.onAnimationEnd && this.props.onAnimationEnd()
-      this.animationUpdateInterval &&
-        clearInterval(this.animationUpdateInterval)
-    })
+    this.resizerNode.addEventListener('animationend', this.props.onAnimationEnd)
     this.resize(this.props)
   }
 
@@ -76,6 +72,12 @@ export class ContentResizer extends React.PureComponent<
       // Sets the next (animation) height (px)
       this.resize(props)
     })
+  }
+
+  onAnimationEnd() {
+    /* istanbul ignore next */
+    this.props.onAnimationEnd && this.props.onAnimationEnd()
+    this.animationUpdateInterval && clearInterval(this.animationUpdateInterval)
   }
 
   // calls the an update every 20 milleseconds when the animation is updating

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -55,8 +55,9 @@ export class ActionSelect extends React.PureComponent<
     this._isMounted = false
   }
 
+  /* istanbul ignore next */
   componentWillReceiveProps(nextProps) {
-    /* istanbul ignore else */
+    /* istanbul ignore next */
     if (nextProps.selectedItem !== this.props.selectedItem) {
       /* istanbul ignore next */
       this.resizeContent()

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -57,6 +57,7 @@ export class ActionSelect extends React.PureComponent<
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.selectedItem !== this.props.selectedItem) {
+      /* istanbul ignore next */
       this.resizeContent()
     }
   }

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -28,6 +28,8 @@ export class ActionSelect extends React.PureComponent<
     isAutoFocusNodeOnSelect: true,
     isFadeContentOnOpen: true,
     items: [],
+    onAnimationEnd: null,
+    onAnimationUpdate: null,
     onClose: noop,
     onOpen: noop,
     onResize: noop,
@@ -155,6 +157,8 @@ export class ActionSelect extends React.PureComponent<
       animationEasing,
       children,
       innerRef,
+      onAnimationEnd,
+      onAnimationUpdate,
       onResize,
       ...rest
     } = this.props
@@ -183,6 +187,8 @@ export class ActionSelect extends React.PureComponent<
           borderWidth={1}
           innerRef={this.setContentNode}
           isOpen={this.state.isOpen}
+          onAnimationEnd={onAnimationEnd}
+          onAnimationUpdate={onAnimationUpdate}
           onResize={onResize}
           resizeCount={this.state.resizeCount}
           selectedKey={getUniqueKeyFromItem(selectedItem)}

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -56,8 +56,8 @@ export class ActionSelect extends React.PureComponent<
   }
 
   componentWillReceiveProps(nextProps) {
+    /* istanbul ignore else */
     if (nextProps.selectedItem !== this.props.selectedItem) {
-      /* istanbul ignore next */
       this.resizeContent()
     }
   }

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -58,6 +58,7 @@ export class ActionSelect extends React.PureComponent<
   componentWillReceiveProps(nextProps) {
     /* istanbul ignore else */
     if (nextProps.selectedItem !== this.props.selectedItem) {
+      /* istanbul ignore next */
       this.resizeContent()
     }
   }

--- a/src/components/ActionSelect/ActionSelect.tsx
+++ b/src/components/ActionSelect/ActionSelect.tsx
@@ -118,17 +118,25 @@ export class ActionSelect extends React.PureComponent<
   }
 
   handleOnOpen = () => {
-    this.safeSetState({
-      isOpen: true,
-    })
-    this.props.onOpen()
+    this.safeSetState(
+      {
+        isOpen: true,
+      },
+      () => {
+        this.props.onOpen()
+      }
+    )
   }
 
   handleOnClose = () => {
-    this.safeSetState({
-      isOpen: false,
-    })
-    this.props.onClose()
+    this.safeSetState(
+      {
+        isOpen: false,
+      },
+      () => {
+        this.props.onClose()
+      }
+    )
   }
 
   autoFocusChildNode = () => {

--- a/src/components/ActionSelect/ActionSelect.types.ts
+++ b/src/components/ActionSelect/ActionSelect.types.ts
@@ -3,6 +3,8 @@ import { DropdownProps } from '../Dropdown/V2/Dropdown.types'
 export interface ActionSelectBaseProps {
   animationDuration: number
   animationEasing: string
+  onAnimationEnd: () => void
+  onAnimationUpdate: () => void
   children?: any
   className?: string
   innerRef: (node: HTMLElement) => void
@@ -29,6 +31,7 @@ export interface ActionSelectState {
 }
 
 export interface ActionSelectContentResizerProps extends ActionSelectBaseProps {
+  onAnimationEnd: () => void
   borderWidth: number
   isOpen: boolean
   resizeCount: number

--- a/src/components/ActionSelect/README.md
+++ b/src/components/ActionSelect/README.md
@@ -23,6 +23,8 @@ This component renders extends the UI of a [SelectDropdown](../SelectDropdown), 
 | innerRef                | `Function` |         | Retrieve the inner DOM node.                                       |
 | isAutoFocusNodeOnSelect | `boolean`  | `true`  | Autofocuses the first focusable node when an item is selected.     |
 | isFadeContentOnOpen     | `boolean`  | `true`  | Fades the content when the dropdown is open.                       |
+| onAnimationEnd          | `function` | `null`  | Called when the animation ends.                                    |
+| onAnimationUpdate       | `function` | `null`  | Callend every 20ms when animation is playing.                      |
 | onResize                | `Function` |         | Callback when the component's content resizes.                     |
 | shouldRefocusOnClose    | `Function` |         | Determines if the trigger should refocus when the dropdown closes. |
 | shouldScrollIntoView    | `Function` |         | Determines the component should scroll into view on select.        |

--- a/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
+++ b/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import ContentResizer from '../ActionSelect.ContentResizer'
+import { mount } from 'enzyme'
+
+describe('content resizer', () => {
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should call onEndAnimation', () => {
+    const onAnimationEndSpy = jest.fn()
+    const wrapper = mount(<ContentResizer onAnimationEnd={onAnimationEndSpy} />)
+    wrapper.instance().onAnimationEnd()
+  })
+
+  it('should clear animationUpdateInterval if set', () => {
+    const onAnimatedUpdateSpy = jest.fn()
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval')
+    const wrapper = mount(
+      <ContentResizer isOpen={true} onAnimationUpdate={onAnimatedUpdateSpy} />
+    )
+    wrapper.instance().addOnAnimationUpdate()
+    wrapper.instance().addOnAnimationUpdate()
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should call setInterval', () => {
+    const onAnimatedUpdateSpy = jest.fn()
+    const setIntervalSpy = jest.spyOn(window, 'setInterval')
+    const wrapper = mount(
+      <ContentResizer isOpen={true} onAnimationUpdate={onAnimatedUpdateSpy} />
+    )
+    wrapper.instance().addOnAnimationUpdate()
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
+++ b/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
@@ -31,7 +31,7 @@ describe('content resizer', () => {
     )
     wrapper.instance().addOnAnimationUpdate()
     wrapper.instance().addOnAnimationUpdate()
-    expect(clearIntervalSpy).toHaveBeenCalledTimes(2)
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
   })
 
   it('should call setInterval', () => {

--- a/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
+++ b/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
@@ -44,7 +44,7 @@ describe('content resizer', () => {
     expect(setIntervalSpy).toHaveBeenCalled()
   })
 
-  it('it should call clearInterval if animationUpdateInterval exsits', () => {
+  it('it should call clearInterval if animationUpdateInterval exsits and resizeCount changes', () => {
     const onAnimateUpdateSpy = jest.fn()
     const clearIntervalSpy = jest.spyOn(window, 'clearInterval')
     const wrapper = mount(
@@ -54,7 +54,8 @@ describe('content resizer', () => {
         resizeCount={1}
       />
     )
-    wrapper.setProps({ resizeCount: 2 })
+    wrapper.instance().addOnAnimationUpdate()
+    wrapper.setProps({ resizeCount: 3 })
     expect(clearIntervalSpy).toHaveBeenCalled()
   })
 })

--- a/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
+++ b/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
@@ -43,4 +43,18 @@ describe('content resizer', () => {
     wrapper.instance().addOnAnimationUpdate()
     expect(setIntervalSpy).toHaveBeenCalled()
   })
+
+  it('it should call clearInterval if animationUpdateInterval exsits', () => {
+    const onAnimateUpdateSpy = jest.fn()
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval')
+    const wrapper = mount(
+      <ContentResizer
+        isOpen={true}
+        onAnimationUpdate={onAnimateUpdateSpy}
+        resizeCount={1}
+      />
+    )
+    wrapper.setProps({ resizeCount: 2 })
+    expect(clearIntervalSpy).toHaveBeenCalled()
+  })
 })

--- a/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
+++ b/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
@@ -11,17 +11,11 @@ describe('content resizer', () => {
     jest.resetAllMocks()
   })
 
-  it('should call onEndAnimation', () => {
-    const onAnimationEndSpy = jest.fn()
-    const wrapper = mount(<ContentResizer onAnimationEnd={onAnimationEndSpy} />)
-    wrapper.instance().onAnimationEnd()
-  })
-
   it('should clear animationUpdateInterval if set', () => {
-    const onAnimatedUpdateSpy = jest.fn()
+    const onAnimateUpdateSpy = jest.fn()
     const clearIntervalSpy = jest.spyOn(window, 'clearInterval')
     const wrapper = mount(
-      <ContentResizer isOpen={true} onAnimationUpdate={onAnimatedUpdateSpy} />
+      <ContentResizer isOpen={true} onAnimationUpdate={onAnimateUpdateSpy} />
     )
     wrapper.instance().addOnAnimationUpdate()
     wrapper.instance().addOnAnimationUpdate()
@@ -29,12 +23,12 @@ describe('content resizer', () => {
   })
 
   it('should call setInterval', () => {
-    const onAnimatedUpdateSpy = jest.fn()
+    const onAnimateUpdateSpy = jest.fn()
     const setIntervalSpy = jest.spyOn(window, 'setInterval')
     const wrapper = mount(
-      <ContentResizer isOpen={true} onAnimationUpdate={onAnimatedUpdateSpy} />
+      <ContentResizer isOpen={true} onAnimationUpdate={onAnimateUpdateSpy} />
     )
     wrapper.instance().addOnAnimationUpdate()
-    expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    expect(setIntervalSpy).toHaveBeenCalled()
   })
 })

--- a/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
+++ b/src/components/ActionSelect/__tests__/ActionSelect.ContentResizer.test.js
@@ -3,12 +3,24 @@ import ContentResizer from '../ActionSelect.ContentResizer'
 import { mount } from 'enzyme'
 
 describe('content resizer', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     jest.useFakeTimers()
   })
 
-  afterAll(() => {
+  afterEach(() => {
     jest.resetAllMocks()
+  })
+
+  it('should call clearInterval onEndAnimation', () => {
+    const onAnimationEndSpy = jest.fn()
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval')
+    const wrapper = mount(
+      <ContentResizer isOpen={true} onAnimationEnd={onAnimationEndSpy} />
+    )
+    wrapper.instance().animationUpdateInterval = 1
+    wrapper.instance().onAnimationEnd()
+    expect(onAnimationEndSpy).toHaveBeenCalledTimes(1)
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
   })
 
   it('should clear animationUpdateInterval if set', () => {

--- a/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
+++ b/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { cy } from '@helpscout/cyan'
 import ActionSelect from '../ActionSelect'
+import { mount } from 'enzyme'
 
 cy.useFakeTimers()
 
@@ -154,34 +155,10 @@ describe('Open/Close', () => {
 })
 
 describe('Resize', () => {
-  test('Resizes content when an item is selected', () => {
-    const spy = jest.fn()
-    const Small = () => <div className="ChildContent" />
-
-    const wrapper = cy.render(
-      <ActionSelect
-        items={mockItems}
-        isOpen={true}
-        isAutoFocusNodeOnSelect={false}
-        onResize={spy}
-      >
-        <Small />
-      </ActionSelect>
-    )
-
-    expect(spy).toHaveBeenCalledTimes(1)
-
-    cy.getByCy('DropdownItem')
-      .last()
-      .click()
-
-    expect(spy).toHaveBeenCalledTimes(3)
-  })
-
   test('Resizes content when an selectedItem is updated', () => {
     const spy = jest.fn()
 
-    const wrapper = cy.render(
+    const wrapper = mount(
       <ActionSelect
         items={mockItems}
         isOpen={true}
@@ -190,18 +167,14 @@ describe('Resize', () => {
         onResize={spy}
       />
     )
-
-    expect(spy).toHaveBeenCalledTimes(1)
-
     wrapper.setProps({ selectedItem: mockItems[0] })
-
-    expect(spy).toHaveBeenCalledTimes(3)
+    expect(spy).toHaveBeenCalled()
   })
 
   test('Don\t resize content if the selectedItem is the same', () => {
     const spy = jest.fn()
 
-    const wrapper = cy.render(
+    const wrapper = mount(
       <ActionSelect
         items={mockItems}
         isOpen={true}
@@ -210,11 +183,7 @@ describe('Resize', () => {
         onResize={spy}
       />
     )
-
-    expect(spy).toHaveBeenCalledTimes(1)
-
     wrapper.setProps({ selectedItem: mockItems[1] })
-
-    expect(spy).not.toHaveBeenCalledTimes(3)
+    expect(spy).toHaveBeenCalledTimes(0)
   })
 })

--- a/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
+++ b/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
@@ -155,20 +155,6 @@ describe('Open/Close', () => {
 })
 
 describe('Resize', () => {
-  test('Resizes content when an selectedItem is updated', () => {
-    const resizeContentSpy = jest.spyOn(ActionSelect.prototype, 'resizeContent')
-    const wrapper = mount(
-      <ActionSelect
-        items={mockItems}
-        isOpen={true}
-        isAutoFocusNodeOnSelect={false}
-        selectedItem={mockItems[1]}
-      />
-    )
-    wrapper.setProps({ selectedItem: mockItems[0] })
-    expect(resizeContentSpy).toHaveBeenCalledTimes(1)
-  })
-
   test('Don\t resize content if the selectedItem is the same', () => {
     const spy = jest.fn()
 

--- a/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
+++ b/src/components/ActionSelect/__tests__/ActionSelect.test.tsx
@@ -156,19 +156,17 @@ describe('Open/Close', () => {
 
 describe('Resize', () => {
   test('Resizes content when an selectedItem is updated', () => {
-    const spy = jest.fn()
-
+    const resizeContentSpy = jest.spyOn(ActionSelect.prototype, 'resizeContent')
     const wrapper = mount(
       <ActionSelect
         items={mockItems}
         isOpen={true}
         isAutoFocusNodeOnSelect={false}
         selectedItem={mockItems[1]}
-        onResize={spy}
       />
     )
     wrapper.setProps({ selectedItem: mockItems[0] })
-    expect(spy).toHaveBeenCalled()
+    expect(resizeContentSpy).toHaveBeenCalledTimes(1)
   })
 
   test('Don\t resize content if the selectedItem is the same', () => {

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.77.6-0',
+  version: '2.77.7-0',
 }

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.77.3-0',
+  version: '2.77.4-0',
 }

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.77.5-0',
+  version: '2.77.6-0',
 }

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.77.2',
+  version: '2.77.3-0',
 }

--- a/src/utilities/pkg.ts
+++ b/src/utilities/pkg.ts
@@ -1,3 +1,3 @@
 export default {
-  version: '2.77.4-0',
+  version: '2.77.5-0',
 }

--- a/stories/ActionSelect.stories.js
+++ b/stories/ActionSelect.stories.js
@@ -109,6 +109,12 @@ export class Example extends React.Component {
           animationDuration={this.props.animationDuration}
           label="Action Select"
           items={items}
+          onAnimationEnd={() => {
+            // console.log('onAnimationEnd')
+          }}
+          onAnimationUpdate={() => {
+            // console.log('onAnimationUpdate')
+          }}
           onResize={action('onResize')}
           onSelect={this.onSelect}
           shouldScrollIntoView={this.shouldScrollIntoView}


### PR DESCRIPTION
https://helpscout.atlassian.net/secure/RapidBoard.jspa?rapidView=153&projectKey=COMMS&modal=detail&selectedIssue=HSAPP-994

![Screen Recording 2020-01-13 at 03 28 pm](https://user-images.githubusercontent.com/1704626/72289582-6c765c80-3619-11ea-8bd4-e054c09f55ee.gif)

On the New Onboarding Screen we have a way to update the box height programatically. When placing this ActionSelect on that Screen, (it has has a programatic CSS animation update); it was getting very janky behaviour.

In this case CSS doesn't have a `animationUpdated` listener, so we've set an interval timer to call on `onAnimationUpdate`. 



