### PR TITLE
Fix typing indicator styling issue

### DIFF
--- a/src/components/Message/Message.Bubble.css.js
+++ b/src/components/Message/Message.Bubble.css.js
@@ -108,7 +108,7 @@ export const MessageBubbleUI = styled('div')`
     }
   }
 
-  &.is-note {
+  &.is-note:not(.is-typing) {
     background-color: ${getColor('yellow.200')};
     color: ${getColor('yellow.900')};
 


### PR DESCRIPTION
Fix a styling issue with the HSDS Chat Message typing indicator. 

### Before
<img width="113" alt="Screen Shot 2020-05-29 at 10 10 16" src="https://user-images.githubusercontent.com/7111256/83275352-a5603980-a194-11ea-96e1-0c9f32d58439.png">

### After 
<img width="117" alt="Screen Shot 2020-05-29 at 10 08 44" src="https://user-images.githubusercontent.com/7111256/83275362-a85b2a00-a194-11ea-840c-6d6d0ea88dd9.png">
