### PR TITLE
Upgrade React and React DOM peer dependencies to 16.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "make:version": "node ./scripts/make-version.js"
   },
   "peerDependencies": {
-    "react": "^16.8",
-    "react-dom": "^16.8",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
     "styled-components": "^5"
   },
   "dependencies": {
@@ -170,9 +170,9 @@
     "prettier": "1.19.1",
     "pretty-quick": "^1.8.0",
     "prop-types": "^15.7.2",
-    "react": "^16.8.6",
+    "react": "^16.13.1",
     "react-dev-utils": "^3.0.2",
-    "react-dom": "^16.8.6",
+    "react-dom": "^16.13.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "remake-cli": "0.0.7",


### PR DESCRIPTION
This PR will be held until after HSDS v3 migrations in HSAPP have all been merged for testing in HSApp

This is just a package change... and to limit scope it ONLY includes the React and React-DOM updates, no other packages are updated unless we identify mandatory updates for compatibility.

We will need to test and look for any components not functioning/displaying as expected or errors/warnings in the console, or lint errors newly thrown, but so far I'm not seeing anything unusual.