### PR TITLE
Adjust Mesage Bubble spacing that include Emoji

### DIFF
--- a/src/components/Message/styles/Message.css.js
+++ b/src/components/Message/styles/Message.css.js
@@ -66,6 +66,10 @@ const css = `
     padding-bottom: 0 !important;
   }
 
+  .c-MessageChatBlock:first-child .c-MessageBubble.emoji-only {
+    padding-top: 0 !important;
+  }
+
   .c-MessageChatBlock:last-child .c-MessageBubble.emoji-only {
     padding-bottom: 0 !important;
   }

--- a/stories/Message/Message.default.stories.js
+++ b/stories/Message/Message.default.stories.js
@@ -34,9 +34,8 @@ stories.add('default', () => (
       </Message.Action>
     </Message>
     <Message from avatar={<Avatar name="Arctic Puffin" />}>
-      <Message.Chat read timestamp="9:41am" metaPosition="top">
-        🐐
-      </Message.Chat>
+      <Message.Chat read timestamp="9:41am" body="🙂" />
+      <Message.Chat read timestamp="9:41am" body="Hello World" />
     </Message>
     <Message from avatar={<Avatar name="Arctic Puffin" />}>
       <Message.Chat read timestamp="9:41am">


### PR DESCRIPTION
There was unfortunately a missing CSS rule, in the previous release: https://github.com/helpscout/hsds-react/releases/tag/v2.89.7

### Before
<img width="175" alt="Screen Shot 2020-03-05 at 12 43 54" src="https://user-images.githubusercontent.com/7111256/76014317-03a3b600-5edf-11ea-9ba6-3a7a63213954.png">

### After
<img width="156" alt="Screen Shot 2020-03-05 at 12 44 30" src="https://user-images.githubusercontent.com/7111256/76014345-14542c00-5edf-11ea-8e80-a9f45f638744.png">
