### PR TITLE
Removed getValidProps call from Animate component

### DIFF
--- a/src/components/Animate/Animate.jsx
+++ b/src/components/Animate/Animate.jsx
@@ -102,7 +102,7 @@ export class Animate extends React.PureComponent {
 
     return (
       <Transition
-        {...getValidProps(rest)}
+        {...rest}
         mountOnEnter={mountOnEnter}
         unmountOnExit={unmountOnExit}
         appear={animateOnMount}


### PR DESCRIPTION
I've removed the call to `getValidProps` on the Animate component because it was filtering out props like `onEnter`, `onExit`, etc, which are needed for this component to work correctly.