### PR TITLE
Only pass valid props within ActionSelect ContentResizer

### DIFF
--- a/src/components/ActionSelect/ActionSelect.ContentResizer.jsx
+++ b/src/components/ActionSelect/ActionSelect.ContentResizer.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import Animate from '../Animate'
 import { ContentUI, ContentResizerUI } from './ActionSelect.css'
 import { getEasingTiming } from '../../utilities/easing'
@@ -175,7 +176,7 @@ export class ContentResizer extends React.PureComponent {
 
     return (
       <ContentResizerUI
-        {...rest}
+        {...getValidProps(rest)}
         ref={this.setResizerNodeRef}
         style={this.getResizeStyles()}
         onTransitionEnd={this.resetHeight}


### PR DESCRIPTION
We were passing `...rest` as props to a styled component, which in this case was a `div`. Some of the props were not relevant so React was emitting a warning.

<img width="664" alt="Screenshot 2020-06-24 at 22 57 14" src="https://user-images.githubusercontent.com/6132043/85740159-4c36e780-b6f9-11ea-8511-25a75890d697.png">

In this PR I have passed `rest` through the `getValidProps` utility so we only pass props that are valid.