### PR TITLE
Update modal v2 alert styles to match design specs

### DIFF
--- a/src/components/Modal/Modal.Body.jsx
+++ b/src/components/Modal/Modal.Body.jsx
@@ -57,7 +57,7 @@ class ModalBody extends React.PureComponent {
 
     const componentClassName = classNames(
       'c-ModalBody',
-      v2 && 'is-v2',
+      v2 && 'v2',
       seamless && 'is-seamless',
       scrollable ? 'is-scrollable' : 'is-not-scrollable',
       className

--- a/src/components/Modal/Modal.HeaderV2.css.js
+++ b/src/components/Modal/Modal.HeaderV2.css.js
@@ -66,7 +66,7 @@ export const BrandedHeaderImageUI = styled('div')`
 
 export const AlertHeaderUI = styled('div')`
   border: none;
-  padding: 50px 50px 20px;
+  padding: 50px 50px 4px;
   text-align: center;
   width: 100%;
   flex-grow: 1;

--- a/src/components/Modal/Modal.css.js
+++ b/src/components/Modal/Modal.css.js
@@ -86,8 +86,10 @@ export const InnerWrapperUI = styled('div')`
     }
 
     &.is-alert {
-      min-height: 179px;
+      min-height: 180px;
       width: 440px;
+      max-width: 440px;
+      top: auto;
     }
   }
 `
@@ -114,7 +116,8 @@ export const CardUI = styled(Card)`
 
   &.v2.is-alert {
     min-width: 440px;
-    padding-bottom: 60px;
+    padding-bottom: 40px;
+    top: auto;
   }
 `
 
@@ -167,7 +170,7 @@ export const BodyUI = styled('div')`
     }
   }
 
-  &.is-v2 {
+  &.v2 {
     padding: 0px;
 
     ${modalBodyBEM.element('scrollableContent')} {

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -209,7 +209,7 @@ class Modal extends React.PureComponent {
     const modalKindClassName = getModalKindClassName(kind)
     const componentClassName = classNames(
       'c-Modal__Card',
-      v2 && 'is-v2',
+      v2 && 'v2',
       v2 && modalKindClassName,
       cardClassName
     )

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -365,7 +365,7 @@ export const V2AlertWithDangerState = () => (
     description="You're about to do a thing that could impact a lot of other things. Continue?"
     state="danger"
     trigger={<Link>Clicky</Link>}
-    title="Are you sure?"
+    title="Delete the thing?"
   >
     <Modal.ActionFooter
       showDefaultCancel={false}

--- a/src/components/Modal/__tests__/Modal.Body.test.js
+++ b/src/components/Modal/__tests__/Modal.Body.test.js
@@ -18,7 +18,7 @@ describe('ClassName', () => {
   })
 
   test('Applies v2 className if specified', () => {
-    const customClass = 'is-v2'
+    const customClass = 'v2'
     const wrapper = mount(<Body version={2} />)
 
     expect(wrapper.getDOMNode().classList.contains(customClass)).toBe(true)


### PR DESCRIPTION
We update the modal alert component to match the current specs

* sit vertically centered on the page be 440px wide
* have Horizontal padding: 50px
* have Top padding: 50px
* have Bottom padding: 60px
* have min-height 180px (vs 179)
* Button group sits 24px below the copy


<img width="536" alt="Image 2020-06-16 at 11 22 20 AM" src="https://user-images.githubusercontent.com/203992/84809842-8527db80-afd8-11ea-9333-df290f86af67.png">
<img width="512" alt="Image 2020-06-16 at 11 23 05 AM" src="https://user-images.githubusercontent.com/203992/84809848-86f19f00-afd8-11ea-9698-1f144db297a8.png">
<img width="510" alt="Image 2020-06-16 at 11 24 59 AM" src="https://user-images.githubusercontent.com/203992/84809853-8822cc00-afd8-11ea-98dd-0dc8cbd21f2f.png">

Those changes will only affected `v3`