### PR TITLE
Add systematic hover state control to AvatarSelector

### DIFF
--- a/src/components/AvatarSelector/AvatarSelector.tsx
+++ b/src/components/AvatarSelector/AvatarSelector.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { classNames } from '../../utilities/classNames'
 import {
   AvatarSelectorUI,
   AvatarSelectorWrapperUI,
@@ -10,6 +11,7 @@ import {
 export interface Props {
   image: string
   initials: string
+  isHovered: boolean
   isOpen: boolean
   name: string
 }
@@ -18,6 +20,7 @@ export default class AvatarSelector extends React.PureComponent<Props> {
   static defaultProps = {
     image: '',
     initials: '',
+    isHovered: false,
     isOpen: false,
     name: '',
   }
@@ -40,9 +43,15 @@ export default class AvatarSelector extends React.PureComponent<Props> {
   }
 
   render() {
-    const { image, initials, isOpen, name } = this.props
+    const { image, initials, isHovered, isOpen, name } = this.props
+
+    const componentClassNames = classNames(
+      'c-AvatarSelector',
+      isHovered && 'is-hovered'
+    )
+
     return (
-      <AvatarSelectorWrapperUI className="c-AvatarSelector" tabIndex="0">
+      <AvatarSelectorWrapperUI className={componentClassNames} tabIndex="0">
         {image || initials || name
           ? this.renderAvatar()
           : this.renderBlankAvatar()}

--- a/src/components/AvatarSelector/styles/AvatarSelector.css.js
+++ b/src/components/AvatarSelector/styles/AvatarSelector.css.js
@@ -37,7 +37,8 @@ export const AvatarSelectorWrapperUI = styled('div')`
     }
   }
 
-  &:hover {
+  &:hover,
+  &.is-hovered {
     background-color: ${getColor('grey.500')};
   }
 `


### PR DESCRIPTION
When the AvatarSelector was used as a trigger for the Dropdown component, the hover prop was not be used to systematically add hover states to the Avatar button. 

![screencast 2020-05-01 17-28-05](https://user-images.githubusercontent.com/7111256/80846260-3e6d5600-8bd1-11ea-924c-e086abbc83ba.gif)
