### PR TITLE
Add disabled props + Fix modal focus trapping

### DIFF
--- a/src/components/Modal/Modal.ActionFooter.jsx
+++ b/src/components/Modal/Modal.ActionFooter.jsx
@@ -15,12 +15,14 @@ class ActionFooter extends React.PureComponent {
     cancelText: 'Cancel',
     kind: MODAL_KIND.DEFAULT,
     onCancel: noop,
-    primaryButtonText: 'Save',
-    secondaryButtonText: null,
-    showDefaultCancel: true,
-    state: '',
     onPrimaryClick: noop,
     onSecondaryClick: noop,
+    primaryButtonText: 'Save',
+    primaryButtonDisabled: false,
+    secondaryButtonText: null,
+    secondaryButtonDisabled: false,
+    showDefaultCancel: true,
+    state: '',
   }
 
   handleCancel = e => {
@@ -42,7 +44,7 @@ class ActionFooter extends React.PureComponent {
   }
 
   renderPrimaryButton() {
-    const { primaryButtonText, state } = this.props
+    const { primaryButtonText, state, primaryButtonDisabled } = this.props
     return (
       <PrimaryButtonUI
         state={state}
@@ -50,6 +52,7 @@ class ActionFooter extends React.PureComponent {
         size="lg"
         version={2}
         onClick={this.handlePrimaryAction}
+        disabled={primaryButtonDisabled}
       >
         {primaryButtonText}
       </PrimaryButtonUI>
@@ -57,34 +60,25 @@ class ActionFooter extends React.PureComponent {
   }
 
   renderSecondaryButton() {
-    const { kind, secondaryButtonText } = this.props
+    const { kind, secondaryButtonText, secondaryButtonDisabled } = this.props
     if (!secondaryButtonText) {
       return null
     }
 
-    if (kind === MODAL_KIND.ALERT) {
-      return (
-        <SecondaryAlertButtonUI
-          kind="secondary"
-          size="lg"
-          version={2}
-          onClick={this.handleSecondaryAction}
-        >
-          {secondaryButtonText}
-        </SecondaryAlertButtonUI>
-      )
-    } else {
-      return (
-        <SecondaryButtonUI
-          kind="secondary"
-          size="lg"
-          version={2}
-          onClick={this.handleSecondaryAction}
-        >
-          {secondaryButtonText}
-        </SecondaryButtonUI>
-      )
-    }
+    const ButtonComponent =
+      kind === MODAL_KIND.ALERT ? SecondaryAlertButtonUI : SecondaryButtonUI
+
+    return (
+      <ButtonComponent
+        kind="secondary"
+        size="lg"
+        version={2}
+        onClick={this.handleSecondaryAction}
+        disabled={secondaryButtonDisabled}
+      >
+        {secondaryButtonText}
+      </ButtonComponent>
+    )
   }
 
   renderCancelButton() {

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -198,6 +198,9 @@ export const V2WithVeryLongContent = () => (
       {ContentSpec.generate(12).map(({ id, content }) => (
         <p key={id}>{content}</p>
       ))}
+      <p>
+        <a href="#">focusable anchor</a> and <a>not focusable anchor</a>
+      </p>
     </Modal.Body>
     <Modal.ActionFooter
       primaryButtonText="Primary"

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -140,6 +140,31 @@ V2WithSecondaryButton.story = {
   name: 'V2/with secondary button',
 }
 
+export const V2WithDisabledPrimary = () => (
+  <Modal
+    version={2}
+    isOpen={true}
+    trigger={<Link>Clicky</Link>}
+    title="Modal Title"
+  >
+    <Modal.Body version={2}>
+      {ContentSpec.generate(2).map(({ id, content }) => (
+        <p key={id}>{content}</p>
+      ))}
+    </Modal.Body>
+    <Modal.ActionFooter
+      primaryButtonText="Primary"
+      secondaryButtonDisabled={true}
+      primaryButtonDisabled={true}
+      secondaryButtonText="Secondary"
+    />
+  </Modal>
+)
+
+V2WithDisabledPrimary.story = {
+  name: 'V2/with disabled buttons',
+}
+
 export const V2WithDangerButton = () => (
   <Modal
     version={2}

--- a/src/utilities/__tests__/focus/findCurrentFocusedNodeIndex.test.js
+++ b/src/utilities/__tests__/focus/findCurrentFocusedNodeIndex.test.js
@@ -12,7 +12,7 @@ test('Returns falsey if with node (arg) is invalid', () => {
 test('Returns index of current focused node', () => {
   document.body.innerHTML = `
     <span>Nope</span>
-    <a>Yes</a>
+    <a href="#">Yes</a>
     <input type='text' value='Yes' />
     <div>Nope</div>
     <select><option>Yes</option></select>
@@ -31,7 +31,7 @@ test('Returns index of current focused node', () => {
 test("Returns false if current node isn't focusable", () => {
   document.body.innerHTML = `
     <span class="nope">Nope</span>
-    <a>Yes</a>
+    <a href="#">Yes</a>
     <input type='text' value='Yes' />
     <div>Nope</div>
     <select><option>Yes</option></select>

--- a/src/utilities/__tests__/focus/findFirstFocusableNode.test.js
+++ b/src/utilities/__tests__/focus/findFirstFocusableNode.test.js
@@ -12,7 +12,7 @@ test('Returns falsey if no focusable nodes found', () => {
 test('Returns first focusable node', () => {
   document.body.innerHTML = `
     <span>Nope</span>
-    <a>Yes</a>
+    <a href="#">Yes</a>
     <input type='text' value='Yes' />
     <div>Nope</div>
     <select><option>Yes</option></select>
@@ -30,7 +30,7 @@ test('Returns first focusable node', () => {
 
 test('Returns first focusable node within scope', () => {
   document.body.innerHTML = `
-    <a>Yes</a>
+    <a href="#">Yes</a>
     <span>Nope</span>
     <input type='text' value='Yes' />
     <div>Nope</div>

--- a/src/utilities/__tests__/focus/findFocusableNodes.test.js
+++ b/src/utilities/__tests__/focus/findFocusableNodes.test.js
@@ -14,7 +14,7 @@ test('Returns empty nodeList if no focusable nodes found', () => {
 
 test('Returns a list of focusable nodes', () => {
   document.body.innerHTML = `
-    <a>Yes</a>
+    <a href="#">Yes</a>
     <span>Nope</span>
     <input type='text' value='Yes' />
     <div>Nope</div>
@@ -24,6 +24,8 @@ test('Returns a list of focusable nodes', () => {
     <span tabindex="-1">Nope</span>
     <span tabindex="0">Yup</span>
     <span tabindex="10">Yup</span>
+    <button disabled>disabled button</button>
+    <a>not focusable anchor</a>
   `
   const o = findFocusableNodes()
   expect(o instanceof NodeList).toBeTruthy()

--- a/src/utilities/__tests__/focus/findLastFocusableNode.test.js
+++ b/src/utilities/__tests__/focus/findLastFocusableNode.test.js
@@ -21,7 +21,7 @@ test('Returns last focusable node', () => {
     <span tabindex="-1">Nope</span>
     <span tabindex="0">Yup</span>
     <span tabindex="10">Yup</span>
-    <a>Yes</a>
+    <a href="#">Yes</a>
     <span>Nope</span>
   `
   const o = findLastFocusableNode()

--- a/src/utilities/__tests__/focus/findNextFocusableNode.test.js
+++ b/src/utilities/__tests__/focus/findNextFocusableNode.test.js
@@ -14,7 +14,7 @@ test('Returns next focusable node', () => {
   document.body.innerHTML = `
     <span>Nope</span>
     <input type='text' value='Yes' />
-    <a>NEXT</a>
+    <a href="#">NEXT</a>
     <div>Nope</div>
     <select><option>Yes</option></select>
     <textarea>Yes</textarea>
@@ -34,7 +34,7 @@ test('Returns next focusable node', () => {
 
 test('Returns next focusable node within scope', () => {
   document.body.innerHTML = `
-    <a>Yes</a>
+    <a href="#">Yes</a>
     <span>Nope</span>
     <div>Nope</div>
     <select><option>Yes</option></select>

--- a/src/utilities/__tests__/focus/findPreviousFocusableNode.test.js
+++ b/src/utilities/__tests__/focus/findPreviousFocusableNode.test.js
@@ -13,7 +13,7 @@ test('Returns falsey if with invalid args found', () => {
 test('Returns previous focusable node', () => {
   document.body.innerHTML = `
     <span>Nope</span>
-    <a>PREV</a>
+    <a href="#">PREV</a>
     <input type='text' value='Yes' />
     <div>Nope</div>
     <select><option>Yes</option></select>
@@ -34,7 +34,7 @@ test('Returns previous focusable node', () => {
 
 test('Returns previous focusable node within scope', () => {
   document.body.innerHTML = `
-    <a>Yes</a>
+    <a href="#">Yes</a>
     <span>Nope</span>
     <div>Nope</div>
     <select><option>Yes</option></select>

--- a/src/utilities/__tests__/focus/focusNextFocusableNode.test.js
+++ b/src/utilities/__tests__/focus/focusNextFocusableNode.test.js
@@ -12,7 +12,7 @@ test('Focuses next node, and returns next node', () => {
 
   document.body.innerHTML = `
     <span>Nope</span>
-    <a>Current</a>
+    <a href="#">Current</a>
     <input type='text' value='NEXT' />
     <div>Nope</div>
     <select><option>Yes</option></select>
@@ -41,7 +41,7 @@ test('Focuses next node within scope', () => {
   document.body.innerHTML = `
     <span>Nope</span>
     <div class="scope">
-      <a>Current</a>
+      <a href="#">Current</a>
       <input type='text' value='NEXT' />
     </div>
     <div>Nope</div>
@@ -80,7 +80,7 @@ test('Focuses first focusable node if there are no next nodes', () => {
     <span tabindex="-1">Nope</span>
     <span tabindex="0">Yup</span>
     <span tabindex="10">Yup</span>
-    <a>Current</a>
+    <a href="#">Current</a>
   `
 
   const n = document.querySelector('a')

--- a/src/utilities/__tests__/focus/focusPreviousFocusableNode.test.js
+++ b/src/utilities/__tests__/focus/focusPreviousFocusableNode.test.js
@@ -13,7 +13,7 @@ test('Focuses previous node, and returns previous node', () => {
   document.body.innerHTML = `
     <span>Nope</span>
     <input type='text' value='NEXT' />
-    <a>Current</a>
+    <a href="#">Current</a>
     <div>Nope</div>
     <select><option>Yes</option></select>
     <textarea>Yes</textarea>
@@ -42,7 +42,7 @@ test('Focuses previous node within scope', () => {
     <span>Nope</span>
     <div class="scope">
       <input type='text' value='NEXT' />
-      <a>Current</a>
+      <a href="#">Current</a>
     </div>
     <div>Nope</div>
     <select><option>Yes</option></select>
@@ -71,7 +71,7 @@ test('Focuses last focusable node if there are no previous nodes', () => {
   }
 
   document.body.innerHTML = `
-    <a>Current</a>
+    <a href="#">Current</a>
     <span>Nope</span>
     <div>Nope</div>
     <select><option>Yes</option></select>

--- a/src/utilities/focus.js
+++ b/src/utilities/focus.js
@@ -1,7 +1,7 @@
 import { getNodeScope, getWindowFromNode, isNodeElement } from './node'
 
 export const FOCUSABLE_SELECTOR =
-  'a,frame,iframe,input:not([type=hidden]),select,textarea,button:not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])'
+  'a[href],frame,iframe,input:not([type=hidden]):not([disabled]),select,textarea,button:not([disabled]):not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])'
 
 export const findFocusableNodes = nodeScope => {
   const scope = getNodeScope(nodeScope)


### PR DESCRIPTION
## Disabled props
This update adds two new props to `Modal.ActionFooter` that will disabled the action button when needed. `primaryButtonDisabled` & `secondaryButtonDisabled`

<img width="722" alt="Image 2020-04-17 at 2 26 19 PM" src="https://user-images.githubusercontent.com/203992/79603274-05ee5800-80ba-11ea-9437-702248b5972b.png">

## Fix focus trapping
The node selector to find focusableNode did included disabled `<button>` and `<a>` with an `href`. We update the selector to better reflect what can be focused inside a modal

![Screen Recording 2020-04-17 at 02 26 PM](https://user-images.githubusercontent.com/203992/79603350-31714280-80ba-11ea-88fc-402d23b6688d.gif)
