### PR TITLE
Fix cypress

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     jest: true,
     node: true,
   },
+  globals: ['cy', 'Cypress', 'expect', 'assert'],
   plugins: ['babel', 'jsx-a11y', 'react', 'import'],
   extends: [
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.

--- a/cypress/integration/Button.js
+++ b/cypress/integration/Button.js
@@ -1,6 +1,6 @@
 describe('Button', function() {
   it('Can click a Button', function() {
-    cy.visitStory('Button', 'everything')
+    cy.visitStory('components-buttons-button--default')
 
     cy.get('[data-cy="Button"]:first').click()
   })

--- a/cypress/integration/Dropdown.js
+++ b/cypress/integration/Dropdown.js
@@ -1,0 +1,10 @@
+beforeEach(() => {
+  cy.visitStory('components-dropdowns-dropdown--dropdown-default')
+})
+
+describe('Dropdown', () => {
+  it('Should open a Dropdown', () => {
+    cy.get('[data-cy="DropdownTrigger"]').click()
+    cy.get('.DropdownMenuContainerPlacementRoot').should('exist')
+  })
+})

--- a/cypress/integration/Modal.js
+++ b/cypress/integration/Modal.js
@@ -1,0 +1,10 @@
+beforeEach(() => {
+  cy.visitStory('components-overlay-modal--v-2-default')
+})
+
+describe('Modal', () => {
+  it('Should open a modal', () => {
+    cy.get('button:first').click()
+    cy.get('[data-cy="Modal"]').should('exist')
+  })
+})

--- a/cypress/integration/Pagination.js
+++ b/cypress/integration/Pagination.js
@@ -1,5 +1,5 @@
 beforeEach(() => {
-  cy.visitStory('Pagination', 'in action')
+  cy.visitStory('components-wayfinding-pagination--in-action')
 })
 
 describe('Pagination / range', () => {
@@ -24,10 +24,10 @@ describe('Pagination / navigation', () => {
     cy.get('[data-cy="Pagination-firstButton"]').should('exist')
   })
 
-  it('Last/Next should be disabled on last page', () => {
+  it('Last/Next should not exists on last page', () => {
     cy.get('[data-cy="Pagination-lastButton"]:first').click()
-    cy.get('[data-cy="Pagination-lastButton"]').should('be.disabled')
-    cy.get('[data-cy="Pagination-nextButton"]').should('be.disabled')
+    cy.get('[data-cy="Pagination-lastButton"]').should('not.exist')
+    cy.get('[data-cy="Pagination-nextButton"]').should('not.exist')
   })
 
   it('Can increase current page', () => {
@@ -38,9 +38,10 @@ describe('Pagination / navigation', () => {
       const nextValue = originalValue + 50
 
       cy.get('[data-cy="Pagination-nextButton"]:first').click()
-      cy
-        .get('[data-cy="Pagination-startRange"]')
-        .should('be', nextValue.toString())
+      cy.get('[data-cy="Pagination-startRange"]').should(
+        'be',
+        nextValue.toString()
+      )
     })
   })
 
@@ -54,9 +55,10 @@ describe('Pagination / navigation', () => {
       const nextValue = originalValue - 50
 
       cy.get('[data-cy="Pagination-prevButton"]:first').click()
-      cy
-        .get('[data-cy="Pagination-startRange"]')
-        .should('be', nextValue.toString())
+      cy.get('[data-cy="Pagination-startRange"]').should(
+        'be',
+        nextValue.toString()
+      )
     })
   })
 })
@@ -70,9 +72,10 @@ describe('Pagination / keyboard', () => {
       originalValue = parseInt(originalValue, 10)
       const nextValue = originalValue + 50
 
-      cy
-        .get('[data-cy="Pagination-startRange"]')
-        .should('be', nextValue.toString())
+      cy.get('[data-cy="Pagination-startRange"]').should(
+        'be',
+        nextValue.toString()
+      )
     })
   })
 
@@ -86,9 +89,10 @@ describe('Pagination / keyboard', () => {
 
       cy.get('body').trigger('keydown', { keyCode: 74, which: 74 })
 
-      cy
-        .get('[data-cy="Pagination-startRange"]')
-        .should('be', nextValue.toString())
+      cy.get('[data-cy="Pagination-startRange"]').should(
+        'be',
+        nextValue.toString()
+      )
     })
   })
 })

