### PR TITLE
Hide Storybook Addon Panel by default

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -3,7 +3,7 @@ import theme from './theme'
 
 addons.setConfig({
   theme,
-  showPanel: true,
+  showPanel: false,
   enableShortcuts: false,
   selectedPanel: 'knobs',
 })


### PR DESCRIPTION
This PR updates the default setting for displaying the Storybook Addon menu. Now the menu will be hidden by default. 