### PR TITLE
Fix the border color of the CopyCode upon focus

### DIFF
--- a/src/components/CopyCode/styles/CopyCode.css.js
+++ b/src/components/CopyCode/styles/CopyCode.css.js
@@ -6,7 +6,7 @@ export const config = {
   borderColor: getColor('border'),
   borderColorFocus: getColor('blue.500'),
   boxShadow: '0 0 0 0 transparent',
-  boxShadowFocus: `0 0 0 1px ${getColor('blue.400')}`,
+  boxShadowFocus: `0 0 0 1px ${getColor('blue.500')}`,
   fontFamily:
     '"SFMono-Regular","Roboto Mono",Consolas,"Liberation Mono",Menlo,Courier,monospace',
   fontSize: 12,


### PR DESCRIPTION
We [changed the color of the border when the CopyCode component is focused to blue.500](https://github.com/helpscout/hsds-react/commit/b2846ef674e26a56bdcc2ccd305f68f677b8b914#diff-3b6a2f7b6a7795a08dfc329597b498c3R7), but the box shadow also needed to be changed. This PR changes it to match.

This is needed as part of https://helpscout.atlassian.net/browse/HSAPP-1535