--- a/cypress/integration/Tooltip.js
+++ b/cypress/integration/Tooltip.js
@@ -1,0 +1,11 @@
+beforeEach(() => {
+  cy.visitStory('components-overlay-tooltipv2--default')
+})
+
+describe('Tooltip', () => {
+  it('Should open a tooltip', () => {
+    cy.get('body').click() // make sure to hide any visible tooltip
+    cy.get('[data-cy="Tooltip"]').click()
+    cy.get('[data-tippy-root]').should('exist')
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -4,17 +4,16 @@
 // https://on.cypress.io/custom-commands
 // ***********************************************
 
-Cypress.Commands.add('visitStory', (kind = '', name = '') => {
-  const url = getStoryBookUrl(kind, name)
+Cypress.Commands.add('visitStory', (id = '') => {
+  const url = getStoryBookUrl(id)
 
   return cy.visit(url)
 })
 
 /**
  * Generates the iFrame URL for a given component/story.
- * @param {string} kind The Component
- * @param {string} name The name of the Story
+ * @param {string} id the url id attribute of a story
  */
-function getStoryBookUrl(kind = 'ArticleCard', name = 'Content') {
-  return `iframe.html?selectedKind=${kind}&selectedStory=${name}`
+function getStoryBookUrl(id = '') {
+  return `iframe.html?id=${id}`
 }

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "../node_modules"
-  },
-  "include": ["../node_modules/cypress/types", "**/*.ts"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1402,6 +1402,34 @@
         }
       }
     },
+    "@cypress/request": {
+      "version": "2.88.5",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.5.tgz",
+      "integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
     "@cypress/xvfb": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
@@ -6789,6 +6817,12 @@
         "@types/react": "*"
       }
     },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "dev": true
+    },
     "@types/sizzle": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
@@ -7864,13 +7898,10 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.10"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "dev": true
     },
     "async-each": {
       "version": "1.0.3",
@@ -9513,13 +9544,10 @@
       }
     },
     "cachedir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-1.3.0.tgz",
-      "integrity": "sha512-O1ji32oyON9laVPJL1IZ5bmwd2cB46VfpxkDequezH+15FDzzVddEyrGEeX4WusDSqKxdyFdDQDEG1yo1GoWkg==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.1"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+      "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+      "dev": true
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -10072,12 +10100,6 @@
       "requires": {
         "restore-cursor": "^3.1.0"
       }
-    },
-    "cli-spinners": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
-      "dev": true
     },
     "cli-table3": {
       "version": "0.5.1",
@@ -11249,52 +11271,50 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.3.tgz",
-      "integrity": "sha512-I9L/d+ilTPPA4vq3NC1OPKmw7jJIpMKNdyfR8t1EXYzYCjyqbc59migOm1YSse/VRbISLJ+QGb5k4Y3bz2lkYw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.8.0.tgz",
+      "integrity": "sha512-Lsff8lF8pq6k/ioNua783tCsxGSLp6gqGXecdIfqCkqjYiOA53XKuEf1CaQJLUVs1dHSf49eDUp/sb620oJjVQ==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
+        "@cypress/request": "2.88.5",
         "@cypress/xvfb": "1.2.4",
+        "@types/sinonjs__fake-timers": "6.0.1",
         "@types/sizzle": "2.3.2",
         "arch": "2.1.1",
-        "bluebird": "3.5.0",
-        "cachedir": "1.3.0",
+        "bluebird": "3.7.2",
+        "cachedir": "2.3.0",
         "chalk": "2.4.2",
         "check-more-types": "2.24.0",
-        "commander": "2.15.1",
+        "cli-table3": "0.5.1",
+        "commander": "4.1.0",
         "common-tags": "1.8.0",
-        "debug": "3.2.6",
+        "debug": "4.1.1",
         "eventemitter2": "4.1.2",
-        "execa": "0.10.0",
+        "execa": "1.0.0",
         "executable": "4.1.1",
-        "extract-zip": "1.6.7",
-        "fs-extra": "5.0.0",
-        "getos": "3.1.1",
-        "is-ci": "1.2.1",
+        "extract-zip": "1.7.0",
+        "fs-extra": "8.1.0",
+        "getos": "3.1.4",
+        "is-ci": "2.0.0",
         "is-installed-globally": "0.1.0",
         "lazy-ass": "1.6.0",
-        "listr": "0.12.0",
+        "listr": "0.14.3",
         "lodash": "4.17.15",
-        "log-symbols": "2.2.0",
-        "minimist": "1.2.0",
+        "log-symbols": "3.0.0",
+        "minimist": "1.2.5",
         "moment": "2.24.0",
-        "ramda": "0.24.1",
-        "request": "2.88.0",
+        "ospath": "1.2.2",
+        "pretty-bytes": "5.3.0",
+        "ramda": "0.26.1",
         "request-progress": "3.0.0",
-        "supports-color": "5.5.0",
+        "supports-color": "7.1.0",
         "tmp": "0.1.0",
-        "untildify": "3.0.3",
+        "untildify": "4.0.0",
         "url": "0.11.0",
         "yauzl": "2.10.0"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -11303,12 +11323,6 @@
           "requires": {
             "color-convert": "^1.9.0"
           }
-        },
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
         },
         "chalk": {
           "version": "2.4.2",
@@ -11319,21 +11333,17 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
-          }
-        },
-        "ci-info": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^1.0.1"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "color-convert": {
@@ -11352,9 +11362,9 @@
           "dev": true
         },
         "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+          "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
           "dev": true
         },
         "cross-spawn": {
@@ -11370,23 +11380,14 @@
             "which": "^1.2.9"
           }
         },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "execa": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
