### PR TITLE
Fix Dropdown.MenuContainer memory leak

### DIFF
--- a/src/components/Dropdown/Dropdown.MenuContainer.jsx
+++ b/src/components/Dropdown/Dropdown.MenuContainer.jsx
@@ -326,7 +326,7 @@ export class MenuContainer extends React.PureComponent {
       this.didOpen = true
     }
     if (isBrowserEnv()) {
-      requestAnimationFrame(this.repositionMenuNodeCycle)
+      this.positionRAF = requestAnimationFrame(this.repositionMenuNodeCycle)
     }
   }
 
@@ -341,6 +341,12 @@ export class MenuContainer extends React.PureComponent {
     this.didOpen = false
     // End the reposition cycle
     cancelAnimationFrame(this.positionRAF)
+
+    // This call busts the out-of-date memorized props for
+    // `memoSetPositionStylesOnNode` with the default settings provided by
+    // `getPositionProps` when the `node` or `placementNode` are not defined.
+    this.updateMenuNodePosition()
+
     this.props.closeDropdown()
     this.focusTriggerNodeOnClose()
   }


### PR DESCRIPTION
This PR addresses several bugs in the Dropdown.MenuContainer component. The issues include:
- a memory leak created by not properly cleaning up an animation frame reference
- (uncovered by fixing the first bug) `memoSetPositionStylesOnNode`'s memorized function  props not being updated (reset) on close of the portal. 

To address these issues:
1. I added the missing animation reference update, so that that reference will be cleaned up by the `cancelAnimationFrame` call. 
2. Called `updateMenuNodePosition` in the `onPortalClose` call so that the result of the call to `getPositionProps` would produce its defaultValue and that would replace the memorized arguments in `memoSetPositionStylesOnNode`. This allowed for the next call to run `setPositionStylesOnNode` properly.

For a detailed explanation of the bugs and fixes, please refer to: https://c.hlp.sc/BluZz8RX