### PR TITLE
Adds Babel plugin to make HSDS imports nicer to write while tree-shakeable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5253,6 +5253,16 @@
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
       "dev": true
     },
+    "@types/babel-plugin-tester": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-plugin-tester/-/babel-plugin-tester-9.0.0.tgz",
+      "integrity": "sha512-+YTsSQgllJTOrvWT+DR34GQbLs/oKMODZV2WbypdoZTrZlr/+jkv4HK+E69ljoThECXErzQeItCNE/tZDOoZRA==",
+      "dev": true,
+      "requires": {
+        "@types/babel__core": "*",
+        "@types/prettier": "*"
+      }
+    },
     "@types/babel-types": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
@@ -5456,6 +5466,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "@types/prettier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.1.tgz",
+      "integrity": "sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==",
       "dev": true
     },
     "@types/prop-types": {
@@ -7102,6 +7118,26 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
+    },
+    "babel-plugin-tester": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-tester/-/babel-plugin-tester-9.2.0.tgz",
+      "integrity": "sha512-HCbgmxOJXCcJ8hMk4ek6Ehfv0Ye7D7EpglNP8bh2gmRZnLPkKSJF+ufvypur/F38N3bEWWHYX4QfdnfLyql2DQ==",
+      "dev": true,
+      "requires": {
+        "@types/babel-plugin-tester": "^9.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "prettier": "^2.0.1",
+        "strip-indent": "^3.0.0"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+          "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+          "dev": true
+        }
+      }
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
@@ -18253,6 +18289,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "lodash.once": {

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-inline-svg": "1.0.1",
     "babel-plugin-styled-components": "^1.10.6",
+    "babel-plugin-tester": "^9.2.0",
     "confusing-browser-globals": "^1.0.7",
     "coveralls": "3.0.9",
     "cpx": "^1.5.0",

--- a/src/utilities/babel-plugin-hsds-imports/__snapshots__/plugin.test.js.snap
+++ b/src/utilities/babel-plugin-hsds-imports/__snapshots__/plugin.test.js.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[
+  `hsds-component-import Should change destructured hsds imports to default style imports (1 item): Should change destructured hsds imports to default style imports (1 item) 1`
+] = `
+
+import { Tooltip } from '@helpscout/hsds-react/components/'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import Tooltip from '@helpscout/hsds-react/components/Tooltip'
+
+
+`
+
+exports[
+  `hsds-component-import Should change destructured hsds imports to default style imports (2+ items): Should change destructured hsds imports to default style imports (2+ items) 1`
+] = `
+
+import { Tooltip, Select } from '@helpscout/hsds-react/components/'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import Select from '@helpscout/hsds-react/components/Select'
+import Tooltip from '@helpscout/hsds-react/components/Tooltip'
+
+
+`
+
+exports[
+  `hsds-component-import Should make sure that "components" is in the transformed path in default imports: Should make sure that "components" is in the transformed path in default imports 1`
+] = `
+
+import Button from '@helpscout/hsds-react'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import Button from '@helpscout/hsds-react/components/Button'
+
+
+`
+
+exports[
+  `hsds-component-import Should make sure that "components" is in the transformed path in destructured imports: Should make sure that "components" is in the transformed path in destructured imports 1`
+] = `
+
+import { Tooltip, Select } from '@helpscout/hsds-react'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import Select from '@helpscout/hsds-react/components/Select'
+import Tooltip from '@helpscout/hsds-react/components/Tooltip'
+
+
+`
+
+exports[
+  `hsds-component-import Should not change HSDS utilities: Should not change HSDS utilities 1`
+] = `
+
+import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
+
+
+`
+
+exports[
+  `hsds-component-import Should not change default imports: Should not change default imports 1`
+] = `
+
+import Page from '@helpscout/hsds-react/components/Page'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import Page from '@helpscout/hsds-react/components/Page'
+
+
+`
+
+exports[
+  `hsds-component-import Should not change imports that are not hsds or in the options: Should not change imports that are not hsds or in the options 1`
+] = `
+
+import React from 'react'
+import _ from 'lodash'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import React from 'react'
+import _ from 'lodash'
+
+
+`
+
+exports[
+  `hsds-component-import Should work with mixed stuff: Should work with mixed stuff 1`
+] = `
+
+import Button from '@helpscout/hsds-react'
+import Page from '@helpscout/hsds-react/components/Page'
+import { Hello } from '@helpscout/hsds-react'
+import { Tooltip, Select } from '@helpscout/hsds-react/components/'
+import React from 'react'
+import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import Select from '@helpscout/hsds-react/components/Select'
+import Tooltip from '@helpscout/hsds-react/components/Tooltip'
+import Hello from '@helpscout/hsds-react/components/Hello'
+import Page from '@helpscout/hsds-react/components/Page'
+import Button from '@helpscout/hsds-react/components/Button'
+import React from 'react'
+import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
+
+
+`
+
+exports[
+  `hsds-component-import Should work with options (2+): Should work with options (2+) 1`
+] = `
+
+import Button from 'hsds-react-next'
+import Page from 'hsds-react-next/components/Page'
+import { Hello } from 'hsds-react-next'
+import { Tooltip, Select } from '@helpscout/hsds-react/components/'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import Select from '@helpscout/hsds-react/components/Select'
+import Tooltip from '@helpscout/hsds-react/components/Tooltip'
+import Hello from 'hsds-react-next/components/Hello'
+import Page from 'hsds-react-next/components/Page'
+import Button from 'hsds-react-next/components/Button'
+
+
+`
+
+exports[
+  `hsds-component-import Should work with options: Should work with options 1`
+] = `
+
+import Button from 'hsds-react-next'
+import Page from 'hsds-react-next/components/Page'
+import { Hello } from 'hsds-react-next'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import Hello from 'hsds-react-next/components/Hello'
+import Page from 'hsds-react-next/components/Page'
+import Button from 'hsds-react-next/components/Button'
+
+
+`

--- a/src/utilities/babel-plugin-hsds-imports/__snapshots__/plugin.test.js.snap
+++ b/src/utilities/babel-plugin-hsds-imports/__snapshots__/plugin.test.js.snap
@@ -1,8 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[
-  `hsds-component-import Should change destructured hsds imports to default style imports (1 item): Should change destructured hsds imports to default style imports (1 item) 1`
-] = `
+exports[`hsds-component-import Should change destructured hsds imports to default style imports (1 item): Should change destructured hsds imports to default style imports (1 item) 1`] = `
 
 import { Tooltip } from '@helpscout/hsds-react/components/'
 
@@ -11,11 +9,9 @@ import { Tooltip } from '@helpscout/hsds-react/components/'
 import Tooltip from '@helpscout/hsds-react/components/Tooltip'
 
 
-`
+`;
 
-exports[
-  `hsds-component-import Should change destructured hsds imports to default style imports (2+ items): Should change destructured hsds imports to default style imports (2+ items) 1`
-] = `
+exports[`hsds-component-import Should change destructured hsds imports to default style imports (2+ items): Should change destructured hsds imports to default style imports (2+ items) 1`] = `
 
 import { Tooltip, Select } from '@helpscout/hsds-react/components/'
 
@@ -25,11 +21,9 @@ import Select from '@helpscout/hsds-react/components/Select'
 import Tooltip from '@helpscout/hsds-react/components/Tooltip'
 
 
-`
+`;
 
-exports[
-  `hsds-component-import Should make sure that "components" is in the transformed path in default imports: Should make sure that "components" is in the transformed path in default imports 1`
-] = `
+exports[`hsds-component-import Should make sure that "components" is in the transformed path in default imports: Should make sure that "components" is in the transformed path in default imports 1`] = `
 
 import Button from '@helpscout/hsds-react'
 
@@ -38,11 +32,9 @@ import Button from '@helpscout/hsds-react'
 import Button from '@helpscout/hsds-react/components/Button'
 
 
-`
+`;
 
-exports[
-  `hsds-component-import Should make sure that "components" is in the transformed path in destructured imports: Should make sure that "components" is in the transformed path in destructured imports 1`
-] = `
+exports[`hsds-component-import Should make sure that "components" is in the transformed path in destructured imports: Should make sure that "components" is in the transformed path in destructured imports 1`] = `
 
 import { Tooltip, Select } from '@helpscout/hsds-react'
 
@@ -52,11 +44,20 @@ import Select from '@helpscout/hsds-react/components/Select'
 import Tooltip from '@helpscout/hsds-react/components/Tooltip'
 
 
-`
+`;
 
-exports[
-  `hsds-component-import Should not change HSDS utilities: Should not change HSDS utilities 1`
-] = `
+exports[`hsds-component-import Should not change HSDS adapters: Should not change HSDS adapters 1`] = `
+
+import '@helpscout/hsds-react/adapters/app'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import '@helpscout/hsds-react/adapters/app'
+
+
+`;
+
+exports[`hsds-component-import Should not change HSDS utilities: Should not change HSDS utilities 1`] = `
 
 import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
 
@@ -65,11 +66,9 @@ import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
 import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
 
 
-`
+`;
 
-exports[
-  `hsds-component-import Should not change default imports: Should not change default imports 1`
-] = `
+exports[`hsds-component-import Should not change default imports: Should not change default imports 1`] = `
 
 import Page from '@helpscout/hsds-react/components/Page'
 
@@ -78,11 +77,9 @@ import Page from '@helpscout/hsds-react/components/Page'
 import Page from '@helpscout/hsds-react/components/Page'
 
 
-`
+`;
 
-exports[
-  `hsds-component-import Should not change imports that are not hsds or in the options: Should not change imports that are not hsds or in the options 1`
-] = `
+exports[`hsds-component-import Should not change imports that are not hsds or in the options: Should not change imports that are not hsds or in the options 1`] = `
 
 import React from 'react'
 import _ from 'lodash'
@@ -93,11 +90,9 @@ import React from 'react'
 import _ from 'lodash'
 
 
-`
+`;
 
-exports[
-  `hsds-component-import Should work with mixed stuff: Should work with mixed stuff 1`
-] = `
+exports[`hsds-component-import Should work with mixed stuff: Should work with mixed stuff 1`] = `
 
 import Button from '@helpscout/hsds-react'
 import Page from '@helpscout/hsds-react/components/Page'
@@ -117,11 +112,9 @@ import React from 'react'
 import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
 
 
-`
+`;
 
-exports[
-  `hsds-component-import Should work with options (2+): Should work with options (2+) 1`
-] = `
+exports[`hsds-component-import Should work with options (2+): Should work with options (2+) 1`] = `
 
 import Button from 'hsds-react-next'
 import Page from 'hsds-react-next/components/Page'
@@ -137,11 +130,9 @@ import Page from 'hsds-react-next/components/Page'
 import Button from 'hsds-react-next/components/Button'
 
 
-`
+`;
 
-exports[
-  `hsds-component-import Should work with options: Should work with options 1`
-] = `
+exports[`hsds-component-import Should work with options (single): Should work with options (single) 1`] = `
 
 import Button from 'hsds-react-next'
 import Page from 'hsds-react-next/components/Page'
@@ -154,4 +145,19 @@ import Page from 'hsds-react-next/components/Page'
 import Button from 'hsds-react-next/components/Button'
 
 
-`
+`;
+
+exports[`hsds-component-import Should work with options: Should work with options 1`] = `
+
+import Button from 'hsds-react-next'
+import Page from 'hsds-react-next/components/Page'
+import { Hello } from 'hsds-react-next'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import Hello from 'hsds-react-next/components/Hello'
+import Page from 'hsds-react-next/components/Page'
+import Button from 'hsds-react-next/components/Button'
+
+
+`;

--- a/src/utilities/babel-plugin-hsds-imports/index.js
+++ b/src/utilities/babel-plugin-hsds-imports/index.js
@@ -1,0 +1,62 @@
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+})
+exports.default = _default
+
+function _default(babel) {
+  const { types: t } = babel
+  return {
+    name: 'hsds-component-import',
+    visitor: {
+      ImportDeclaration(path, state) {
+        const packages = state.opts.packages || ['@helpscout/hsds-react']
+        let packageName = path.node.source.value
+
+        if (shouldBail(packageName, packages)) return null
+
+        if (packageName.endsWith('/')) {
+          packageName = packageName.slice(0, packageName.length - 1)
+        }
+
+        if (!packageName.includes('components')) {
+          packageName += '/components'
+        }
+
+        const program = path.findParent(t.isProgram)
+
+        path.node.specifiers.forEach(specifier => {
+          const identifier = specifier.local
+          const identifierName = identifier.name
+          const defaultImportSpecifier = t.importDefaultSpecifier(identifier)
+          let pkgPath = `${packageName}`
+
+          if (!packageName.includes(identifierName)) {
+            pkgPath += `/${identifierName}`
+          }
+
+          const newImportDeclaration = t.importDeclaration(
+            [defaultImportSpecifier],
+            t.stringLiteral(pkgPath)
+          )
+          program.node.body.unshift(newImportDeclaration)
+        })
+
+        path.remove()
+      },
+    },
+  }
+}
+
+function shouldBail(packageName, packages) {
+  if (!packageName) return true
+  if (packageName.includes('utilities')) return true
+  let found = false
+
+  for (let i = 0; i < packages.length; i++) {
+    if (packageName.includes(packages[i])) {
+      found = true
+    }
+  }
+
+  return !found
+}

