### PR TITLE
PROD-816 Update Popover to be able to display on hover

### DIFF
--- a/src/components/Popover/Popover.jsx
+++ b/src/components/Popover/Popover.jsx
@@ -59,6 +59,7 @@ export const Popover = props => {
     content,
     renderContent,
     className,
+    triggerOn,
     ...rest
   } = props
 
@@ -83,13 +84,14 @@ export const Popover = props => {
       data-cy="Popover"
       innerRef={innerRef}
       render={render}
-      trigger="click"
+      trigger={triggerOn}
     />
   )
 }
 
 Popover.defaultProps = Object.assign(Tooltip.defaultProps, {
   innerRef: noop,
+  triggerOn: 'click',
 })
 
 Popover.propTypes = Object.assign(Tooltip.propTypes, {

--- a/src/components/Popover/Popover.stories.js
+++ b/src/components/Popover/Popover.stories.js
@@ -25,7 +25,7 @@ export const Default = () => {
     'triggerOn',
     {
       click: 'click',
-      hover: 'hover',
+      hover: 'mouseenter',
     },
     'click'
   )


### PR DESCRIPTION
The Popover was hardcoded to trigger on click, but it needs to default to 'click' but be configurable so that will open on hover as well.

Solution: Update some props. The [triggerOn](https://github.com/helpscout/hsds-react/pull/830) prop exists in the documentation, but it wasn't being passed in, and we needed to remove the hard-coding to accept `triggerOn` instead.

Testing: Please check this out in Storybook using the action where you can switch between click and hover - you can try click as well as hover.

I created a beta release and tested this on the Properties feature branch - it's working there.