### PR TITLE
PROD-726 Fix Margin Bottom on HSDS Form (v2)

### DIFF
--- a/src/components/Form/Actions/Form.Actions.css.js
+++ b/src/components/Form/Actions/Form.Actions.css.js
@@ -2,7 +2,7 @@ import baseStyles from '../../../styles/resets/baseStyles.css'
 import styled from '../../styled'
 
 export const config = {
-  marginBottom: 100,
+  marginBottom: 20,
   marginTop: 30,
   spacing: 10,
 }


### PR DESCRIPTION
The margin-bottom on the HSDS Form, applied via the Form Actions, was 100px, which was much too large. It should have been 20px, which is consistent with other forms in Help Scout.

In the following screenshot, we see the Form Actions used inside an Accordion Section. In total, there is 120px of space at the bottom, where there should be 40px (20px for the Form Action margin bottom and 20px for the Accordion Section padding.

![Problem](https://p-zkf42x.t2.n0.cdn.getcloudapp.com/items/2NuXbeEB/Image%202020-05-11%20at%203.33.41%20PM.png?v=37f0a71df1269824d70f0c06ee681a41)

In the next screenshot we see how after applying this change, we have the correct amount of space.

![Solution](https://p-zkf42x.t2.n0.cdn.getcloudapp.com/items/lluD7b5r/Image%202020-05-11%20at%203.34.14%20PM.png?v=86d52de76c33871d30efe147db5c5341)