### PR TITLE
Message Bubble w/Typing Indicator UI adjustments

### DIFF
--- a/src/components/Message/styles/Bubble.css.js
+++ b/src/components/Message/styles/Bubble.css.js
@@ -119,6 +119,12 @@ export const MessageBubbleUI = styled('div')`
     }
   }
 
+  &.is-typing {
+    background: none;
+    border: 0;
+    padding-top: 7px;
+  }
+
   &.is-theme-embed {
     background-color: ${getColor('grey.400')};
     border: 1px solid ${getColor('grey.400')};


### PR DESCRIPTION
[Jira Ticket](https://helpscout.atlassian.net/browse/COMMS-589)

Refactor the UI for Chat message typing indicator. To achieve this, we:
- removed the background color of the Message Bubble
- move the y-pos of the typing indicator up 6px


### Before
![Screen Recording 2020-04-27 at 16 35](https://user-images.githubusercontent.com/7111256/80423192-33e74f80-88a5-11ea-91d9-d176c4f07e89.gif)

### After
![Screen Recording 2020-04-27 at 16 24](https://user-images.githubusercontent.com/7111256/80423102-fa164900-88a4-11ea-8811-d5eeade8f28b.gif)