--- a/src/utilities/babel-plugin-hsds-imports/index.js
+++ b/src/utilities/babel-plugin-hsds-imports/index.js
@@ -9,7 +9,9 @@ function _default(babel) {
     name: 'hsds-component-import',
     visitor: {
       ImportDeclaration(path, state) {
-        const packages = state.opts.packages || ['@helpscout/hsds-react']
+        const packages = state.opts.packages
+          ? [].concat(state.opts.packages)
+          : ['@helpscout/hsds-react']
         let packageName = path.node.source.value
 
         if (shouldBail(packageName, packages)) return null
@@ -50,6 +52,7 @@ function _default(babel) {
 function shouldBail(packageName, packages) {
   if (!packageName) return true
   if (packageName.includes('utilities')) return true
+  if (packageName.includes('adapters')) return true
   let found = false
 
   for (let i = 0; i < packages.length; i++) {

--- a/src/utilities/babel-plugin-hsds-imports/plugin.test.js
+++ b/src/utilities/babel-plugin-hsds-imports/plugin.test.js
@@ -1,0 +1,90 @@
+import pluginTester from 'babel-plugin-tester'
+import hsdsImports from './'
+
+pluginTester({
+  plugin: hsdsImports,
+  snapshot: true,
+  tests: [
+    {
+      title: 'Should not change imports that are not hsds or in the options',
+      code: `
+      import React from 'react'
+      import _ from 'lodash'
+      `,
+    },
+    {
+      title: 'Should not change default imports',
+      code: `
+      import Page from '@helpscout/hsds-react/components/Page'
+      `,
+    },
+    {
+      title:
+        'Should change destructured hsds imports to default style imports (1 item)',
+      code: `
+      import { Tooltip } from '@helpscout/hsds-react/components/'
+      `,
+    },
+    {
+      title:
+        'Should change destructured hsds imports to default style imports (2+ items)',
+      code: `
+      import { Tooltip, Select } from '@helpscout/hsds-react/components/'
+      `,
+    },
+    {
+      title:
+        'Should make sure that "components" is in the transformed path in destructured imports',
+      code: `
+      import { Tooltip, Select } from '@helpscout/hsds-react'
+      `,
+    },
+    {
+      title:
+        'Should make sure that "components" is in the transformed path in default imports',
+      code: `
+      import Button from '@helpscout/hsds-react'
+      `,
+    },
+    {
+      title: 'Should not change HSDS utilities',
+      code: `
+      import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
+      `,
+    },
+    {
+      title: 'Should work with mixed stuff',
+      code: `
+      import Button from '@helpscout/hsds-react'
+      import Page from '@helpscout/hsds-react/components/Page'
+      import { Hello } from '@helpscout/hsds-react'
+      import { Tooltip, Select } from '@helpscout/hsds-react/components/'
+      import React from 'react'
+      import { getColor } from '@helpscout/hsds-react/styles/utilities/color'
+      `,
+    },
+    {
+      title: 'Should work with options',
+      pluginOptions: {
+        packages: ['hsds-react-next'],
+      },
+      code: `
+      import Button from 'hsds-react-next'
+      import Page from 'hsds-react-next/components/Page'
+      import { Hello } from 'hsds-react-next'
+      `,
+    },
+    {
+      title: 'Should work with options (2+)',
+      pluginOptions: {
+        packages: ['hsds-react-next', '@helpscout/hsds-react'],
+      },
+      code: `
+      import Button from 'hsds-react-next'
+      import Page from 'hsds-react-next/components/Page'
+      import { Hello } from 'hsds-react-next'
+      import { Tooltip, Select } from '@helpscout/hsds-react/components/'
+      `,
+    },
+  ],
+})

--- a/src/utilities/babel-plugin-hsds-imports/plugin.test.js
+++ b/src/utilities/babel-plugin-hsds-imports/plugin.test.js
@@ -53,6 +53,12 @@ pluginTester({
       `,
     },
     {
+      title: 'Should not change HSDS adapters',
+      code: `
+      import '@helpscout/hsds-react/adapters/app'
+      `,
+    },
+    {
       title: 'Should work with mixed stuff',
       code: `
       import Button from '@helpscout/hsds-react'
@@ -67,6 +73,17 @@ pluginTester({
       title: 'Should work with options',
       pluginOptions: {
         packages: ['hsds-react-next'],
+      },
+      code: `
+      import Button from 'hsds-react-next'
+      import Page from 'hsds-react-next/components/Page'
+      import { Hello } from 'hsds-react-next'
+      `,
+    },
+    {
+      title: 'Should work with options (single)',
+      pluginOptions: {
+        packages: 'hsds-react-next',
       },
       code: `
       import Button from 'hsds-react-next'


### PR DESCRIPTION
What do we _don't_ want?

```js
import Page from 'hsds-react-next/components/Page'
import Button from 'hsds-react-next/components/Button'
import Select from 'hsds-react-next/components/Select'
```

What do we want?

```js
import { Page, Button, Select } from 'hsds-react-next'
```

Currently applications need to import components using the first mode above to allow tree-shaking, otherwise we can use `import { Page, Button, Select } from 'hsds-react-next/components/'` (notice the "/components" requirement) but it won't be tree-shakeable.

This PR adds a babel plugin that takes care of it for you!

So feel free to write the nice and concise form of importing, and get all the benefits. Who said you can't have your cake and eat it too?

Have a look at the test cases, in a nutshell:
- Allows you to use destructuring
- Allows you to remove "components" from the import path
- Accepts one option `packages` to instruct which hsds package you want this to have an effect on, say both of "helspcout-hsds-react-next" and "@helpscout/hsds-react" or just one

Besides unit testing included here, I made some tests with a brand new app, check the results for yourselves:

Destructuring without the plugin:

<img width="446" alt="Screen Shot 2020-06-04 at 2 40 15 PM" src="https://user-images.githubusercontent.com/1414086/83772386-9d683400-a683-11ea-8726-79ab63a448c6.png">

With plugin:

<img width="532" alt="Screen Shot 2020-06-04 at 2 40 47 PM" src="https://user-images.githubusercontent.com/1414086/83772455-b07b0400-a683-11ea-8cd2-69451f263be7.png">

To use, add it to your babel conf file:

```
{
  "plugins": [
    [
      "@helpscout/hsds-react/src/utilities/babel-plugin-hsds-imports/",
      { "packages": ["helpscout-hsds-react-next"] }
    ]
  ]
}

```