@@ -11394,79 +11395,25 @@
             "strip-eof": "^1.0.0"
           }
         },
-        "extract-zip": {
-          "version": "1.6.7",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-          "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-          "dev": true,
-          "requires": {
-            "concat-stream": "1.6.2",
-            "debug": "2.6.9",
-            "mkdirp": "0.5.1",
-            "yauzl": "2.4.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            },
-            "yauzl": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-              "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-              "dev": true,
-              "requires": {
-                "fd-slicer": "~1.0.1"
-              }
-            }
-          }
-        },
-        "fd-slicer": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-          "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-          "dev": true,
-          "requires": {
-            "pend": "~1.2.0"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
-          }
-        },
         "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
+            "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
         },
         "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "has-flag": {
           "version": "3.0.0",
@@ -11474,205 +11421,14 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "^2.0.0"
-          }
-        },
-        "is-ci": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-          "dev": true,
-          "requires": {
-            "ci-info": "^1.5.0"
-          }
-        },
-        "listr": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
-          "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "cli-truncate": "^0.2.1",
-            "figures": "^1.7.0",
-            "indent-string": "^2.1.0",
-            "is-promise": "^2.1.0",
-            "is-stream": "^1.1.0",
-            "listr-silent-renderer": "^1.1.1",
-            "listr-update-renderer": "^0.2.0",
-            "listr-verbose-renderer": "^0.4.0",
-            "log-symbols": "^1.0.2",
-            "log-update": "^1.0.2",
-            "ora": "^0.2.3",
-            "p-map": "^1.1.1",
-            "rxjs": "^5.0.0-beta.11",
-            "stream-to-observable": "^0.1.0",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "log-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-              "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-              "dev": true,
-              "requires": {
-                "chalk": "^1.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "listr-update-renderer": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
-          "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "cli-truncate": "^0.2.1",
-            "elegant-spinner": "^1.0.1",
-            "figures": "^1.7.0",
-            "indent-string": "^3.0.0",
-            "log-symbols": "^1.0.2",
-            "log-update": "^1.0.2",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "indent-string": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-              "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-              "dev": true
-            },
-            "log-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-              "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-              "dev": true,
-              "requires": {
-                "chalk": "^1.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "listr-verbose-renderer": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
-          "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "cli-cursor": "^1.0.2",
-            "date-fns": "^1.27.2",
-            "figures": "^1.7.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
         "log-symbols": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1"
+            "chalk": "^2.4.2"
           }
-        },
-        "log-update": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
-          "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^1.0.0",
-            "cli-cursor": "^1.0.2"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
@@ -11683,73 +11439,17 @@
             "path-key": "^2.0.0"
           }
         },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "p-map": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-          "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-          "dev": true
-        },
         "path-key": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
         "ramda": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-          "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+          "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
           "dev": true
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
-          }
         },
         "rimraf": {
           "version": "2.7.1",
@@ -11758,15 +11458,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "rxjs": {
-          "version": "5.5.12",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-          "dev": true,
-          "requires": {
-            "symbol-observable": "1.0.1"
           }
         },
         "shebang-command": {
@@ -11785,19 +11476,21 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+              "dev": true
+            }
           }
