### PR TITLE
Fixed differences between v2 and v3 in Accordion component

### DIFF
--- a/src/components/Accordion/Accordion.Title.jsx
+++ b/src/components/Accordion/Accordion.Title.jsx
@@ -103,7 +103,7 @@ const AccordionTitle = props => {
     isSortable,
   } = useContext(AccordionContext) || {}
 
-  const isLink = props.href || props.to || isSorting
+  const isLink = props.href || props.to
   const isIconOpen = isLink ? false : isOpen
 
   const componentClassName = getComponentClassName({

--- a/src/components/Accordion/Accordion.css.js
+++ b/src/components/Accordion/Accordion.css.js
@@ -170,6 +170,7 @@ export const TitleUI = styled('div')`
   cursor: pointer;
   display: block;
   padding: 18px 20px;
+  position: relative;
   text-decoration: none;
   font-weight: 500;
 

--- a/src/components/Sortable/Sortable.DragHandle.jsx
+++ b/src/components/Sortable/Sortable.DragHandle.jsx
@@ -9,7 +9,7 @@ import { noop } from '../../utilities/other'
 import { DragHandleUI } from './Sortable.css'
 
 const SortableDragHandle = SortableHandle(props => {
-  const { className, onDragStart, ...rest } = props
+  const { className, iconSize, onDragStart, ...rest } = props
 
   const componentClassName = classNames('c-SortableDragHandle', className)
 
@@ -19,7 +19,7 @@ const SortableDragHandle = SortableHandle(props => {
       className={componentClassName}
       onMouseDown={onDragStart}
     >
-      <Icon name="drag-handle" ignoreClick={false} />
+      <Icon name="small-drag-handle" size={iconSize} ignoreClick={false} />
     </DragHandleUI>
   )
 })


### PR DESCRIPTION
## Summary

@knicklabs spotted a few differences between the Accordion component implementation in v2 and v3. This PR solves these issues.

1. Sortable drag-handle updated to the right icon and size.
2. Fixed position of drag-handle while dragging an expanded item.
3. Fixed issue where chevron icons changed orientation when dragging them.