### PR TITLE
Change CopyInput to use copy-small icon

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -53,7 +53,8 @@ class Button extends React.PureComponent {
 
     return React.Children.map(children, (child, index) => {
       if (child && !child.hasOwnProperty('type')) return child
-      if (child.type !== Icon) return child
+      if (!child || (child && child.type !== Icon)) return child
+
       const len = React.Children.count(children)
       const isFirst = index === 0
       const isLast = index === len - 1

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -52,8 +52,9 @@ class Button extends React.PureComponent {
     const { children } = this.props
 
     return React.Children.map(children, (child, index) => {
-      if (child && !child.hasOwnProperty('type')) return child
-      if (!child || (child && child.type !== Icon)) return child
+      if (!child) return
+      if (!child.hasOwnProperty('type')) return child
+      if (child.type !== Icon) return child
 
       const len = React.Children.count(children)
       const isFirst = index === 0

--- a/src/components/CopyButton/CopyButton.css.js
+++ b/src/components/CopyButton/CopyButton.css.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { getColor } from '../../styles/utilities/color'
 import Button from '../Button'
+import Icon from '../Icon'
 
 export const config = {
   copyConfirmed: {
@@ -10,6 +11,10 @@ export const config = {
 }
 
 export const TextUI = styled.span`
+  display: inline-flex;
+  transition: opacity linear 150ms;
+`
+export const IconUI = styled(Icon)`
   display: inline-flex;
   transition: opacity linear 150ms;
 `
@@ -36,11 +41,27 @@ export const CopyButtonUI = styled(Button)`
 
   &.c-CopyButton {
     min-width: 60px;
+
+    &.is-with-icon {
+      min-width: 40px;
+      max-width: 40px;
+      padding: 0;
+      text-align: center;
+      background: ${getColor('grey.200')};
+      color: ${getColor('charcoal.300')};
+
+      &:hover {
+        background: ${getColor('blue.100')};
+      }
+    }
   }
 
   &.is-copyConfirmed {
     border-color: ${config.copyConfirmed.background} !important;
     ${TextUI} {
+      opacity: 0;
+    }
+    ${IconUI} {
       opacity: 0;
     }
     ${ConfirmationIconWrapperUI} {

--- a/src/components/CopyButton/CopyButton.jsx
+++ b/src/components/CopyButton/CopyButton.jsx
@@ -8,6 +8,7 @@ import {
   CopyButtonUI,
   ConfirmationIconWrapperUI,
   TextUI,
+  IconUI,
 } from './CopyButton.css'
 
 class CopyButton extends React.PureComponent {
@@ -59,11 +60,13 @@ class CopyButton extends React.PureComponent {
   }
 
   render() {
-    const { className, kind, size, ...rest } = this.props
+    const { className, kind, size, icon, label, ...rest } = this.props
     const { shouldRenderConfirmation } = this.state
+
     const componentClassName = classNames(
       'c-CopyButton',
       shouldRenderConfirmation && 'is-copyConfirmed',
+      icon && 'is-with-icon',
       className
     )
     const iconSize = size === 'sm' ? '20' : '24'
@@ -83,7 +86,8 @@ class CopyButton extends React.PureComponent {
             size={iconSize}
           />
         </ConfirmationIconWrapperUI>
-        <TextUI>Copy</TextUI>
+        {icon && <IconUI size={iconSize} name={icon} />}
+        {label && <TextUI>{label}</TextUI>}
       </CopyButtonUI>
     )
   }
@@ -96,6 +100,7 @@ CopyButton.propTypes = {
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,
   kind: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   onClick: PropTypes.func,
   onReset: PropTypes.func,
   resetTimeout: PropTypes.number,
@@ -104,11 +109,12 @@ CopyButton.propTypes = {
 }
 
 CopyButton.defaultProps = {
-  'data-cy': 'CopyButton',
   canRenderFocus: false,
+  'data-cy': 'CopyButton',
+  kind: 'secondary',
+  label: 'Copy',
   onClick: noop,
   onReset: noop,
-  kind: 'secondary',
   resetTimeout: 2000,
 }
 

--- a/src/components/CopyButton/CopyButton.stories.js
+++ b/src/components/CopyButton/CopyButton.stories.js
@@ -18,3 +18,13 @@ export const Medium = () => (
 export const Small = () => (
   <CopyButton onClick={action('Click')} onReset={action('Reset')} size="sm" />
 )
+
+export const Icon = () => (
+  <CopyButton
+    onClick={action('Click')}
+    onReset={action('Reset')}
+    size="lg"
+    icon="copy-small"
+    label={false}
+  />
+)

--- a/src/components/CopyInput/CopyInput.jsx
+++ b/src/components/CopyInput/CopyInput.jsx
@@ -59,6 +59,8 @@ class CopyInput extends React.PureComponent {
             style={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }}
             tabIndex={'-1'}
             innerRef={node => (this.copyButtonNode = node)}
+            icon="copy-small"
+            label={false}
           />
         }
       />

--- a/src/icons/copy-small.svg
+++ b/src/icons/copy-small.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M6 8C6 6.89543 6.89543 6 8 6H13C14.1046 6 15 6.89543 15 8H14C14 7.44772 13.5523 7 13 7H8C7.44772 7 7 7.44772 7 8V13C7 13.5523 7.44772 14 8 14V15C6.89543 15 6 14.1046 6 13V8Z" fill="#93A1B0"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9H16C17.1046 9 18 9.89543 18 11V16C18 17.1046 17.1046 18 16 18H11C9.89543 18 9 17.1046 9 16V11C9 9.89543 9.89543 9 11 9ZM11 10C10.4477 10 10 10.4477 10 11V16C10 16.5523 10.4477 17 11 17H16C16.5523 17 17 16.5523 17 16V11C17 10.4477 16.5523 10 16 10H11Z" fill="#93A1B0"/>
 </svg>


### PR DESCRIPTION
This update add an icon prop to the `CopyButton` component. We also add a label prop that can be turn off. The end result is a icon button that still has the confirm animation (triggered on click)

![Screen Recording 2020-06-16 at 10 15 AM](https://user-images.githubusercontent.com/203992/84787758-5f8cd900-afbc-11ea-9e57-fde2de15c84d.gif)

This update also change the CopyInput component to leverage this new button style

![Screen Recording 2020-06-16 at 10 16 AM](https://user-images.githubusercontent.com/203992/84787833-716e7c00-afbc-11ea-94bf-cb9842ac5d34.gif)