-        },
-        "symbol-observable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-          "dev": true
         },
         "tmp": {
           "version": "0.1.0",
@@ -11808,20 +11501,10 @@
             "rimraf": "^2.6.3"
           }
         },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
-        },
         "untildify": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-          "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+          "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
           "dev": true
         },
         "which": {
@@ -14854,12 +14537,12 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getos": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.1.tgz",
-      "integrity": "sha512-oUP1rnEhAr97rkitiszGP9EgDVYnmchgFzfqRzSkgtfv7ai6tEi7Ko8GgjNXts7VLWEqrTWyhsOKLe5C5b/Zkg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.4.tgz",
+      "integrity": "sha512-UORPzguEB/7UG5hqiZai8f0vQ7hzynMQyJLxStoQ8dPGAcmgsfXOPA4iE/fGtweHYkK+z4zc9V0g+CIFRf5HYw==",
       "dev": true,
       "requires": {
-        "async": "2.6.1"
+        "async": "^3.1.0"
       }
     },
     "getpass": {
@@ -16502,12 +16185,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-    },
-    "is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -22840,45 +22517,6 @@
         "word-wrap": "~1.2.3"
       }
     },
-    "ora": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
-      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.1",
-        "cli-cursor": "^1.0.2",
-        "cli-spinners": "^0.1.2",
-        "object-assign": "^4.0.1"
-      },
-      "dependencies": {
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^1.0.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
-          }
-        }
-      }
-    },
     "original": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -22923,6 +22561,12 @@
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
       }
+    },
+    "ospath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
+      "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
+      "dev": true
     },
     "ow": {
       "version": "0.15.1",
@@ -24065,6 +23709,12 @@
           }
         }
       }
+    },
+    "pretty-bytes": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+      "dev": true
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -26873,15 +26523,6 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
-    },
     "replace-ext": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
@@ -28296,12 +27937,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "dev": true
-    },
-    "stream-to-observable": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
-      "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
     },
     "strict-uri-encode": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "coveralls": "3.0.9",
     "cpx": "^1.5.0",
     "cross-env": "5.1.0",
-    "cypress": "^3.4.1",
+    "cypress": "^4.5.0",
     "dotenv": "4.0.0",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -100,7 +100,7 @@ export const Default = () => {
     ),
     spinButtonOnLoading: boolean('spinButtonOnLoading', false),
   }
-  return <Button {...props} />
+  return <Button {...props} data-cy="Button" />
 }
 
 Default.story = {

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -457,6 +457,7 @@ class Modal extends React.PureComponent {
         className={componentClassName}
         role="document"
         style={styles}
+        data-cy="Modal"
       >
         <KeypressListener
           keyCode={Keys.TAB}

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -100,8 +100,8 @@ Nested.story = {
 export const V2Default = () => (
   <Modal
     version={2}
-    isOpen={true}
-    trigger={<Link>Clicky</Link>}
+    isOpen={false}
+    trigger={<button>open modal</button>}
     title="Modal Title"
   >
     <Modal.Body version={2}>

--- a/src/components/Portal/Portal.jsx
+++ b/src/components/Portal/Portal.jsx
@@ -68,13 +68,18 @@ export class Portal extends React.Component {
     // 2. Fallback to <Portal.Container />
     mountSelector =
       mountSelector || document.querySelector(`#${portalContainerId}`)
-    // 3. Fallback to document.body
 
-    // 3- is inside an iframe
-    if (!mountSelector && window.parent && !window.STORYBOOK_ENV) {
+    // 3- is inside an iframe, but not the one created by storybook/cypress
+    if (
+      !mountSelector &&
+      window.parent &&
+      !window.STORYBOOK_ENV &&
+      !window.Cypress
+    ) {
       mountSelector = window.parent.document.body
     }
 
+    // 4. Fallback to document.body
     return mountSelector || this.document.body // fallback
   }
 


### PR DESCRIPTION
Since we release HSDS v3, all our (two) cypress tests were broken. This update fix all of them and adds some small tests for Modal, Tooltip and Dropdown.

This update also fix a cypress issue that occured on hs-app related to iframe. We make sure that all components that use Portal (through our custom implementation) will be injected inside the iframe if it's within cypress (just like we did before with storybook).