### PR TITLE
Remove Helix import

### DIFF
--- a/src/components/Message/styles/Bubble.css.js
+++ b/src/components/Message/styles/Bubble.css.js
@@ -1,6 +1,5 @@
 import styled from '../../styled'
 import { getColor } from '../../../styles/utilities/color'
-import { faker } from '@helpscout/helix'
 import baseStyles from '../../../styles/resets/baseStyles.css'
 import { BEM } from '../../../utilities/classNames'
 import Heading from '../../Heading'


### PR DESCRIPTION
This PR removes the `helix` library import that was added on https://github.com/helpscout/hsds-react/releases/tag/v2.87.0 to avoid increasing bundle size.

The imported module was not being used so I assume we won't have any issues :)