### PR TITLE
CopyButton minor tweak: updates the checkmark size to match the button size

### DIFF
--- a/src/components/CopyButton/CopyButton.tsx
+++ b/src/components/CopyButton/CopyButton.tsx
@@ -85,7 +85,7 @@ class CopyButton extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { className, kind, ...rest } = this.props
+    const { className, kind, size, ...rest } = this.props
     const { shouldRenderConfirmation } = this.state
 
     const componentClassName = classNames(
@@ -99,16 +99,19 @@ class CopyButton extends React.PureComponent<Props, State> {
       shouldRenderConfirmation && 'is-copyConfirmed'
     )
 
+    const iconSize = size === 'sm' ? 'tick-small' : 'tick-large'
+
     return (
       <CopyButtonUI
         {...rest}
         className={componentClassName}
         kind={kind}
         onClick={this.handleOnClick}
+        size={size}
         version={2}
       >
         <ConfirmationIconWrapperUI className={wrapperClassName}>
-          <Icon className="c-CopyButton__iconConfirmation" name="tick-small" />
+          <Icon className="c-CopyButton__iconConfirmation" name={iconSize} />
         </ConfirmationIconWrapperUI>
         <ContentWrapperUI className={wrapperClassName}>Copy</ContentWrapperUI>
       </CopyButtonUI>

--- a/src/components/CopyInput/CopyInput.tsx
+++ b/src/components/CopyInput/CopyInput.tsx
@@ -73,9 +73,10 @@ class CopyInput extends React.PureComponent<Props> {
         suffix={
           <CopyButton
             onClick={this.handleCopyClick.bind(this)}
-            size="lg"
             isLast
+            size="lg"
             style={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }}
+            tabIndex="-1"
             buttonRef={node => {
               this.copyButtonNode = node
             }}

--- a/stories/CopyButton.stories.js
+++ b/stories/CopyButton.stories.js
@@ -8,3 +8,11 @@ const stories = storiesOf('CopyButton', module)
 stories.add('Default', () => (
   <CopyButton onClick={action('Click')} onReset={action('Reset')} />
 ))
+
+stories.add('Medium', () => (
+  <CopyButton onClick={action('Click')} onReset={action('Reset')} size="md" />
+))
+
+stories.add('Small', () => (
+  <CopyButton onClick={action('Click')} onReset={action('Reset')} size="sm" />
+))


### PR DESCRIPTION
CopyButton checkmark which displays on clicking copy, is too small when rendered inside a large version of the component and looks strange.

Also, makes a CopyButton within a CopyInput default to not being part of the focus loop

This is needed for two HSApp issues:
- https://helpscout.atlassian.net/browse/HSAPP-1926
- https://helpscout.atlassian.net/browse/HSAPP-1921

**Before:**
CopyButton size = anything => checkmark icon size = "tick-small"

**After:**
CopyButton size = "lg" => checkmark icon size = "tick-large"
CopyButton size = "md" => checkmark icon size = "tick-large"
CopyButton size = "sm" => checkmark icon size = "tick-small"

This adds new stories to the CopyButton for medium and small to demonstrate the difference on click.

![Screen Shot 2020-04-28 at 1 52 51 PM](https://user-images.githubusercontent.com/657935/80536996-1c1cd380-8958-11ea-9742-8a7e5cdda443.png)
)
