### PR TITLE
Refactor Accordion to use either an internal or external state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.2.7",
+  "version": "3.2.8-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.2.7",
+  "version": "3.2.8-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/Accordion/Accordion.Section.jsx
+++ b/src/components/Accordion/Accordion.Section.jsx
@@ -43,20 +43,18 @@ const getComponentClassName = ({ className, isOpen, isLink, status }) => {
   )
 }
 
-const getIsOpen = ({ isLink, isOpen, uuid }) => {
+const isSectionOpen = ({ isLink, uuid }, openSections) => {
   if (isLink) return false
-
-  const { sections = {} } = useContext(AccordionContext) || {}
-
-  return !!(Object.keys(sections).length ? sections[uuid] : isOpen)
+  return openSections.includes(uuid)
 }
 
 export const AccordionSection = props => {
   const { children, ...rest } = props
 
   const [uuid] = useState(props.id || nextUuid())
+  const { openSections = [] } = useContext(AccordionContext) || {}
 
-  const isOpen = getIsOpen({ ...props, uuid })
+  const isOpen = isSectionOpen({ ...props, uuid }, openSections)
 
   const componentClassName = getComponentClassName({ ...props, isOpen })
 

--- a/src/components/Accordion/Accordion.Title.jsx
+++ b/src/components/Accordion/Accordion.Title.jsx
@@ -94,8 +94,14 @@ const AccordionTitle = props => {
     ...rest
   } = props
   const { uuid, isOpen } = useContext(SectionContext) || {}
-  const { isPage, isSeamless, setOpen = noop, size, isSorting, isSortable } =
-    useContext(AccordionContext) || {}
+  const {
+    isPage,
+    isSeamless,
+    setSectionState = noop,
+    size,
+    isSorting,
+    isSortable,
+  } = useContext(AccordionContext) || {}
 
   const isLink = props.href || props.to || isSorting
   const isIconOpen = isLink ? false : isOpen
@@ -119,7 +125,7 @@ const AccordionTitle = props => {
     if (event.isDefaultPrevented() || event.isPropagationStopped()) return
     if (isLink) return
     event && event.preventDefault()
-    setOpen(uuid, !isOpen)
+    setSectionState(uuid, !isOpen)
   }
 
   const handleKeyPress = event => {

--- a/src/components/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion.jsx
@@ -50,46 +50,53 @@ const getComponentClassName = ({
   )
 }
 
-const buildOpenSections = sectionIds =>
-  sectionIds.reduce(
-    (accumulator, id) => ({
-      ...accumulator,
-      [id]: true,
-    }),
-    {}
-  )
-
-const getOpenSectionIds = sections => {
-  return Object.keys(sections).reduce((accumulator, key) => {
-    if (sections[key] && sections[key] === true) {
-      return [...accumulator, key]
-    }
-    return accumulator
-  }, [])
-}
-
 export const getSortableProps = ({ distance, pressDelay }) => {
   return distance > 0 ? { distance } : { pressDelay }
+}
+
+const useSectionState = (originalState, allowMultiple) => {
+  const [openSections, setOpenSections] = useState(originalState)
+
+  const setSectionState = (uuid, isOpen) => {
+    setOpenSections(isOpen ? [uuid] : [])
+  }
+
+  const setMultipleState = (uuid, isOpen) => {
+    if (isOpen) {
+      const newSections = [...openSections, uuid]
+      setOpenSections(
+        newSections.filter((item, pos) => newSections.indexOf(item) == pos)
+      )
+    } else {
+      setOpenSections(openSections.filter(id => id !== uuid))
+    }
+  }
+
+  return [openSections, allowMultiple ? setMultipleState : setSectionState]
 }
 
 export const AccordionContext = createContext(null)
 
 const Accordion = props => {
   const {
+    allowMultiple,
     children,
-    openSectionIds,
     duration,
     isPage: isPageProps,
     isSeamless: isSeamlessProps,
-    size,
     isSortable,
     onSortEnd,
+    openSectionIds,
+    size,
     useWindowAsScrollContainer,
     ...rest
   } = props
 
-  const [sections, setOpenSections] = useState({})
   const [isSorting, setIsSorting] = useState(false)
+  const [openSections, setSectionState] = useSectionState(
+    openSectionIds,
+    allowMultiple
+  )
 
   const { accordion = {} } = useContext(PageContext)
   const { getCurrentScope } = React.useContext(GlobalContext) || {}
@@ -99,45 +106,12 @@ const Accordion = props => {
   const isPage = accordion.isPage || isPageProps
   const isSeamless = accordion.isSeamless || isSeamlessProps
 
-  useEffect(() => {
-    let sectionIds = {}
-
-    if (openSectionIds.length === 0) {
-      setOpenSections(sectionIds)
-      return
-    }
-
-    const { allowMultiple } = props
-
-    if (!allowMultiple) {
-      sectionIds[openSectionIds[0]] = true
-    } else {
-      sectionIds = buildOpenSections(openSectionIds)
-    }
-
-    setOpenSections(sectionIds)
-  }, [stringifyArray(openSectionIds)])
-
   const onClose = uuid => {
-    props.onClose(uuid, getOpenSectionIds(sections))
+    props.onClose(uuid, openSections)
   }
 
   const onOpen = uuid => {
-    props.onOpen(uuid, getOpenSectionIds(sections))
-  }
-
-  const setOpen = (uuid, isOpen) => {
-    const { allowMultiple } = props
-
-    if (allowMultiple) {
-      return setOpenSections({
-        ...sections,
-        [uuid]: isOpen,
-      })
-    }
-    return setOpenSections({
-      [uuid]: isOpen,
-    })
+    props.onOpen(uuid, openSections)
   }
 
   const getContainer = () => {
@@ -156,8 +130,9 @@ const Accordion = props => {
     isSorting,
     onClose,
     onOpen,
-    sections,
-    setOpen,
+    // WARN: we use the internal state only if there is no outside method to update the list of open sections
+    openSections: props.setSectionState ? openSectionIds : openSections,
+    setSectionState: props.setSectionState || setSectionState,
     size,
   }
 

--- a/src/components/Accordion/Accordion.stories.mdx
+++ b/src/components/Accordion/Accordion.stories.mdx
@@ -175,10 +175,10 @@ This component is to be used within an `Accordion`.
   </Story>
 </Preview>
 
-#### Multi-Line
+#### All link styles
 
 <Preview>
-  <Story name="Multi-Line">
+  <Story name="All link styles">
     <Page>
       <Page.Card>
         <Accordion

--- a/src/components/Accordion/Accordion.storiesHelpers.js
+++ b/src/components/Accordion/Accordion.storiesHelpers.js
@@ -79,15 +79,13 @@ export class AccordionWithCustomIds extends React.Component {
           pressDelay={number('pressDelay', 300)}
           onSortEnd={onSortEnd}
           openSectionIds={[value]}
+          setSectionState={uuid => {
+            this.updateSectionId(uuid)
+          }}
         >
           {dataWithIds.map((datum, index) => (
             <Accordion.Section key={index} id={datum.id}>
-              <Accordion.Title
-                onClick={e => {
-                  e.stopPropagation()
-                  this.updateSectionId(datum.id)
-                }}
-              >
+              <Accordion.Title>
                 <Text truncate weight={500}>
                   {datum.title}
                 </Text>

--- a/src/components/Accordion/__tests__/Accordion.Body.test.js
+++ b/src/components/Accordion/__tests__/Accordion.Body.test.js
@@ -8,8 +8,8 @@ import Body, { classNameStrings as classNames } from '../Accordion.Body'
 describe('ClassNames', () => {
   test('Has default className', () => {
     const wrapper = mount(
-      <Accordion duration={0}>
-        <Section isOpen>
+      <Accordion duration={0} openSectionIds={[1]}>
+        <Section id={1}>
           <Body />
         </Section>
       </Accordion>
@@ -28,8 +28,8 @@ describe('ClassNames', () => {
   test('Applies custom className if specified', () => {
     const className = 'kustom'
     const wrapper = mount(
-      <Accordion isSeamless duration={0}>
-        <Section isOpen>
+      <Accordion isSeamless duration={0} openSectionIds={[1]}>
+        <Section id={1}>
           <Body className={className} />
         </Section>
       </Accordion>
@@ -40,8 +40,8 @@ describe('ClassNames', () => {
 
   test('Applies a className to indicate that the Body is in a seamless accordion', () => {
     const wrapper = mount(
-      <Accordion isSeamless duration={0}>
-        <Section isOpen>
+      <Accordion isSeamless duration={0} openSectionIds={[1]}>
+        <Section id={1}>
           <Body />
         </Section>
       </Accordion>
@@ -53,8 +53,8 @@ describe('ClassNames', () => {
   test('Applies a className to indicate that the Body is in the specified size accordion', () => {
     ;['xs', 'sm', 'md', 'lg', 'xl'].forEach(size => {
       const wrapper = mount(
-        <Accordion size={size}>
-          <Section isOpen>
+        <Accordion size={size} openSectionIds={[1]}>
+          <Section id={1}>
             <Body />
           </Section>
         </Accordion>
@@ -66,8 +66,8 @@ describe('ClassNames', () => {
 
   test('Applies a className to indicate that the Body is in an Accordion embedded in a page', () => {
     const wrapper = mount(
-      <Accordion isPage>
-        <Section isOpen>
+      <Accordion isPage openSectionIds={[1]}>
+        <Section id={1}>
           <Body />
         </Section>
       </Accordion>

--- a/src/components/Accordion/__tests__/Accordion.Section.test.js
+++ b/src/components/Accordion/__tests__/Accordion.Section.test.js
@@ -25,7 +25,12 @@ describe('ClassNames', () => {
   })
 
   test('Applies a className to indicate that the Section is open', () => {
-    const wrapper = mount(<Section isOpen />)
+    const openSections = [1]
+    const wrapper = mount(
+      <AccordionContext.Provider value={{ openSections }}>
+        <Section id={1} />
+      </AccordionContext.Provider>
+    )
     const el = wrapper.find(`div.${classNames.baseComponentClassName}`)
 
     expect(el.hasClass(classNames.isOpenClassName)).toBe(true)
@@ -61,9 +66,9 @@ describe('Uuid', () => {
 describe('isOpen', () => {
   test('Renders open styles, if defined', () => {
     const uuid = 'myuuid'
-    const sections = { [uuid]: true }
+    const openSections = [uuid]
     const wrapper = mount(
-      <AccordionContext.Provider value={{ sections }}>
+      <AccordionContext.Provider value={{ openSections }}>
         <Section id={uuid} />
       </AccordionContext.Provider>
     )

--- a/src/components/Accordion/__tests__/Accordion.Title.test.js
+++ b/src/components/Accordion/__tests__/Accordion.Title.test.js
@@ -31,9 +31,11 @@ describe('ClassNames', () => {
 
   test('Applies a className to indicate that the Title is in an open section', () => {
     const wrapper = mount(
-      <Section isOpen>
-        <Title />
-      </Section>
+      <AccordionContext.Provider value={{ openSections: [1] }}>
+        <Section id={1}>
+          <Title />
+        </Section>
+      </AccordionContext.Provider>
     )
     const o = wrapper.find(`div.${classNames.baseComponentClassName}`)
     expect(o.hasClass(classNames.isOpenClassName)).toBe(true)
@@ -78,14 +80,14 @@ describe('ClassNames', () => {
   })
 })
 
-describe('setOpen', () => {
+describe('setSectionState', () => {
   test('Attempts to open the section by uuid when clicked', () => {
     const spy = jest.fn()
     const uuid = 'test'
     const wrapper = mount(
-      <AccordionContext.Provider value={{ setOpen: spy }}>
+      <AccordionContext.Provider value={{ setSectionState: spy }}>
         <Section>
-          <SectionContext.Provider value={{ uuid, isOpen: false }}>
+          <SectionContext.Provider value={{ uuid }}>
             <Title />
           </SectionContext.Provider>
         </Section>
@@ -98,13 +100,13 @@ describe('setOpen', () => {
     expect(spy).toBeCalledWith(uuid, true)
   })
 
-  test('Dont call the setOpen method if the onClick event is prevented when clicked', () => {
+  test('Dont call the setSectionState method if the onClick event is prevented when clicked', () => {
     const spy = jest.fn()
     const uuid = 'test'
     const wrapper = mount(
-      <AccordionContext.Provider value={{ setOpen: spy }}>
+      <AccordionContext.Provider value={{ setSectionState: spy }}>
         <Section>
-          <SectionContext.Provider value={{ uuid, isOpen: false }}>
+          <SectionContext.Provider value={{ uuid }}>
             <Title onClick={e => e.stopPropagation()} />
           </SectionContext.Provider>
         </Section>
@@ -122,11 +124,11 @@ describe('setOpen', () => {
     const spy = jest.fn()
     const uuid = 'test'
     const wrapper = mount(
-      <AccordionContext.Provider value={{ setOpen: spy }}>
-        <Section>
-          <SectionContext.Provider value={{ uuid, isOpen: true }}>
-            <Title />
-          </SectionContext.Provider>
+      <AccordionContext.Provider
+        value={{ setSectionState: spy, openSections: [uuid] }}
+      >
+        <Section id={uuid}>
+          <Title />
         </Section>
       </AccordionContext.Provider>
     )
@@ -142,9 +144,9 @@ describe('setOpen', () => {
       const spy = jest.fn()
       const uuid = 'test'
       const wrapper = mount(
-        <AccordionContext.Provider value={{ setOpen: spy }}>
+        <AccordionContext.Provider value={{ setSectionState: spy }}>
           <Section>
-            <SectionContext.Provider value={{ uuid, isOpen: false }}>
+            <SectionContext.Provider value={{ uuid }}>
               <Title />
             </SectionContext.Provider>
           </Section>
@@ -162,11 +164,11 @@ describe('setOpen', () => {
       const spy = jest.fn()
       const uuid = 'test'
       const wrapper = mount(
-        <AccordionContext.Provider value={{ setOpen: spy }}>
-          <Section>
-            <SectionContext.Provider value={{ uuid, isOpen: true }}>
-              <Title />
-            </SectionContext.Provider>
+        <AccordionContext.Provider
+          value={{ setSectionState: spy, openSections: [uuid] }}
+        >
+          <Section id={uuid}>
+            <Title />
           </Section>
         </AccordionContext.Provider>
       )

--- a/src/components/Accordion/__tests__/Accordion.test.js
+++ b/src/components/Accordion/__tests__/Accordion.test.js
@@ -82,22 +82,23 @@ describe('Content', () => {
 
   test('Can render sub-components', () => {
     const wrapper = mount(
-      <Accordion duration={0}>
-        <Section isOpen>
+      <Accordion duration={0} openSectionIds={[1]}>
+        <Section id={1}>
           <Title />
           <Body />
         </Section>
       </Accordion>
     )
+
     expect(
       wrapper.find(`div.${sectionClassNames.baseComponentClassName}`)
-    ).toHaveLength(1)
+    ).toBeTruthy()
     expect(
       wrapper.find(`div.${titleClassNames.baseComponentClassName}`)
-    ).toHaveLength(1)
+    ).toBeTruthy()
     expect(
       wrapper.find(`div.${bodyClassNames.baseComponentClassName}`)
-    ).toHaveLength(1)
+    ).toBeTruthy()
   })
 })
 
@@ -225,6 +226,28 @@ describe('State', () => {
         .getDOMNode()
         .classList.contains('is-open')
     ).toBeTruthy()
+  })
+
+  test('It should use an external state manager when setSectionState is used', () => {
+    const wrapper = mount(
+      <Accordion openSectionIds={[1]} setSectionState={() => {}}>
+        <Accordion.Section id={1}>
+          <Accordion.Title>Title 1</Accordion.Title>
+        </Accordion.Section>
+        <Accordion.Section id={2}>
+          <Accordion.Title>Title 2</Accordion.Title>
+        </Accordion.Section>
+      </Accordion>
+    )
+
+    expect(
+      wrapper
+        .find('.c-Accordion__Section')
+        .first()
+        .getDOMNode()
+        .classList.contains('is-open')
+    ).toBeTruthy()
+
     wrapper.setProps({ openSectionIds: [4, 5, 6] })
     expect(
       wrapper

--- a/src/components/Accordion/docs/Accordion.md
+++ b/src/components/Accordion/docs/Accordion.md
@@ -30,17 +30,18 @@ inner `Body` expanded simultaneously.
 
 ## Props
 
-| Prop           | Type                  | Description                                                                                             |
-| -------------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
-| allowMultiple  | `boolean`             | Allows multiple sections to have their body revealed simultaneously.                                    |
-| children       | `Accordion.Section[]` | Sections to be stacked and controlled.                                                                  |
-| className      | `string`              | Custom class names to be added to the component.                                                        |
-| distance       | `number`              | When isSortable is true, the distance determines how far a user must drag in order to sort.             |
-| isSeamless     | `boolean`             | Exclude borders and horizontal padding.                                                                 |
-| isSortable     | `boolean`             | Enable sections to be re-ordered by drag and drop.                                                      |
-| onOpen         | `function`            | Callback to be invoked when the body of a section is revealed.                                          |
-| onClose        | `function`            | Callback to be invoked when the body of a section is concealed.                                         |
-| onSortEnd      | `function`            | When is sortable is true, callback to be invoked when sorting ends.                                     |
-| openSectionIds | `array`               | An array of ids corresponding to sections that should be open.                                          |
-| pressDelay     | `number`              | When isSortable is true and distance is 0, the time in ms that must elapse on a press in order to sort. |
-| size           | `string`              | The amount of padding. Valid sizes are `xs`, `sm`, `md`, and `lg`.                                      |
+| Prop            | Type                  | Description                                                                                             |
+| --------------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
+| allowMultiple   | `boolean`             | Allows multiple sections to have their body revealed simultaneously.                                    |
+| children        | `Accordion.Section[]` | Sections to be stacked and controlled.                                                                  |
+| className       | `string`              | Custom class names to be added to the component.                                                        |
+| distance        | `number`              | When isSortable is true, the distance determines how far a user must drag in order to sort.             |
+| isSeamless      | `boolean`             | Exclude borders and horizontal padding.                                                                 |
+| isSortable      | `boolean`             | Enable sections to be re-ordered by drag and drop.                                                      |
+| onOpen          | `function`            | Callback to be invoked when the body of a section is revealed.                                          |
+| onClose         | `function`            | Callback to be invoked when the body of a section is concealed.                                         |
+| onSortEnd       | `function`            | When is sortable is true, callback to be invoked when sorting ends.                                     |
+| openSectionIds  | `array`               | An array of ids corresponding to sections that should be open.                                          |
+| setSectionState | `function`            | Handle the state outside the accordion component                                                        |
+| pressDelay      | `number`              | When isSortable is true and distance is 0, the time in ms that must elapse on a press in order to sort. |
+| size            | `string`              | The amount of padding. Valid sizes are `xs`, `sm`, `md`, and `lg`.                                      |

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.2.7',
+  version: '3.2.8-0',
 }


### PR DESCRIPTION
This update rewrite the internal state of the Accordion component to use an array containing the current open section ids. Before it was converted to an object but now it's simpler and less prone to an out of sync state

We create our own hook to handle the state. See `useSectionState ` in the Accordion component

When using the external state, it is still an array, but the method to set the new state is pass as a prop. Also, the allowMultiple has no effect when the state is set outside of the component. It needs to be handle by the external state

```javascript
const [openSectionIds, setOpenSectionIds] = useState()

return (
  <Accordion
    openSectionIds={openSectionIds}
    setSectionState={uuid => {
      setOpenSectionIds([uuid])
    }}
  >
    {dataWithIds.map((datum, index) => (
      <Accordion.Section key={index} id={datum.id}>
        <Accordion.Title>
          <Text truncate weight={500}>
            {datum.title}
          </Text>
        </Accordion.Title>
        <Accordion.Body>{datum.body}</Accordion.Body>
      </Accordion.Section>
    ))}
  </Accordion>
)
)
```