### PR TITLE
Remove scroll to bottom

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -23,13 +23,7 @@ import { createUniqueIDFactory } from '../../utilities/id'
 import { isModifierKeyPressed } from '../../utilities/keys'
 import { isDefined } from '../../utilities/is'
 import { noop, requestAnimationFrame } from '../../utilities/other'
-import {
-  COMPONENT_KEY,
-  getTextAreaLineCurrent,
-  getTextAreaLineTotal,
-  moveCursorToEnd,
-  isTextArea,
-} from './Input.utils'
+import { COMPONENT_KEY, moveCursorToEnd, isTextArea } from './Input.utils'
 import {
   CharValidatorText,
   CharValidatorUI,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -194,33 +194,6 @@ export class Input extends React.PureComponent<InputProps, InputState> {
     }, forceAutoFocusTimeout)
   }
 
-  // JSDOM does not provide the necessary values to test this method.
-  // Mocking it would also be extremely difficult and brittle.
-
-  /* istanbul ignore next */
-  scrollToBottom() {
-    if (!this.props.multiline) return
-    if (!this.inputNode || !isTextArea(this.inputNode)) return
-    if (!isDefined(this.computedStyles.paddingBottom)) return
-
-    const { scrollTop, clientHeight } = this.inputNode
-
-    const currentLine = getTextAreaLineCurrent(this.inputNode)
-    const totalLines = getTextAreaLineTotal(this.inputNode)
-    const isLastLine = currentLine === totalLines
-
-    const scrollBottom =
-      scrollTop + clientHeight + this.computedStyles.paddingBottom
-
-    if (isLastLine) {
-      requestAnimationFrame(() => {
-        if (this.inputNode && this.inputNode.scrollTo) {
-          this.inputNode.scrollTo(0, scrollBottom)
-        }
-      })
-    }
-  }
-
   callStartTyping() {
     /* istanbul ignore next */
     if (this.props.onStartTyping) {
@@ -373,7 +346,6 @@ export class Input extends React.PureComponent<InputProps, InputState> {
     }
 
     this.props.onKeyDown(event)
-    this.scrollToBottom()
   }
 
   handleOnKeyUp = (event: Event) => {

--- a/src/components/Input/__tests__/Input.test.js
+++ b/src/components/Input/__tests__/Input.test.js
@@ -168,16 +168,6 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalled()
   })
 
-  test('onKeydown callback fires scrollToBottom', () => {
-    const spy = jest.fn()
-    const wrapper = mount(<Input multiline={true} onKeyDown={spy} />)
-    const input = wrapper.find('textarea')
-    wrapper.instance().scrollToBottom = spy
-
-    input.simulate('keydown')
-    expect(spy).toHaveBeenCalled()
-  })
-
   test('onResize callback is called when Input resizes', () => {
     const spy = jest.fn()
     const wrapper = mount(<Input multiline={true} onResize={spy} />)


### PR DESCRIPTION
*Problem:*
When typing in a multiline text input with a scroll bar, if you moved the caret to the top of the input the multi input would auto scroll to the bottom.

*Solution:*
Remove scrollToBottom. Looking at the blame I could not figure out why this was added. It seems this is a bit over engineered; I've removed, but am confused as to why it was even there in the first place, since the native behaviour of the input seems to be what we want.

ie, it doesn't scroll to the bottom when the caret is at the top.

