### PR TITLE
Fix active border in rate action component

### DIFF
--- a/src/components/RateAction/README.md
+++ b/src/components/RateAction/README.md
@@ -17,6 +17,6 @@ This component is a `button` used for ratings, visualized with an [Emoticon](../
 | disabled   | `bool`   | Disables the emoticon from interactions. Default `false`.                               |
 | name       | `string` | Determines the Emoticon image. One of 'reaction-happy', 'reaction-sad', 'reaction-okay' |
 | size       | `string` | Adjusts the size of the component. One of 'lg', 'md', 'sm'                              |
-| withBorder | `bool`   | Shows a big border around the icon                                                      |
+| withCircle | `bool`   | Shows a big border around the icon                                                      |
 
 For additional props, check out [Emoticon](../Emoticon).

--- a/src/components/RateAction/RateAction.css.js
+++ b/src/components/RateAction/RateAction.css.js
@@ -55,10 +55,10 @@ export const RateActionUI = styled('button')`
       transition: fill 200ms linear;
     }
 
-    ${({ name, size, withBorder }) => {
+    ${({ name, size, withCircle }) => {
       const _size = parseInt(config.size[size], 10) * 2 + 4
       return (
-        withBorder &&
+        withCircle &&
         `
           &:before {
             content: '';
@@ -89,8 +89,8 @@ export const RateActionUI = styled('button')`
       ${baseStyles};
       content: '';
       border-radius: 50%;
-      border: ${({ withBorder }) =>
-        withBorder ? 'none' : `2px solid ${config.outlineColor}`};
+      border: ${({ withCircle }) =>
+        !withCircle ? `2px solid ${config.outlineColor}` : 'none'};
       display: none;
       height: calc(${config.size.default} + 4px);
       left: -2px;
@@ -111,7 +111,7 @@ export const RateActionUI = styled('button')`
     }
 
     &.is-active {
-      ${withBorder => withBorder && `transform: scale(1.3)`};
+      ${withCircle => withCircle && `transform: scale(1.3)`};
       &:focus {
         transform: scale(1.3);
       }

--- a/src/components/RateAction/RateAction.css.js
+++ b/src/components/RateAction/RateAction.css.js
@@ -74,7 +74,7 @@ export const RateActionUI = styled('button')`
             width: ${_size}px;
             z-index: -1;
           }
-          &:hover:before {
+          &:hover:before, &.is-active:before {
             background-color: ${getBorderHoverColor(name)}
           }`
       )
@@ -89,7 +89,8 @@ export const RateActionUI = styled('button')`
       ${baseStyles};
       content: '';
       border-radius: 50%;
-      border: 2px solid ${config.outlineColor};
+      border: ${({ withBorder }) =>
+        withBorder ? 'none' : `2px solid ${config.outlineColor}`};
       display: none;
       height: calc(${config.size.default} + 4px);
       left: -2px;
@@ -110,8 +111,9 @@ export const RateActionUI = styled('button')`
     }
 
     &.is-active {
+      ${withBorder => withBorder && `transform: scale(1.3)`};
       &:focus {
-        transform: scale(1);
+        transform: scale(1.3);
       }
       &:after {
         animation: HSDSRateActionSelected 200ms

--- a/src/components/RateAction/RateAction.js
+++ b/src/components/RateAction/RateAction.js
@@ -15,7 +15,7 @@ export class RateAction extends React.PureComponent {
     name: 'reaction-happy',
     onClick: noop,
     size: 'lg',
-    withBorder: false,
+    withCircle: false,
   }
 
   static propTypes = {
@@ -78,7 +78,7 @@ export class RateAction extends React.PureComponent {
       size,
       onBlur,
       onFocus,
-      withBorder,
+      withCircle,
       ...rest
     } = this.props
 
@@ -93,7 +93,7 @@ export class RateAction extends React.PureComponent {
         onFocus={this.handleOnFocus}
         name={name}
         size={size}
-        withBorder={withBorder}
+        withCircle={withCircle}
       >
         <Emoticon
           {...rest}

--- a/src/components/RateAction/RateAction.stories.js
+++ b/src/components/RateAction/RateAction.stories.js
@@ -28,7 +28,7 @@ stories.add('Default', () => {
 stories.add('withBorder', () => {
   return (
     <div style={{ fontFamily: font }}>
-      <h4>Default</h4>
+      <h4>With Border</h4>
       {REACTIONS_EMOTICONS.map(iconName => (
         <div style={{ margin: '0 0 15px', clear: 'both' }}>
           <span style={{ float: 'left', marginRight: 20 }}>{iconName}: </span>

--- a/src/components/RateAction/RateAction.stories.js
+++ b/src/components/RateAction/RateAction.stories.js
@@ -25,10 +25,10 @@ stories.add('Default', () => {
   )
 })
 
-stories.add('withBorder', () => {
+stories.add('withCircle', () => {
   return (
     <div style={{ fontFamily: font }}>
-      <h4>With Border</h4>
+      <h4>With Circle</h4>
       {REACTIONS_EMOTICONS.map(iconName => (
         <div style={{ margin: '0 0 15px', clear: 'both' }}>
           <span style={{ float: 'left', marginRight: 20 }}>{iconName}: </span>
@@ -42,7 +42,7 @@ stories.add('withBorder', () => {
                 marginLeft: 32,
               }}
             >
-              <RateAction size={size} name={iconName} withBorder={true} />
+              <RateAction size={size} name={iconName} withCircle={true} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
Adds an `is-active` state to RateAction so that it can maintain an active state.

<img width="474" alt="Image 2020-02-06 at 2 11 17 pm" src="https://user-images.githubusercontent.com/1704626/73970124-9ce4aa00-48ea-11ea-967e-339f228d2a25.png">
