### PR TITLE
Move EditableField Tooltip appendTo prop and other small fixes

### DIFF
--- a/scripts/codemod/cli.js
+++ b/scripts/codemod/cli.js
@@ -259,7 +259,7 @@ function run() {
         return null
       }
 
-      if (transformer === 'all') {
+      if (selectedTransformer === 'all') {
         const allTransforms = TRANSFORMER_INQUIRER_CHOICES.map(t => {
           runTransform({
             files: filesExpanded,

--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -381,7 +381,7 @@ const avatarPropTypes = {
   removingAvatarAnimation: PropTypes.bool,
   shape: PropTypes.oneOf(['circle', 'rounded', 'square']),
   showStatusBorderColor: PropTypes.bool,
-  size: PropTypes.oneOf(['xl', 'lg', 'md', 'smmd', 'sm', 'xs', 'xxs']),
+  size: PropTypes.oneOf(Object.keys(config.size)),
   status: PropTypes.string,
   statusIcon: PropTypes.string,
   withShadow: PropTypes.bool,

--- a/src/components/EditableField/EditableField.Input.jsx
+++ b/src/components/EditableField/EditableField.Input.jsx
@@ -88,6 +88,7 @@ export class EditableFieldInput extends React.Component {
   fieldInputContentRef
   optionsDropdownRef
   inputRef
+  inputWrapperRef = React.createRef()
 
   setFieldInputContentNode = node => {
     this.fieldInputContentRef = node
@@ -300,6 +301,7 @@ export class EditableFieldInput extends React.Component {
           display="block"
           placement="top-end"
           title={validationInfo.message}
+          appendTo={this.inputWrapperRef.current}
         >
           <Icon name={validationInfo.icon || DEFAULT_ICON} size={24} />
         </Tooltip>
@@ -339,6 +341,7 @@ export class EditableFieldInput extends React.Component {
           className={INPUT_CLASSNAMES.inputWrapper}
           placeholder={placeholder}
           value={fieldValue.value}
+          ref={this.inputWrapperRef}
         >
           <InputUI
             {...getValidProps(rest)}

--- a/src/components/Popover/Popover.jsx
+++ b/src/components/Popover/Popover.jsx
@@ -89,12 +89,12 @@ export const Popover = props => {
   )
 }
 
-Popover.defaultProps = Object.assign(Tooltip.defaultProps, {
+Popover.defaultProps = Object.assign({}, Tooltip.defaultProps, {
   innerRef: noop,
   triggerOn: 'click',
 })
 
-Popover.propTypes = Object.assign(Tooltip.propTypes, {
+Popover.propTypes = Object.assign({}, Tooltip.propTypes, {
   className: PropTypes.string,
   content: PropTypes.any,
   children: PropTypes.any,

--- a/src/components/Skeleton/Skeleton.Avatar.jsx
+++ b/src/components/Skeleton/Skeleton.Avatar.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { classNames } from '../../utilities/classNames'
 import { AvatarUI } from './Skeleton.Avatar.css'
+import { config as avatarConfig } from '../Avatar/Avatar.css'
 
 class SkeletonAvatar extends React.PureComponent {
   static displayName = 'Skeleton.Avatar'
@@ -31,7 +32,7 @@ SkeletonAvatar.propTypes = {
   /** Shape of the avatar. */
   shape: PropTypes.oneOf(['circle', 'rounded', 'square']),
   /** Size of the avatar. */
-  size: PropTypes.oneOf(['xl', 'lg', 'md', 'sm']),
+  size: PropTypes.oneOf(Object.keys(avatarConfig.size)),
   /** Enables animations for the component. */
   withAnimations: PropTypes.bool,
 }

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -51,7 +51,7 @@ const Tooltip = props => {
     closeOnContentClick,
     closeOnEscPress,
     display,
-    'data-cy': dataCy = 'Tooltip',
+    'data-cy': dataCy,
     innerRef,
     isOpen,
     minWidth,
@@ -64,6 +64,7 @@ const Tooltip = props => {
     zIndex: zIndexProp,
     ...rest
   } = props
+
   const { getCurrentScope } = useContext(GlobalContext) || {}
   const { zIndex = zIndexProp, animationDuration: animationDurationContext } =
     useContext(TooltipContext) || {}
@@ -172,6 +173,7 @@ Tooltip.defaultProps = {
   animationDuration: 200,
   arrowSize: 12,
   closeOnEscPress: true,
+  'data-cy': 'Tooltip',
   display: null,
   isOpen: false,
   placement: 'top',


### PR DESCRIPTION
## EditableField -> Tooltip `appendTo` prop

This update change the `appendTo` element of the EditableField to use the input wrapper element.

Long story short, when migrating to Tippy we change the Tooltip to be [interactive](https://atomiks.github.io/tippyjs/v6/all-props/#interactive) by default. Tippy will use the parent as an anchor point when that's the case. Usually it is fine but in the case of the EditableField, the appendTo element is set with `position:absolute` which mean the tooltip will reference the size of the element. By moving the `appendTo` element outside the trigger we are not impacted by it anymore.

That's a quick fix for the EditableField component, but if we see that it's causing too much issue (like with z-index and other stuff) we might entirely remove the interactive setup, unless a dev activate it manually via a prop.

https://github.com/helpscout/hsds-react/blob/d64709b037c30c5dce5a0ac741979778cda89f84/src/components/EditableField/EditableField.Input.jsx#L293-L309

## Tooltip default
An earlier change in #830 cause a side effect on the Tooltip default value. Because we used `Object.assign` on `Tooltip.defaultProps` itself, the Popover default value were overwriting the tooltip one by reference.

Creating a entirely new object fix that 

https://github.com/helpscout/hsds-react/blob/d64709b037c30c5dce5a0ac741979778cda89f84/src/components/Popover/Popover.jsx#L92-L95

## PropTypes Avatar fixes
We squeeze some change on the Avatar propTypes declaration in this PR. We leverage the config sizes to generate the allowed value in both Avatar and Skeleton.Avatar

https://github.com/helpscout/hsds-react/blob/d64709b037c30c5dce5a0ac741979778cda89f84/src/components/Skeleton/Skeleton.Avatar.jsx#L35

## CLI codemode fix
It wasn't possible to run all codemods directly from the command (instead of selecting which codemod to run from the prompt). 

We update the script to use the arguments or the selected transformers when validating if it should be all codemods or a single one that needs to be executed

https://github.com/helpscout/hsds-react/blob/d64709b037c30c5dce5a0ac741979778cda89f84/scripts/codemod/cli.js#L255-L283

