### PR TITLE
Configurable codemod import package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,6 +236,6 @@
     }
   },
   "bin": {
-    "hsds-codemod": "./scripts/codemod/hsds-codemod.js"
+    "hsds-codemod": "./codemod/hsds-codemod.js"
   }
 }

--- a/scripts/codemod/cli.js
+++ b/scripts/codemod/cli.js
@@ -137,7 +137,7 @@ const TRANSFORMER_INQUIRER_CHOICES = [
   },
   {
     name:
-      '3.0 ReplaceImports: Replace all hsds-react import with the next release (hsds-react-next)',
+      '3.0 ReplaceImports: Replace all hsds-react import with the next release',
     value: 'ReplaceImportsTransform',
   },
 ]
@@ -212,6 +212,30 @@ function run() {
         when: !cli.input[0],
         pageSize: TRANSFORMER_INQUIRER_CHOICES.length,
         choices: TRANSFORMER_INQUIRER_CHOICES,
+      },
+      {
+        type: 'input',
+        name: 'originalImportName',
+        message: 'Enter the original package name',
+        when: function(answers) {
+          return (
+            answers.transformer === 'all' ||
+            answers.transformer === 'ReplaceImportsTransform'
+          )
+        },
+        default: '@helpscout/hsds-react',
+      },
+      {
+        type: 'input',
+        name: 'importName',
+        message: 'Enter the new package name',
+        when: function(answers) {
+          const isReplaceImports =
+            answers.transformer === 'all' ||
+            answers.transformer === 'ReplaceImportsTransform'
+          return isReplaceImports && answers.originalImportName
+        },
+        default: 'helpscout-hsds-react-next',
       },
     ])
     .then(answers => {

--- a/scripts/codemod/transforms/ReplaceImportsTransform.js
+++ b/scripts/codemod/transforms/ReplaceImportsTransform.js
@@ -4,7 +4,7 @@ export default function replaceImportTransform(
   api,
   {
     moduleName = '@helpscout/hsds-react',
-    moduleNameTarget = '@helpscout/hsds-react-next',
+    moduleNameTarget = 'helpscout-hsds-react-next',
   }
 ) {
   const j = api.jscodeshift


### PR DESCRIPTION
This update adds 2 steps after selecting which codemod to run.

This will allows us to change when needed the package name that needs to be find&replace.

The extra prompt questions will be shown only when selected "All" or "Replace import path"

![Screen Recording 2020-04-27 at 12 02 PM](https://user-images.githubusercontent.com/203992/80393785-f8d22580-887e-11ea-81c3-30b49b16aae2.gif)
