### PR TITLE
Fix chat message body with emoji spacing issue

### DIFF
--- a/src/components/Message/Message.Bubble.tsx
+++ b/src/components/Message/Message.Bubble.tsx
@@ -55,19 +55,6 @@ export const Bubble = (props: Props, context: Context) => {
   const isThemeNotifications = theme === 'notifications'
   const isThemeEmbed = theme === 'embed'
   const fromName = from && typeof from === 'string' ? from : null
-  const componentClassName = classNames(
-    'c-MessageBubble',
-    from && 'is-from',
-    icon && 'withIcon',
-    isNote && 'is-note',
-    size && `is-${size}`,
-    ltr && !rtl && 'is-ltr',
-    !ltr && rtl && 'is-rtl',
-    theme && `is-theme-${theme}`,
-    to && 'is-to',
-    typing && 'is-typing',
-    className
-  )
 
   let showEmojiOnlyStyles = false
 
@@ -165,6 +152,21 @@ export const Bubble = (props: Props, context: Context) => {
       {iconMarkup}
       <div className="c-MessageBubble__bodyWrapper">{innerContentMarkup}</div>
     </div>
+  )
+
+  const componentClassName = classNames(
+    'c-MessageBubble',
+    from && 'is-from',
+    icon && 'withIcon',
+    isNote && 'is-note',
+    size && `is-${size}`,
+    ltr && !rtl && 'is-ltr',
+    !ltr && rtl && 'is-rtl',
+    theme && `is-theme-${theme}`,
+    to && 'is-to',
+    typing && 'is-typing',
+    showEmojiOnlyStyles && 'emoji-only',
+    className
   )
 
   return (

--- a/src/components/Message/styles/Bubble.css.js
+++ b/src/components/Message/styles/Bubble.css.js
@@ -158,7 +158,7 @@ export const MessageBubbleUI = styled('div')`
     `
       background: none !important;
       border: none;
-      padding-top: 0;
-      padding-bottom:0;
+      padding-left: 0;
+      padding-right:0;
     `}
 `

--- a/src/components/Message/styles/Message.css.js
+++ b/src/components/Message/styles/Message.css.js
@@ -60,6 +60,15 @@ const css = `
     margin-bottom: 0;
     min-width: initial;
   }
+
+  .c-MessageChatBlock:only-child .c-MessageBubble.emoji-only {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+
+  .c-MessageChatBlock:last-child .c-MessageBubble.emoji-only {
+    padding-bottom: 0 !important;
+  }
 `
 
 export default css

--- a/stories/Message/Message.default.stories.js
+++ b/stories/Message/Message.default.stories.js
@@ -34,6 +34,11 @@ stories.add('default', () => (
       </Message.Action>
     </Message>
     <Message from avatar={<Avatar name="Arctic Puffin" />}>
+      <Message.Chat read timestamp="9:41am" metaPosition="top">
+        🐐
+      </Message.Chat>
+    </Message>
+    <Message from avatar={<Avatar name="Arctic Puffin" />}>
       <Message.Chat read timestamp="9:41am">
         Hey Buddy!
       </Message.Chat>


### PR DESCRIPTION
This address a spacing issues when Emoji only messages are sandwiched between other messages. 

## Before
<img width="419" alt="Screen Shot 2020-03-03 at 12 54 29" src="https://user-images.githubusercontent.com/7111256/75809317-38ccce80-5d4e-11ea-9317-4a77ff950639.png">
<img width="508" alt="Screen Shot 2020-03-03 at 15 42 21" src="https://user-images.githubusercontent.com/7111256/75822442-97517700-5d65-11ea-9a00-e3a011ef4e37.png">

## After
<img width="411" alt="Screen Shot 2020-03-03 at 12 54 16" src="https://user-images.githubusercontent.com/7111256/75809304-35d1de00-5d4e-11ea-8e2a-a684df5409b2.png">

<img width="535" alt="Screen Shot 2020-03-03 at 15 41 23" src="https://user-images.githubusercontent.com/7111256/75822412-89035b00-5d65-11ea-90e4-75ca45ddcf7a.png">
