### PR TITLE
Fix Sortable Accordion Drag Handle Position

### DIFF
--- a/src/components/Accordion/Accordion.css.js
+++ b/src/components/Accordion/Accordion.css.js
@@ -71,6 +71,7 @@ export const AccordionUI = styled('div')`
 
     .c-Accordion__Section__Title.is-sortable {
       background-color: white;
+      position: relative;
       .drag-handle {
         display: none;
         pointer-events: all;


### PR DESCRIPTION
This update fixes the positioning of the drag handle in the sortable Accordion component. The drag handle should be positioned relative to the Section Title, not relative to the entire Section.

[Before](https://p-zkf42x.t2.n0.cdn.getcloudapp.com/items/DOu8X9Od/Screen+Recording+2020-02-11+at+12.39+PM.gif?v=2292d5b7b7a56e81e2a76b161bdbd1e8)

[After](https://p-zkf42x.t2.n0.cdn.getcloudapp.com/items/JruWkgRR/Screen+Recording+2020-02-11+at+12.38+PM.gif?v=5641728837fa990b5edb1ed4a4175d27)