### PR TITLE
COMMS-613 Add re-rendering on prop changes to ComboBox

### DIFF
--- a/src/components/ComboBox/ComboBox.tsx
+++ b/src/components/ComboBox/ComboBox.tsx
@@ -57,6 +57,12 @@ export class ComboBox extends React.Component<ComboBoxProps, ComboBoxState> {
     this._isMounted = false
   }
 
+  componentWillReceiveProps(props) {
+    if (props.isOpen !== this.props.isOpen) {
+      this.setState({ isOpen: props.isOpen })
+    }
+  }
+
   shouldDropDirectionUpdate = positionProps => {
     if (this.state.inputValue) return false
 


### PR DESCRIPTION
Previously the ComboBox component wasn't updating the internal `isOpen` state when the `isOpen` prop was updated. 