### PR TITLE
HSAPP-1325 Tweak Form component to accept custom button props

### DIFF
--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -1,4 +1,6 @@
 import * as React from 'react'
+import PropTypes from 'prop-types'
+
 import Actions from './Actions/Form.Actions'
 import Button from '../Button'
 import { classNames } from '../../utilities/classNames'
@@ -16,17 +18,36 @@ export class Form extends React.PureComponent {
     saveText: 'Save',
   }
 
+  static propTypes = {
+    actionDirection: PropTypes.string,
+    actionTabbable: PropTypes.bool,
+    cancelButtonProps: PropTypes.object,
+    cancelText: PropTypes.string,
+    children: PropTypes.any,
+    className: PropTypes.string,
+    destroyButtonProps: PropTypes.object,
+    destroyText: PropTypes.string,
+    onCancel: PropTypes.func,
+    onDestroy: PropTypes.func,
+    onSave: PropTypes.func,
+    saveButtonProps: PropTypes.object,
+    saveText: PropTypes.string,
+  }
+
   render() {
     const {
       actionDirection,
       actionTabbable,
+      cancelButtonProps,
       cancelText,
       children,
       className,
+      destroyButtonProps,
       destroyText,
       onCancel,
       onDestroy,
       onSave,
+      saveButtonProps,
       saveText,
     } = this.props
 
@@ -41,6 +62,7 @@ export class Form extends React.PureComponent {
         version={2}
         submit={true}
         {...commonButtonProps}
+        {...saveButtonProps}
       >
         {saveText}
       </Button>
@@ -53,6 +75,7 @@ export class Form extends React.PureComponent {
         version={2}
         onClick={onCancel}
         {...commonButtonProps}
+        {...cancelButtonProps}
       >
         {cancelText}
       </Button>
@@ -66,6 +89,7 @@ export class Form extends React.PureComponent {
         version={2}
         onClick={onDestroy}
         {...commonButtonProps}
+        {...destroyButtonProps}
       >
         {destroyText}
       </Button>

--- a/src/components/Form/Form.stories.js
+++ b/src/components/Form/Form.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action as addonAction } from '@storybook/addon-actions'
-import { withKnobs, text, boolean } from '@storybook/addon-knobs'
+import { withKnobs, text, boolean, object } from '@storybook/addon-knobs'
 import styled from '../styled'
 import { Form, FormGroup, FormLabel, Input } from '../index'
 import Readme from './README.md'
@@ -234,6 +234,66 @@ stories.add('with unfocusable buttons', () => {
             onCancel={() => console.log('cancel')}
             onDestroy={() => console.log('delete')}
             onSave={this.handleFormSubmit}
+            saveText="Save Entry"
+          >
+            <FormGroup>
+              <FormLabel label="Site Name">
+                <Input onChange={this.handleChange} value={this.state.text} />
+              </FormLabel>
+            </FormGroup>
+          </Form>
+        </ContainerUI>
+      )
+    }
+  }
+
+  return <SampleForm />
+})
+
+stories.add('with custom button props', () => {
+  class SampleForm extends React.Component {
+    state = {
+      text: 'Sample Text',
+    }
+
+    handleChange = value => {
+      this.setState({
+        text: value,
+      })
+    }
+
+    handleFormSubmit = evt => {
+      evt.preventDefault()
+      console.log(`Submitting text: "${this.state.text}"`)
+      this.setState({ text: '' })
+    }
+
+    handleCancel = () => {
+      console.log('cancelling!')
+      this.setState({ text: '' })
+    }
+
+    handleDestroy = () => {
+      console.log('deleting!')
+      this.setState({ text: '' })
+    }
+    render() {
+      return (
+        <ContainerUI>
+          <Form
+            actionDirection={text('actionDirection', 'left')}
+            cancelButtonProps={object('cancelButtonProps', {
+              isFocused: true,
+            })}
+            destroyButtonProps={object('destroyButtonProps', {
+              isLoading: true,
+            })}
+            cancelText="Cancel Changes"
+            destroyText="Delete Item"
+            onCancel={this.handleCancel}
+            onDestroy={this.handleDestroy}
+            onSave={this.handleFormSubmit}
+            saveButtonProps={object('saveButtonProps', { disabled: true })}
             saveText="Save Entry"
           >
             <FormGroup>

--- a/src/components/Form/Form.test.js
+++ b/src/components/Form/Form.test.js
@@ -32,7 +32,7 @@ describe('Children', () => {
   })
 })
 
-describe.only('Actions', () => {
+describe('Actions', () => {
   test('submits the Form on click of the save button', () => {
     const wrapper = mount(<Form />)
     const el = wrapper.find('.c-Form').hostNodes()

--- a/src/components/Form/Form.test.js
+++ b/src/components/Form/Form.test.js
@@ -32,7 +32,7 @@ describe('Children', () => {
   })
 })
 
-describe('Actions', () => {
+describe.only('Actions', () => {
   test('submits the Form on click of the save button', () => {
     const wrapper = mount(<Form />)
     const el = wrapper.find('.c-Form').hostNodes()
@@ -106,6 +106,21 @@ describe('Actions', () => {
         '-1'
       )
     )
+  })
+
+  test('renders buttons with custom props when applied', () => {
+    const wrapper = mount(
+      <Form
+        actionTabbable={false}
+        cancelButtonProps={{ isLoading: true }}
+        destroyButtonProps={{ isLoading: true }}
+        onCancel={() => {}}
+        onDestroy={() => {}}
+        saveButtonProps={{ isLoading: true }}
+      />
+    )
+
+    expect(wrapper.find('.is-loading').hostNodes()).toHaveLength(3)
   })
 })
 

--- a/src/components/Form/README.md
+++ b/src/components/Form/README.md
@@ -17,6 +17,7 @@ This component contains a smaller sub-component:
   className="entry-form"
   actionDirection="left"
   actionTabbable={false}
+  saveButtonProps={{ disabled: true }}
 >
   <FormGroup>
     <FormLabel label="Site Name">
@@ -28,15 +29,18 @@ This component contains a smaller sub-component:
 
 ## Props
 
-| Prop            | Type      | Description                                                                     |
-| --------------- | --------- | ------------------------------------------------------------------------------- |
-| actionTabbable  | `boolean` | Optional. Can the user focus on actions by tabbing. Defaults to "true"          |
-| actionDirection | `string`  | Optional. Direction in which buttons render, right or left. Defaults to "right" |
-| cancelText      | `string`  | Optional. Text for the cancel button. Button will not render without text.      |
-| children        | `any`     | Content to render.                                                              |
-| className       | `string`  | Optional. Custom class names to be added to the component                       |
-| destroyText     | `string`  | Optional. Text for the delete button. Button will not render without text.      |
-| onSave          | `string`  | Callback for when the form is submitted                                         |
-| onCancel        | `string`  | Callback for the cancel button                                                  |
-| onDestroy       | `string`  | Callback for the delete button                                                  |
-| saveText        | `string`  | Optional. Text for the save button. Defaults to "Save". Button always renders.  |
+| Prop               | Type      | Description                                                                     |
+| ------------------ | --------- | ------------------------------------------------------------------------------- |
+| actionDirection    | `string`  | Optional. Direction in which buttons render, right or left. Defaults to "right" |
+| actionTabbable     | `boolean` | Optional. Can the user focus on actions by tabbing. Defaults to "true"          |
+| cancelButtonProps  | `object`  | Optional. Allows the user to pass in any props that Button component accepts.   |
+| cancelText         | `string`  | Optional. Text for the cancel button. Button will not render without text.      |
+| children           | `any`     | Content to render.                                                              |
+| className          | `string`  | Optional. Custom class names to be added to the component                       |
+| destroyButtonProps | `object`  | Optional. Allows the user to pass in any props that Button component accepts.   |
+| destroyText        | `string`  | Optional. Text for the delete button. Button will not render without text.      |
+| onCancel           | `string`  | Callback for the cancel button                                                  |
+| onDestroy          | `string`  | Callback for the delete button                                                  |
+| onSave             | `string`  | Callback for when the form is submitted                                         |
+| saveButtonProps    | `object`  | Optional. Allows the user to pass in any props that Button component accepts.   |
+| saveText           | `string`  | Optional. Text for the save button. Defaults to "Save". Button always renders.  |


### PR DESCRIPTION
[JIRA](https://helpscout.atlassian.net/browse/HSAPP-1325)

This PR lets the Form component accept custom props for the Save, Cancel and Delete buttons, which will allow you to pass through along any prop that the current `<Button />` component accepts, like `disabled`, `isLoading`, etc.

Testing:
[Story](https://deploy-preview-785--hsds-react.netlify.com/?path=/story/form--with-custom-button-props)
Storybook has been updated with a custom story under `Form => with custom button props`. There are knobs you can use to change the current value or pass in a new value, but I've noticed that I can only make one change before having to refresh the page - just FYI. 

Example GIF: https://c.hlp.sc/2Nurn8Yq
If you change `{"disabled": true}` to `{"disabled": false}`, you should see the save button become enabled. It also shows that after making one change, you can't make another without clicking out of this story and then back in.