### PR TITLE
Fix MessageCard render issue

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -11,9 +11,11 @@ export const MessageCardUI = styled(Card)`
   border-color: transparent !important;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  padding: 20px 20px 25px;
+  padding: 20px 0 25px;
   width: 300px;
   word-break: break-word;
+  display: flex;
+  flex-direction: column;
 
   &.is-align-right {
     border-bottom-right-radius: 4px;
@@ -55,12 +57,16 @@ export const TitleUI = styled(Heading)`
   ${fontFamily};
   line-height: 22px !important;
   margin-top: 5px;
+  padding: 0 20px;
+  flex: 0 0 auto;
 `
 
 export const SubtitleUI = styled(Heading)`
   ${setFontSize(12)};
   line-height: 18px !important;
   margin-top: 6px;
+  padding: 0 20px;
+  flex: 0 0 auto;
 `
 
 const editorHtmlFontSize = 14
@@ -70,6 +76,9 @@ export const BodyUI = styled.div`
   color: ${getColor('charcoal.700')};
   font-size: ${editorHtmlFontSize}px;
   line-height: 26px;
+  padding: 0 20px;
+  flex: 1 1 100%;
+  overflow: auto;
 
   p {
     font-size: ${editorHtmlFontSize}px;
@@ -243,6 +252,8 @@ export const BodyUI = styled.div`
 export const ActionUI = styled('div')`
   margin-bottom: -5px;
   margin-top: 20px;
+  padding: 0 20px;
+  flex: 0 0 auto;
 `
 
 export const ActionButtonUI = styled(Button)`

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -88,8 +88,14 @@ export class MessageCard extends React.PureComponent {
   }
 
   renderBody() {
-    const { body, title, subtitle } = this.props
+    const { title, subtitle } = this.props
+    let { body } = this.props
     const withMargin = title || subtitle
+
+    // if there is no html in the string, transform new line to paragraph
+    if (body && !/<\/?[a-z][\s\S]*>/i.test(body)) {
+      body = body.split('\n').join('<br>')
+    }
 
     return body ? (
       <BodyUI withMargin={withMargin} data-cy="beacon-message-body-content">

--- a/src/components/MessageCard/MessageCard.stories.js
+++ b/src/components/MessageCard/MessageCard.stories.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ThemeProvider } from '../styled'
+import styled, { ThemeProvider } from '../styled'
 import { boolean, number, text, select } from '@storybook/addon-knobs'
 import { getColor } from '../../styles/utilities/color'
 import { action } from '@storybook/addon-actions'
@@ -10,6 +10,15 @@ export default {
   component: MessageCard,
   title: 'Components/Conversation/MessageCard',
 }
+
+const LimitUI = styled.div`
+  ${({ height }) => (height ? `height: ${height};` : '')};
+
+  .c-Animate,
+  .c-MessageCard {
+    height: 100%;
+  }
+`
 
 class Story extends React.Component {
   render() {
@@ -54,11 +63,15 @@ class Story extends React.Component {
       title: text('Title', 'Need help?'),
     }
 
+    const limitProps = {
+      height: text('limit screen height', '100vh'),
+    }
+
     return (
       <ThemeProvider theme={theme}>
-        <div>
+        <LimitUI {...limitProps}>
           <MessageCard {...props} />
-        </div>
+        </LimitUI>
       </ThemeProvider>
     )
   }

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -97,7 +97,15 @@ describe('Body', () => {
     const wrapper = mount(<MessageCard body="<span>Santa!</span>" />)
     const o = wrapper.find(BodyUI)
 
-    expect(o.html()).toContain('<span>Santa!</span>')
+    expect(o.render().find('span').length).toBe(1)
+  })
+
+  test('Renders new line without html in body', () => {
+    const body = 'this is a new line\nwith another line'
+    const wrapper = mount(<MessageCard body={body} />)
+    const o = wrapper.find(BodyUI)
+
+    expect(o.render().find('br').length).toBe(1)
   })
 })
 


### PR DESCRIPTION
This update fix an issue with the MessageCard rendering when there is no html, but with some `\n`.

When rendering the body, we will detect it contains any html element, if it's not the case, we will replace all `\n` with a `<br>`

<img width="334" alt="Image 2020-06-12 at 4 27 00 PM" src="https://user-images.githubusercontent.com/203992/84543925-53f29700-acca-11ea-8c13-32a2d9229986.png">

## Height limit
We add a `overflow:auto` to the body if the content is bigger than the available space. We make sure that the title, subtitle, and action will always be visible in full within the `MessageCard` component

![Screen Recording 2020-06-22 at 02 16 PM](https://user-images.githubusercontent.com/203992/85321741-2dcfb280-b493-11ea-875f-b50eeac0586d.gif)
