### PR TITLE
Replace LoadingDots with TypingDots

### DIFF
--- a/src/components/Message/Message.Bubble.tsx
+++ b/src/components/Message/Message.Bubble.tsx
@@ -4,7 +4,7 @@ import { noop } from '../../utilities/other'
 import { isNativeSpanType } from '@helpscout/react-utils/dist/isType'
 import compose from '@helpscout/react-utils/dist/compose'
 import Heading from '../Heading'
-import LoadingDots from '../LoadingDots'
+import TypingDots from '../TypingDots'
 import Icon from '../Icon'
 import Text from '../Text'
 import styled from '../styled'
@@ -36,7 +36,10 @@ const MessageBubbleTitle = styled(Heading)(TitleCSS)
 const MessageBubbleTyping = styled('div')(TypingCSS)
 
 // convertLinksToHTML will escape for output as HTML
-const enhanceBody = compose(newlineToHTML, convertLinksToHTML)
+const enhanceBody = compose(
+  newlineToHTML,
+  convertLinksToHTML
+)
 
 export const Bubble = (props: Props, context: Context) => {
   const {
@@ -128,7 +131,7 @@ export const Bubble = (props: Props, context: Context) => {
 
   const innerContentMarkup = typing ? (
     <MessageBubbleTyping className="c-MessageBubble__typing">
-      <LoadingDots />
+      <TypingDots />
     </MessageBubbleTyping>
   ) : (
     bodyMarkup

--- a/src/components/Message/__tests__/Message.Bubble.test.js
+++ b/src/components/Message/__tests__/Message.Bubble.test.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { mount } from 'enzyme'
 import Bubble from '../Message.Bubble'
 import Message from '../Message'
-import { LoadingDots, Text } from '../../index'
+import { TypingDots, Text } from '../../index'
 
 const cx = 'c-MessageBubble'
 const ui = {
@@ -65,23 +65,23 @@ describe('Title', () => {
 })
 
 describe('Typing', () => {
-  test('Does not render a LoadingDots by default', () => {
+  test('Does not render a TypingDots by default', () => {
     const wrapper = mount(<Bubble />)
-    const o = wrapper.find(LoadingDots)
+    const o = wrapper.find(TypingDots)
 
     expect(o.length).toBe(0)
   })
 
-  test('Renders LoadingDots if typing', () => {
+  test('Renders TypingDots if typing', () => {
     const wrapper = mount(<Bubble typing />)
-    const o = wrapper.find(LoadingDots)
+    const o = wrapper.find(TypingDots)
 
     expect(o.length).toBe(1)
   })
 
-  test('Renders LoadingDots instead of children if typing', () => {
+  test('Renders TypingDots instead of children if typing', () => {
     const wrapper = mount(<Bubble typing>Mugatu</Bubble>)
-    const o = wrapper.find(LoadingDots)
+    const o = wrapper.find(TypingDots)
 
     expect(o.length).toBe(1)
     expect(o.html()).not.toContain('Mugatu')

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -121,6 +121,7 @@ export { default as Timeline } from './Timeline'
 export { default as Timestamp } from './Timestamp'
 export { default as Toolbar } from './Toolbar'
 export { default as Tooltip } from './Tooltip'
+export { default as TypingDots } from './TypingDots'
 export { default as Truncate } from './Truncate'
 export { default as VisuallyHidden } from './VisuallyHidden'
 


### PR DESCRIPTION
This PR replaces the `LoadingDots` component usage in `Message.Bubble`, used for typing indication, with the `TypingDots` component. 

![Screen Recording 2020-02-04 at 21 21](https://user-images.githubusercontent.com/7111256/73808174-9b08d280-4794-11ea-8e1d-65a3f945095e.gif)
