### PR TITLE
Fix accordion useEffect to recalculate openSectionIds

### DIFF
--- a/src/components/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion.jsx
@@ -99,7 +99,21 @@ const Accordion = props => {
   const isSeamless = accordion.isSeamless || isSeamlessProps
 
   useEffect(() => {
-    setOpenSections(buildOpenSections(openSectionIds))
+    let sectionIds = {}
+
+    if (openSectionIds.length === 0) {
+      setOpenSections(sectionIds)
+      return
+    }
+
+    const { allowMultiple } = props
+
+    if (!allowMultiple) {
+      sectionIds[openSectionIds[0]] = true
+    } else {
+      sectionIds = buildOpenSections(openSectionIds)
+    }
+    setOpenSections(sectionIds)
   }, [stringifyArray(openSectionIds)])
 
   const onClose = uuid => {

--- a/src/components/Accordion/Accordion.stories.mdx
+++ b/src/components/Accordion/Accordion.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Props, Preview } from "@storybook/addon-docs/blocks";
-import { select, text, boolean, number } from '@storybook/addon-knobs'
+import { select, text, boolean, number, array } from '@storybook/addon-knobs'
 import {
   data,
   dataWithIds,
@@ -29,12 +29,13 @@ vertically stacked section which can be expanded or collapsed.
     isSeamless={boolean('isSeamless', false)}
     allowMultiple={boolean('allowMultiple', false)}
     pressDelay={number('pressDelay', 300)}
+    openSectionIds={array('openSectionIds', [])}
     onOpen={onOpen}
     onClose={onClose}
     onSortEnd={onSortEnd}
     size={select('Sizes', {extraSmall: 'xs', small: 'sm', medium: 'md', large: 'lg'}, 'md')}
   >
-      {createSections(data)}
+      {createSections(dataWithIds)}
     </Accordion>
   </Story>
 </Preview>

--- a/src/components/Accordion/Accordion.stories.mdx
+++ b/src/components/Accordion/Accordion.stories.mdx
@@ -7,6 +7,7 @@ import {
   onOpen,
   onClose,
   onSortEnd,
+  AccordionWithCustomIds,
 } from './Accordion.storiesHelpers'
 import Accordion from './'
 import { Page, Text } from '../index'
@@ -219,3 +220,14 @@ This component is to be used within an `Accordion`.
   </Story>
 </Preview>
 
+#### With custom ids
+
+<Preview>
+  <Story name="Custom-Ids">
+    <Page>
+      <Page.Card>
+        <AccordionWithCustomIds />
+      </Page.Card>
+    </Page>
+  </Story>
+</Preview>

--- a/src/components/Accordion/Accordion.storiesHelpers.js
+++ b/src/components/Accordion/Accordion.storiesHelpers.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Accordion, Button, Input, Text } from '../index'
+import { boolean, number } from '@storybook/addon-knobs'
 import { faker } from '@helpscout/helix'
 
 const body = faker.lorem.paragraph()()
@@ -37,3 +38,52 @@ export const createSections = data =>
 export const onOpen = id => console.log('Open', id)
 export const onClose = id => console.log('Close', id)
 export const onSortEnd = (...args) => console.log('Sorted', ...args)
+
+export class AccordionWithCustomIds extends React.Component {
+  state = {
+    value: 3,
+  }
+
+  handleChange = e => {
+    this.updateSectionId(e.target.value)
+  }
+
+  updateSectionId = value => {
+    this.setState({
+      value: parseInt(value, 10),
+    })
+  }
+
+  render() {
+    const { value } = this.state
+
+    return (
+      <div>
+        <form
+          onSubmit={e => e.preventDefault()}
+          style={{ marginBottom: '10px' }}
+        >
+          <input
+            interval="1"
+            min="1"
+            max="4"
+            onChange={this.handleChange}
+            type="number"
+            value={value}
+            style={{ width: '100px' }}
+          />
+        </form>
+        <Accordion
+          distance={number('distance', 5)}
+          isSortable={boolean('isSortable', false)}
+          pressDelay={number('pressDelay', 300)}
+          onOpen={this.updateSectionId}
+          onSortEnd={onSortEnd}
+          openSectionIds={[value]}
+        >
+          {createSections(dataWithIds)}
+        </Accordion>
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
This update fixed an issue with the way the openSectionIds were recalculate with useEffect

Now we make sure that if the array is empty we set the active section as empty. We also make sure to only set one sections as active if the `allowMultiple` prop is set to false