### PR TITLE
Force FilteredList & Truncate to append tooltip on the body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.0.7",
+  "version": "3.0.8-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.0.7",
+  "version": "3.0.8-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/FilteredList/FilteredList.jsx
+++ b/src/components/FilteredList/FilteredList.jsx
@@ -23,17 +23,22 @@ export class FilteredList extends React.Component {
     limit: PropTypes.number,
     inline: PropTypes.bool,
     renderItem: PropTypes.func,
+    tooltipAppendTo: PropTypes.object,
   }
 
   static defaultProps = {
     items: [],
     limit: 5,
+    tooltipAppendTo: 'parent',
   }
 
   shouldComponentUpdate(nextProps) {
-    const { items } = this.props
+    const { items, tooltipAppendTo } = this.props
 
     if (nextProps.items.length !== items.length) {
+      return true
+    }
+    if (tooltipAppendTo !== nextProps.tooltipAppendTo) {
       return true
     }
 
@@ -77,9 +82,11 @@ export class FilteredList extends React.Component {
 
   renderBadge() {
     const { limit, items } = this.props
-
     return (
-      <Tooltip renderContent={this.renderBadgeContent}>
+      <Tooltip
+        closeOnContentClick={true}
+        renderContent={this.renderBadgeContent}
+      >
         <BadgeUI isSquare data-cy="FilteredList.Badge">
           +{items.length - limit}
         </BadgeUI>

--- a/src/components/FilteredList/FilteredList.jsx
+++ b/src/components/FilteredList/FilteredList.jsx
@@ -23,22 +23,17 @@ export class FilteredList extends React.Component {
     limit: PropTypes.number,
     inline: PropTypes.bool,
     renderItem: PropTypes.func,
-    tooltipAppendTo: PropTypes.object,
   }
 
   static defaultProps = {
     items: [],
     limit: 5,
-    tooltipAppendTo: 'parent',
   }
 
   shouldComponentUpdate(nextProps) {
-    const { items, tooltipAppendTo } = this.props
+    const { items } = this.props
 
     if (nextProps.items.length !== items.length) {
-      return true
-    }
-    if (tooltipAppendTo !== nextProps.tooltipAppendTo) {
       return true
     }
 

--- a/src/components/FilteredList/FilteredList.stories.js
+++ b/src/components/FilteredList/FilteredList.stories.js
@@ -23,9 +23,7 @@ Default.story = {
 }
 
 export const WithLimit = () => (
-  <div>
-    <FilteredList items={items} limit={number('limit', 2)} />
-  </div>
+  <FilteredList items={items} limit={number('limit', 2)} />
 )
 
 WithLimit.story = {

--- a/src/components/FilteredList/FilteredList.stories.js
+++ b/src/components/FilteredList/FilteredList.stories.js
@@ -13,6 +13,7 @@ const items = [
   'test@cde.com',
   'anothertest@cde.com',
   'lasttest@cde.com',
+  'unbelievablylongemailaddress2374829e28732@test.com',
 ]
 
 export const Default = () => <FilteredList items={items} />
@@ -22,7 +23,9 @@ Default.story = {
 }
 
 export const WithLimit = () => (
-  <FilteredList items={items} limit={number('limit', 2)} />
+  <div>
+    <FilteredList items={items} limit={number('limit', 2)} />
+  </div>
 )
 
 WithLimit.story = {

--- a/src/components/Tooltip/Tooltip.css.js
+++ b/src/components/Tooltip/Tooltip.css.js
@@ -44,11 +44,14 @@ export const TooltipUI = styled.div`
   font-size: 12px;
   max-width: 300px;
   padding: 6px 8px;
-  word-break: break-word;
   transition-property: transform, visibility, opacity;
   transition-duration: ${({ animationDuration }) => animationDuration}ms;
   transition-timing-function: ease-in-out;
   opacity: 0;
+  word-break: break-all;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 
   ${({ maxWidth }) => (maxWidth ? `max-width: ${maxWidth}px` : '')};
   ${({ minWidth }) => (minWidth ? `min-width: ${minWidth}px` : '')};

--- a/src/components/Truncate/Truncate.jsx
+++ b/src/components/Truncate/Truncate.jsx
@@ -14,7 +14,7 @@ export class Truncate extends React.PureComponent {
     limit: 0,
     showTooltipOnTruncate: false,
     tooltipModifiers: {},
-    tooltipPlacement: 'top-start',
+    tooltipPlacement: 'top',
     tooltipProps: {},
     type: 'auto',
   }
@@ -154,8 +154,8 @@ export class Truncate extends React.PureComponent {
     )
     const content = shouldShowTooltip ? (
       <Tooltip
+        closeOnContentClick={true}
         {...tooltipProps}
-        display="block"
         placement={tooltipPlacement}
         title={title || this.getText()}
       >

--- a/src/components/Truncate/Truncate.jsx
+++ b/src/components/Truncate/Truncate.jsx
@@ -14,7 +14,7 @@ export class Truncate extends React.PureComponent {
     limit: 0,
     showTooltipOnTruncate: false,
     tooltipModifiers: {},
-    tooltipPlacement: 'top',
+    tooltipPlacement: 'top-start',
     tooltipProps: {},
     type: 'auto',
   }

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.0.7',
+  version: '3.0.8-0',
 }


### PR DESCRIPTION
We found some issues on Truncate and FilteredList when inside the customer list table. Those fix will make sure the tooltip is append to the body instead of the parent.

That will stop the tooltip from being selectable, but it's something we can live with it right now, especially since the original tooltip in v2 was not selectable.

This update also contain a fix for the wrapping content of the tooltip on IE Edge.