### PR TITLE
Upgrade Fancy to v2.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1861,9 +1861,9 @@
       }
     },
     "@helpscout/fancy": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.2.7.tgz",
-      "integrity": "sha512-+zN7OARcRzOST+kSNO0aRx+J9r3SYPg/STl4fVxNH85L05lxbv4Ic0CQ4ASA+O5IbDBnNxWNkaYWicWYRYqrHQ==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.2.8.tgz",
+      "integrity": "sha512-Lo4wpDrMS1xDbgFKXjVhUdLbRB+zuOPSLE5XEvaJnGZ+wS2fKy6MYc/Y3+FGnpxSDwUY/xM4YLs6rCN51Hqc7Q==",
       "requires": {
         "@emotion/hash": "0.6.6",
         "@emotion/memoize": "0.6.6",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-dom": "^16 || ^15"
   },
   "dependencies": {
-    "@helpscout/fancy": "2.2.7",
+    "@helpscout/fancy": "2.2.8",
     "@helpscout/motion": "0.0.8",
     "@helpscout/react-utils": "1.0.6",
     "@helpscout/wedux": "0.0.11",


### PR DESCRIPTION
**[Customer Convo](https://secure.helpscout.net/conversation/1089679675/501512/)**

This upgrade is a [one-liner](https://github.com/helpscout/fancy/compare/v2.2.7...v2.2.8#diff-17db3debd221f187e2859daf66158d85R18) on Fancy that passes the `fcy` key to the `createEmotion` instance. In a [previous PR](https://github.com/helpscout/fancy/pull/48) we added the key to the Emotion instance used in iframes, and now we're doing basically the same for instances outside of iframes. This solves a conflict between Beacon and other websites using Emotion.

With this upgrade, all auto-generated class names in hsds-react will now be named `fcy-{hash}` instead of `css-{hash}`. Other than that, there should be no impact.