### PR TITLE
Add Alert UI updates from v3

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -17,6 +17,7 @@ import {
   CloseWrapperUI,
   ContentUI,
   IconWrapperUI,
+  ActionRightUI,
 } from './styles/Alert.css'
 
 export interface Props {
@@ -75,7 +76,7 @@ export class Alert extends React.PureComponent<Props, State> {
       </BadgeWrapperUI>
     ) : icon ? (
       <IconWrapperUI className={cx.icon}>
-        <Icon name="alert" size="20" />
+        <Icon name="alert" size="24" />
       </IconWrapperUI>
     ) : null
 
@@ -86,7 +87,7 @@ export class Alert extends React.PureComponent<Props, State> {
     const { actionRight, dismissible, children } = this.props
 
     const actionRightMarkup = actionRight && (
-      <div className={cx.actionRight}>{actionRight}</div>
+      <ActionRightUI className={cx.actionRight}>{actionRight}</ActionRightUI>
     )
 
     const closeButtonMarkup = dismissible && (

--- a/src/components/Alert/styles/Alert.css.ts
+++ b/src/components/Alert/styles/Alert.css.ts
@@ -15,7 +15,9 @@ export const AlertUI = styled('div')`
   background-color: ${config.backgroundColor};
   color: ${config.color};
   box-shadow: ${config.boxShadow};
-  padding: 8px 16px;
+  padding: 0 16px;
+  min-height: 44px;
+  display: flex;
   margin-bottom: 16px;
   text-align: left;
 
@@ -25,16 +27,13 @@ export const AlertUI = styled('div')`
   > *:last-child {
     margin-bottom: 0;
   }
-
   a:not(.c-button, .c-Button) {
     color: inherit;
     text-decoration: underline;
-
     &:hover {
       color: inherit;
     }
   }
-
   &.is-noMargin {
     margin-bottom: 0;
   }
@@ -43,8 +42,9 @@ export const AlertUI = styled('div')`
 `
 
 export const ContentUI = styled('div')`
-  align-items: flex-start;
+  align-items: center;
   display: flex;
+  flex: 1 1 100%;
 
   > * {
     max-width: 100%;
@@ -64,10 +64,9 @@ export const BadgeWrapperUI = styled('div')`
 `
 
 export const BlockUI = styled('div')`
-  line-height: 28px;
   max-width: 100%;
-  min-height: 28px;
   min-width: 0;
+  padding: 13px 0;
 
   .c-Heading,
   .c-Text,
@@ -98,7 +97,10 @@ export const BlockUI = styled('div')`
 `
 
 export const IconWrapperUI = styled('div')`
-  padding: 3px 0;
+  align-self: center;
+  padding: 0;
+  flex: 0 0 auto;
+
   + * {
     margin-left: 8px;
   }
@@ -108,6 +110,13 @@ export const CloseWrapperUI = styled('div')`
   margin-left: auto;
   margin-right: -4px;
   padding-left: 8px;
+  flex: 0 0 auto;
+`
+
+export const ActionRightUI = styled('div')`
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding: 22px 12px 22px 0;
 `
 
 function makeStateStyles(): string {


### PR DESCRIPTION
This update brings all UI changes to the `Alert` component that was done in v3, to the actual HSDS version.

There is not a tons of UI updates. The line-height was updates, and the component rely on the padding to keep thing well aligned. The icon size was also increase to 24.

<img width="858" alt="Image 2020-04-29 at 10 45 14 AM" src="https://user-images.githubusercontent.com/203992/80610167-03b7c200-8a07-11ea-9087-ec1cc06d5385.png">
<img width="664" alt="Image 2020-04-29 at 10 47 31 AM" src="https://user-images.githubusercontent.com/203992/80610232-1a5e1900-8a07-11ea-846f-6279ed1973f6.png">
