### PR TITLE
Verification Code: trigger the onChange event when a code is pasted

### DIFF
--- a/src/components/VerificationCode/VerificationCode.js
+++ b/src/components/VerificationCode/VerificationCode.js
@@ -102,6 +102,7 @@ export default class VerificationCode extends React.Component {
   }
 
   handlePaste = e => {
+    const { onChange } = this.props
     /* istanbul ignore next */
     const clipboardData = e.clipboardData || window.clipboardData
     const pastedData = clipboardData.getData('Text')
@@ -125,6 +126,7 @@ export default class VerificationCode extends React.Component {
             }
           }
         })
+      onChange(getCurrentCodeValue(this.digitInputNodes))
     }
   }
 


### PR DESCRIPTION
The **`Verification Code`** component was not calling the `onChange` event when a new code is pasted in, only when typing in. We want the onChange to fire if the change is caused by pasting a new value in as well.