### PR TITLE
HSDS-158 Tooltip Fix: Text breaks mid-word

### DIFF
--- a/src/components/Tooltip/Tooltip.css.js
+++ b/src/components/Tooltip/Tooltip.css.js
@@ -48,7 +48,7 @@ export const TooltipUI = styled.div`
   transition-duration: ${({ animationDuration }) => animationDuration}ms;
   transition-timing-function: ease-in-out;
   opacity: 0;
-  word-break: break-all;
+  word-break: break-word;
   white-space: pre-wrap;
   overflow-wrap: break-word;
   word-wrap: break-word;


### PR DESCRIPTION
[Jira Issue](https://helpscout.atlassian.net/browse/HSDS-158)

# Problem

When tooltips have long lines of text, the text breaks at arbitrary points, including mid-word. See the screenshot below.

![Screenshot of Problem](https://p-zkF42X.t2.n0.cdn.getcloudapp.com/items/xQuDR0wL/Image%202020-07-03%20at%206.12.08%20PM.png?v=c0871998cafa464a55fa7ccbd718e391)

# Solution

I changed the value of the `word-break` style property applied to the tooltip to be `break-word` so that words are preserved if possible. 

![Screenshot of Solution](https://p-zkF42X.t2.n0.cdn.getcloudapp.com/items/5zuXjJrR/Image%202020-07-03%20at%206.12.52%20PM.png?v=df4dd8d3d94e57476bb7ff82d48a0904)

# Testing

You can try it out with various text content using the knobs in the add-ons pane on the [Tooltip Story](https://deploy-preview-859--hsds-react.netlify.app/?path=/story/components-overlay-tooltipv2--default).