### PR TITLE
Fix emoji-only UI in Message.Bubble component

### DIFF
--- a/src/components/Message/Message.Bubble.tsx
+++ b/src/components/Message/Message.Bubble.tsx
@@ -131,7 +131,10 @@ export const Bubble = (props: Props, context: Context) => {
 
     if (showEmojiOnlyStyles) {
       return (
-        <MessageBubbleBody className="c-MessageBubble__body">
+        <MessageBubbleBody
+          className="c-MessageBubble__body"
+          showEmojiOnlyStyles={showEmojiOnlyStyles}
+        >
           <Text wordWrap lineHeightInherit size={48}>
             {body}
           </Text>

--- a/src/components/Message/Message.Bubble.tsx
+++ b/src/components/Message/Message.Bubble.tsx
@@ -70,27 +70,6 @@ export const Bubble = (props: Props, context: Context) => {
   )
 
   let showEmojiOnlyStyles = false
-  const hasOnlyOneChild = React.Children.count(children) === 1
-
-  const childrenMarkup = React.Children.map(children, child => {
-    showEmojiOnlyStyles =
-      !isThemeEmbed && hasOnlyOneChild && textIncludesOnlyEmoji(child)
-    const fontSize = isThemeEmbed ? '13' : showEmojiOnlyStyles ? 48 : '14'
-
-    return isWord(child) || isNativeSpanType(child) ? (
-      <MessageBubbleBody
-        className="c-MessageBubble__body"
-        isEmbed={isThemeEmbed}
-        showEmojiOnlyStyles={showEmojiOnlyStyles}
-      >
-        <Text wordWrap lineHeightInherit size={fontSize}>
-          {child}
-        </Text>
-      </MessageBubbleBody>
-    ) : (
-      child
-    )
-  })
 
   const fromMarkup =
     isThemeNotifications && fromName ? (
@@ -121,24 +100,61 @@ export const Bubble = (props: Props, context: Context) => {
     </MessageBubbleTitle>
   ) : null
 
-  const bodyMarkup = body ? (
-    <MessageBubbleBody
-      className="c-MessageBubble__body"
-      isEmbed={isThemeEmbed}
-      dangerouslySetInnerHTML={{
-        __html: enhanceBody(body),
-      }}
-    />
-  ) : (
-    childrenMarkup
-  )
+  const hasOnlyOneChild = React.Children.count(children) === 1
+
+  const childrenMarkup = React.Children.map(children, child => {
+    showEmojiOnlyStyles =
+      !isThemeEmbed && hasOnlyOneChild && textIncludesOnlyEmoji(child)
+    const fontSize = isThemeEmbed ? '13' : showEmojiOnlyStyles ? 48 : '14'
+
+    return isWord(child) || isNativeSpanType(child) ? (
+      <MessageBubbleBody
+        className="c-MessageBubble__body"
+        isEmbed={isThemeEmbed}
+        showEmojiOnlyStyles={showEmojiOnlyStyles}
+      >
+        <Text wordWrap lineHeightInherit size={fontSize}>
+          {child}
+        </Text>
+      </MessageBubbleBody>
+    ) : (
+      child
+    )
+  })
+
+  const renderBody = () => {
+    if (!body) {
+      return childrenMarkup
+    }
+
+    showEmojiOnlyStyles = !isThemeEmbed && textIncludesOnlyEmoji(body)
+
+    if (showEmojiOnlyStyles) {
+      return (
+        <MessageBubbleBody className="c-MessageBubble__body">
+          <Text wordWrap lineHeightInherit size={48}>
+            {body}
+          </Text>
+        </MessageBubbleBody>
+      )
+    }
+    return (
+      <MessageBubbleBody
+        className="c-MessageBubble__body"
+        isEmbed={isThemeEmbed}
+        dangerouslySetInnerHTML={{
+          __html: enhanceBody(body),
+        }}
+      />
+    )
+  }
 
   const innerContentMarkup = typing ? (
     <MessageBubbleTyping className="c-MessageBubble__typing">
       <TypingDots />
     </MessageBubbleTyping>
   ) : (
-    bodyMarkup
+    renderBody()
   )
 
   const contentMarkup = (

--- a/src/components/Message/__tests__/Message.Bubble.test.js
+++ b/src/components/Message/__tests__/Message.Bubble.test.js
@@ -148,6 +148,18 @@ describe('Content', () => {
     expect(wrapper.html()).toContain('<a href="http://www.helpscout.com"')
   })
 
+  describe('when body includes only emoji content', () => {
+    test('Renders body with Text component', () => {
+      const wrapper = mount(<Bubble body="🙄" />)
+      const o = wrapper.find(ui.body).first()
+      const includesTextElement = wrapper.find(Text)
+
+      expect(o.length).toBe(1)
+      expect(includesTextElement.length).toBe(1)
+      expect(wrapper.html()).toContain('🙄')
+    })
+  })
+
   test('Converts newlines to line break elements', () => {
     const body = 'Hello\n\nGoodbye'
     const wrapper = mount(<Bubble body={body} />)

--- a/stories/Message/Message.default.stories.js
+++ b/stories/Message/Message.default.stories.js
@@ -94,6 +94,7 @@ stories.add('default', () => (
     </Message>
 
     <Message to avatar={<Avatar name="Buddy" />}>
+      <Message.Chat read timestamp="9:41am" body="🙃" />
       <Message.Chat
         isNote
         read

--- a/stories/Message/Message.default.stories.js
+++ b/stories/Message/Message.default.stories.js
@@ -20,6 +20,9 @@ stories.add('default', () => (
         omgomgomg
         {1}
       </Message.Chat>
+      <Message.Chat read timestamp="9:41am" metaPosition="top">
+        🚀
+      </Message.Chat>
       <Message.Chat read timestamp="9:41am">
         <strong>*Frantically running through North pole*</strong>
       </Message.Chat>
@@ -62,6 +65,7 @@ stories.add('default', () => (
           Caan, Zooey Deschanel, Mary Steenburgen, Daniel Tay, Edward Asner, and
           Bob Newhart...
         </PreviewCard>
+        <Message.Chat read timestamp="9:41am" body="🙃" />
       </Message.Content>
       <Message.Chat read timestamp="9:41am">
         Just read that!
@@ -94,7 +98,6 @@ stories.add('default', () => (
     </Message>
 
     <Message to avatar={<Avatar name="Buddy" />}>
-      <Message.Chat read timestamp="9:41am" body="🙃" />
       <Message.Chat
         isNote
         read


### PR DESCRIPTION
In release https://github.com/helpscout/hsds-react/releases/tag/v2.88.0 the Chat UI was updated for when the message body included only Emoji characters. However this work did not include the scenario when message data was passed in the `body` prop. This PR addresses that missing support. 


### Before
<img width="694" alt="Screen Shot 2020-03-02 at 16 07 55" src="https://user-images.githubusercontent.com/7111256/75722578-17150e00-5ca0-11ea-9259-8cea49830533.png">

### After
<img width="683" alt="Screen Shot 2020-03-02 at 16 04 20" src="https://user-images.githubusercontent.com/7111256/75722589-1d0aef00-5ca0-11ea-9a88-c673b53ad06b.png">
