### PR TITLE
Tab focus cycling in Modal

### DIFF
--- a/src/components/Modal/Modal.HeaderV2.jsx
+++ b/src/components/Modal/Modal.HeaderV2.jsx
@@ -20,6 +20,7 @@ class HeaderV2 extends React.PureComponent {
   static defaultProps = {
     description: null,
     icon: null,
+    iconSize: '20',
     illo: null,
     illoSize: 60,
     kind: MODAL_KIND.DEFAULT,
@@ -111,6 +112,7 @@ class HeaderV2 extends React.PureComponent {
       children,
       description,
       icon,
+      iconSize,
       kind,
       title,
       ...rest
@@ -128,7 +130,7 @@ class HeaderV2 extends React.PureComponent {
 
     return (
       <HeaderUI {...rest} className={componentClassName} placement={'top'}>
-        {icon ? <Icon name={icon} key={icon} size={'20'} /> : null}
+        {icon ? <Icon name={icon} key={icon} size={iconSize} /> : null}
         {<HeaderTitleUI>{title}</HeaderTitleUI>}
         {children}
       </HeaderUI>

--- a/src/components/Modal/Modal.HeaderV2.jsx
+++ b/src/components/Modal/Modal.HeaderV2.jsx
@@ -20,7 +20,7 @@ class HeaderV2 extends React.PureComponent {
   static defaultProps = {
     description: null,
     icon: null,
-    iconSize: '20',
+    iconSize: '24',
     illo: null,
     illoSize: 60,
     kind: MODAL_KIND.DEFAULT,

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -186,7 +186,7 @@ class Modal extends React.PureComponent {
 
     if (focusedNodeIndex === focusableNodes.length - 1) {
       event.preventDefault()
-      focusableNodes[0].focus()
+      if (focusableNodes && focusableNodes[0]) focusableNodes[0].focus()
     }
   }
 
@@ -199,7 +199,8 @@ class Modal extends React.PureComponent {
 
     if (focusedNodeIndex === 0) {
       event.preventDefault()
-      focusableNodes[focusableNodes.length - 1].focus()
+      const i = focusableNodes.length - 1
+      if (focusableNodes && focusableNodes[i]) focusableNodes[i].focus()
     }
   }
 

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -64,6 +64,7 @@ class Modal extends React.PureComponent {
     isHsApp: PropTypes.bool,
     isOpen: PropTypes.bool,
     icon: PropTypes.string,
+    iconSize: PropTypes.string,
     illo: PropTypes.string,
     illoSize: PropTypes.number,
     kind: PropTypes.string,
@@ -111,6 +112,7 @@ class Modal extends React.PureComponent {
     containTabKeyPress: true,
     description: null,
     icon: null,
+    iconSize: '20',
     illo: null,
     illoSize: 60,
     isHsApp: false,
@@ -279,6 +281,7 @@ class Modal extends React.PureComponent {
       className,
       description,
       icon,
+      iconSize,
       illo,
       illoSize,
       kind,
@@ -313,6 +316,7 @@ class Modal extends React.PureComponent {
     const headerMarkup = v2 ? (
       <HeaderV2
         icon={icon}
+        iconSize={iconSize}
         illo={illo}
         illoSize={illoSize}
         description={description}

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -65,7 +65,7 @@ class Modal extends React.PureComponent {
     isOpen: PropTypes.bool,
     icon: PropTypes.string,
     iconSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    illo: PropTypes.string,
+    illo: PropTypes.any,
     illoSize: PropTypes.number,
     kind: PropTypes.string,
     modalAnimationDelay: PropTypes.number,

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -184,6 +184,7 @@ class Modal extends React.PureComponent {
 
     if (focusedNodeIndex === focusableNodes.length - 1) {
       event.preventDefault()
+      focusableNodes[0].focus()
     }
   }
 
@@ -191,10 +192,12 @@ class Modal extends React.PureComponent {
     const { containTabKeyPress } = this.props
     if (!containTabKeyPress || !this.cardNode || !this.documentNode) return
 
+    const focusableNodes = findFocusableNodes(this.cardNode)
     const focusedNodeIndex = this.getFocusNodeIndexFromEvent(event)
 
     if (focusedNodeIndex === 0) {
       event.preventDefault()
+      focusableNodes[focusableNodes.length - 1].focus()
     }
   }
 

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -64,7 +64,7 @@ class Modal extends React.PureComponent {
     isHsApp: PropTypes.bool,
     isOpen: PropTypes.bool,
     icon: PropTypes.string,
-    iconSize: PropTypes.string,
+    iconSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     illo: PropTypes.string,
     illoSize: PropTypes.number,
     kind: PropTypes.string,
@@ -112,7 +112,7 @@ class Modal extends React.PureComponent {
     containTabKeyPress: true,
     description: null,
     icon: null,
-    iconSize: '20',
+    iconSize: '24',
     illo: null,
     illoSize: 60,
     isHsApp: false,
@@ -200,7 +200,8 @@ class Modal extends React.PureComponent {
     if (focusedNodeIndex === 0) {
       event.preventDefault()
       const i = focusableNodes.length - 1
-      if (focusableNodes && focusableNodes[i]) focusableNodes[i].focus()
+      if (i > -1 && focusableNodes && focusableNodes[i])
+        focusableNodes[i].focus()
     }
   }
 

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -172,6 +172,7 @@ export const V2WithDangerButton = () => (
     isOpen={true}
     trigger={<Link>Clicky</Link>}
     icon="alert"
+    iconSize="24"
     title="Change Subdomain?"
   >
     <Modal.Body version={2}>

--- a/src/components/Pop/Arrow.jsx
+++ b/src/components/Pop/Arrow.jsx
@@ -126,7 +126,7 @@ Arrow.propTypes = {
   color: PropTypes.string,
   className: PropTypes.string,
   children: PropTypes.any,
-  arrowRef: PropTypes.node,
+  arrowRef: PropTypes.any,
   placement: PropTypes.string,
   offset: PropTypes.number,
   size: PropTypes.number,

--- a/src/components/VerificationCode/VerificationCode.jsx
+++ b/src/components/VerificationCode/VerificationCode.jsx
@@ -25,7 +25,8 @@ import Tooltip from '../Tooltip'
 export default class VerificationCode extends React.Component {
   static propTypes = {
     autoFocus: PropTypes.bool,
-    autoSubmit: PropTypes.bool,
+    autoSubmitPaste: PropTypes.bool,
+    autoSubmitKeyUp: PropTypes.bool,
     code: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     isValid: PropTypes.bool,
     numberOfChars: PropTypes.number,
@@ -35,7 +36,8 @@ export default class VerificationCode extends React.Component {
 
   static defaultProps = {
     autoFocus: false,
-    autoSubmit: false,
+    autoSubmitPaste: false,
+    autoSubmitKeyUp: false,
     code: '',
     isValid: true,
     numberOfChars: 6,
@@ -108,16 +110,12 @@ export default class VerificationCode extends React.Component {
   }
 
   handleChange = value => {
-    const { onChange, onEnter, autoSubmit, numberOfChars } = this.props
+    const { onChange } = this.props
     onChange(value)
-
-    if (autoSubmit && value.length === numberOfChars) {
-      onEnter(value)
-    }
   }
 
   handlePaste = e => {
-    const { numberOfChars } = this.props
+    const { numberOfChars, autoSubmitPaste, onEnter } = this.props
     const clipboardData = e.clipboardData || window.clipboardData
     const pastedData = clipboardData.getData('Text')
 
@@ -138,7 +136,13 @@ export default class VerificationCode extends React.Component {
             }
           }
         })
-      this.handleChange(getCurrentCodeValue(this.digitInputNodes))
+
+      const value = getCurrentCodeValue(this.digitInputNodes)
+      this.handleChange(value)
+
+      if (autoSubmitPaste && value.length === numberOfChars) {
+        onEnter(value)
+      }
     }
   }
 
@@ -196,7 +200,7 @@ export default class VerificationCode extends React.Component {
 
     if (key !== 'Meta') {
       const { value } = e.target
-      const { numberOfChars } = this.props
+      const { numberOfChars, autoSubmitKeyUp, onEnter } = this.props
       const digitMask = this.digitMaskNodes[index]
 
       if (key === 'Backspace') {
@@ -240,7 +244,12 @@ export default class VerificationCode extends React.Component {
         digitMask.innerText = value
         nextDigit && nextDigit.select()
 
-        this.handleChange(getCurrentCodeValue(this.digitInputNodes))
+        const currentCodeValue = getCurrentCodeValue(this.digitInputNodes)
+        this.handleChange(currentCodeValue)
+
+        if (autoSubmitKeyUp && currentCodeValue.length === numberOfChars) {
+          onEnter(currentCodeValue)
+        }
       }
     }
   }

--- a/src/components/VerificationCode/VerificationCode.stories.js
+++ b/src/components/VerificationCode/VerificationCode.stories.js
@@ -79,13 +79,13 @@ AutoFocusWithHalfCode.story = {
   name: 'autofocus with half code',
 }
 
-export const AutoSubmit = () => {
+export const AutoSubmitOnPaste = () => {
   const [code, setCode] = useState()
   return (
     <div>
       <VerificationCode
         autoFocus={true}
-        autoSubmit={true}
+        autoSubmitPaste={true}
         onChange={val => {
           console.log(val)
         }}
@@ -100,6 +100,31 @@ export const AutoSubmit = () => {
   )
 }
 
-AutoSubmit.story = {
-  name: 'autoSubmit',
+AutoSubmitOnPaste.story = {
+  name: 'autoSubmit on paste',
+}
+
+export const AutoSubmitOnKeyUp = () => {
+  const [code, setCode] = useState()
+  return (
+    <div>
+      <VerificationCode
+        autoFocus={true}
+        autoSubmitKeyUp={true}
+        onChange={val => {
+          console.log(val)
+        }}
+        onEnter={val => {
+          setCode(val)
+        }}
+      />
+      <p>
+        Submitted code: <b>{code}</b>
+      </p>
+    </div>
+  )
+}
+
+AutoSubmitOnKeyUp.story = {
+  name: 'autoSubmit on keyup',
 }

--- a/src/components/VerificationCode/VerificationCode.test.js
+++ b/src/components/VerificationCode/VerificationCode.test.js
@@ -382,7 +382,9 @@ describe('AutoSubmit', () => {
         getData: t => TEXT,
       },
     }
-    const wrapper = mount(<VerificationCode autoSubmit onEnter={onEnterSpy} />)
+    const wrapper = mount(
+      <VerificationCode autoSubmitPaste onEnter={onEnterSpy} />
+    )
 
     wrapper.simulate('paste', eventMock)
 


### PR DESCRIPTION
This updates move the focus to the first or last in the list based on if the user reach an edge node inside a Modal

![Screen Recording 2020-04-20 at 05 02 PM](https://user-images.githubusercontent.com/203992/79799869-338d0880-8329-11ea-9ff6-c2e8a12dce34.gif)

_**edit**_

### Modal icon size
We also update the `Modal` component to add a new prop  `iconSize` to modify the size of the header icon

### VerificationCode autoSubmit
We split the autoSubmit prop into two different prop (`autoSubmitPaste` `autoSubmitKeyUp`), to allow for more customization. We can now trigger the auto submit on paste or keyup only, or for both.

