### PR TITLE
Bug Fix: Radio stacked prop was not passing through to Choice element, so stacked styles never applied

### DIFF
--- a/src/components/Radio/Radio.jsx
+++ b/src/components/Radio/Radio.jsx
@@ -5,9 +5,16 @@ import { classNames } from '../../utilities/classNames'
 
 export const RadioContext = React.createContext({})
 
-export const Radio = ({ kind: kindProp, className, ...rest }) => {
+export const Radio = ({
+  kind: kindProp,
+  stacked: stackedProp,
+  className,
+  ...rest
+}) => {
   const componentClassName = classNames('c-Radio', className)
-  const { kind = kindProp, stacked } = React.useContext(RadioContext)
+  const { kind = kindProp, stacked = stackedProp } = React.useContext(
+    RadioContext
+  )
 
   return (
     <Choice

--- a/src/components/Radio/Radio.stories.js
+++ b/src/components/Radio/Radio.stories.js
@@ -36,3 +36,15 @@ export const Disabled = () => (
 Disabled.story = {
   name: 'disabled',
 }
+
+export const Stacked = () => (
+  <ChoiceGroup>
+    <Radio stacked={true} label="Derek" value="derek" />
+    <Radio stacked={true} label="Hansel" value="hansel" />
+    <Radio stacked={true} label="Mugatu" value="mugatu" />
+  </ChoiceGroup>
+)
+
+Stacked.story = {
+  name: 'stacked',
+}

--- a/src/components/Radio/Radio.test.js
+++ b/src/components/Radio/Radio.test.js
@@ -12,4 +12,14 @@ describe('Radio', () => {
     expect(choice.props().type).toBe('radio')
     expect(choice.props().value).toBe('check')
   })
+
+  test('Renders a radio as stacked', () => {
+    const wrapper = mount(<Radio value="check" stacked={true} />)
+    const choice = wrapper.find(Choice)
+
+    expect(choice.length).toBeTruthy()
+    expect(choice.props().type).toBe('radio')
+    expect(choice.props().value).toBe('check')
+    expect(choice.props().stacked).toBe(true)
+  })
 })


### PR DESCRIPTION
`Radio` component was not internally passing down the `stacked` prop into the `Choice` component, therefore if you render a Radio with `stacked={true}` it did not get the` 'is-stacked'` classes and associated styling, and did not appear as stacked.

This PR ensures the stacked prop is passed through correctly and also adds a new story to Radio and test to support the change.