### PR TITLE
Increase Tooltip default zIndex for use in Modals

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -43,7 +43,7 @@ export class Tooltip extends React.PureComponent<Props> {
     modifiers: {},
     placement: 'top',
     triggerOn: 'hover',
-    zIndex: 999,
+    zIndex: 9999,
   }
 
   static className = 'c-Tooltip'

--- a/stories/Modal.stories.js
+++ b/stories/Modal.stories.js
@@ -231,6 +231,19 @@ stories.add('header/footer with items', () => (
   </Modal>
 ))
 
+stories.add('with tooltip', () => (
+  <Modal trigger={<Link>Clicky</Link>} isSeamless isOpen>
+    <Modal.Content>
+      <Modal.Header>
+        <Heading size="h4">Heading</Heading>
+      </Modal.Header>
+      <Modal.Body>
+        <Input state={'error'} errorMessage={'Shoot! Something is wrong.'} />
+      </Modal.Body>
+    </Modal.Content>
+  </Modal>
+))
+
 stories.add('custom close trigger', () => {
   class Contents extends React.Component {
     render() {


### PR DESCRIPTION
The default zIndex for our Tooltip component should allow it to work within a Modal. Currently, you would need to manually override the z-index for a Tooltip appearing from within a Modal for it to appear.


**Before (default zIndex = 999)**
<img width="430" alt="Screen Shot 2020-01-28 at 12 24 30 PM" src="https://user-images.githubusercontent.com/657935/73304259-c3a92f00-41cc-11ea-98cc-70bd7801815f.png">


**After (default zIndex = 9999)**
<img width="400" alt="Screen Shot 2020-01-28 at 12 31 44 PM" src="https://user-images.githubusercontent.com/657935/73304268-c73cb600-41cc-11ea-8e88-f5405ba89496.png">
