### PR TITLE
Refactor Pop component to allow styling base wrapper

### DIFF
--- a/src/components/Pop/Pop.tsx
+++ b/src/components/Pop/Pop.tsx
@@ -18,6 +18,7 @@ export interface Props extends PopProps {
   onContentClick: (event: React.MouseEvent) => void
   shouldClose: (...args: any) => boolean
   shouldOpen: (...args: any) => boolean
+  wrapperStyles: Object
 }
 
 export interface State {
@@ -47,6 +48,7 @@ class Pop extends React.Component<Props, State> {
     shouldOpen: () => true,
     showArrow: true,
     triggerOn: 'click',
+    wrapperStyles: {},
     zIndex: 1000,
   }
   static Arrow = Arrow
@@ -207,6 +209,12 @@ class Pop extends React.Component<Props, State> {
     }
   }
 
+  getWrapperStyles(): Object {
+    const { wrapperStyles } = this.props
+
+    return { ...wrapperStyles }
+  }
+
   setNodeRef = node => (this.node = node)
 
   render() {
@@ -273,7 +281,7 @@ class Pop extends React.Component<Props, State> {
 
     return (
       <Manager>
-        <div>
+        <div style={this.getWrapperStyles()}>
           <EventListener
             event="click"
             handler={this.handleOnBodyClick}


### PR DESCRIPTION
A change was made to the Pop component several months ago to fix an  issue in Embed. However this change prevented the ability to override the styles on the base element in the Pop component. This change implements the functionality to allow for the overriding of styles of base element. 