### PR TITLE
Remove wrapping span around the button childrens only when it's not loading

### DIFF
--- a/src/components/Button/Button.css.js
+++ b/src/components/Button/Button.css.js
@@ -24,6 +24,14 @@ export const ButtonUI = styled.button`
   text-align: center;
   text-decoration: none;
 
+  ${({ allowContentEventPropogation }) =>
+    allowContentEventPropogation &&
+    `
+    * {
+      pointer-events: none;
+    }
+  `};
+
   &:hover,
   &:active,
   &:focus {
@@ -241,28 +249,13 @@ function renderStyleForProp(config, prop, attribute) {
     : ''
 }
 
-export const ButtonContentUI = styled('span')`
+export const LoadingWrapperUI = styled.span`
   align-items: inherit;
   display: inherit;
   justify-content: inherit;
   text-decoration: inherit;
   width: 100%;
-
-  ${({ allowContentEventPropogation }) =>
-    allowContentEventPropogation &&
-    `
-    pointer-events: none;
-
-    * {
-      pointer-events: none;
-    }
-  `};
-
-  ${({ isLoading }) =>
-    isLoading &&
-    `
-    opacity: 0;
-  `};
+  opacity: 0;
 `
 
 export const FocusUI = styled('span')`

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -5,7 +5,7 @@ import { classNames } from '../../utilities/classNames'
 import { includes } from '../../utilities/arrays'
 import { noop } from '../../utilities/other'
 import RouteWrapper from '../RouteWrapper'
-import { ButtonUI, ButtonContentUI, FocusUI, SpinnerUI } from './Button.css'
+import { ButtonUI, LoadingWrapperUI, FocusUI, SpinnerUI } from './Button.css'
 import Icon from '../Icon'
 
 class Button extends React.PureComponent {
@@ -172,6 +172,8 @@ class Button extends React.PureComponent {
 
     const selector = this.isLink() ? 'a' : 'button'
 
+    const childrenMarkup = this.getChildrenMarkup()
+
     return (
       <ButtonUI
         {...getValidProps(rest)}
@@ -180,15 +182,14 @@ class Button extends React.PureComponent {
         ref={this.setRef}
         type={type}
         as={selector}
+        allowContentEventPropogation={allowContentEventPropogation}
       >
-        {isLoading ? <SpinnerUI /> : null}
-        <ButtonContentUI
-          allowContentEventPropogation={allowContentEventPropogation}
-          className="c-Button__content c-Button__content"
-          isLoading={isLoading}
-        >
-          {this.getChildrenMarkup()}
-        </ButtonContentUI>
+        {isLoading && <SpinnerUI />}
+        {isLoading ? (
+          <LoadingWrapperUI>{childrenMarkup}</LoadingWrapperUI>
+        ) : (
+          childrenMarkup
+        )}
         {this.getFocusMarkup()}
       </ButtonUI>
     )


### PR DESCRIPTION
[Jira](https://helpscout.atlassian.net/browse/JS-88)
![Screen Recording 2020-02-20 at 10 00 AM](https://user-images.githubusercontent.com/203992/74947036-3d959800-53c8-11ea-8cb9-84553299ad25.gif)

**What's the issue**
react-testing-library is not able to retrieve the Button label because our component wrap the label with a `span`.

**What's the new behavior?**
When the button is not loading, we don't wrap the button children with a span. We still need to wrap the children when it's loading to keep the button size the same for when the `isLoading` flag will be turned off.