### PR TITLE
Add data-cy attributes to Modal.ActionFooter

### DIFF
--- a/src/components/Modal/Modal.ActionFooter.jsx
+++ b/src/components/Modal/Modal.ActionFooter.jsx
@@ -34,6 +34,7 @@ class ModalActionFooter extends React.PureComponent {
     const { primaryButtonText, state, primaryButtonDisabled } = this.props
     return (
       <PrimaryButtonUI
+        data-cy="PrimaryButton"
         state={state}
         kind="primary"
         size="lg"
@@ -58,6 +59,7 @@ class ModalActionFooter extends React.PureComponent {
 
     return (
       <ButtonComponent
+        data-cy="SecondaryButton"
         kind="secondary"
         size="lg"
         version={2}
@@ -79,6 +81,7 @@ class ModalActionFooter extends React.PureComponent {
     return (
       <CancelButtonUI
         className="is-cancel"
+        data-cy="CancelButton"
         kind="default"
         version={2}
         onClick={this.handleCancel}


### PR DESCRIPTION
The Saved Replies app is being upgraded to HSDS V3 in [this PR](https://github.com/helpscout/hs-app/pull/8682), however cypress tests need to be updated. The tests were looking for data-cy attributes on buttons like Save and Cancel, but we're no longer hard-coding those buttons ourselves in the Saved Replies app, we're using the buttons that come with the Modal.ActionFooter, and they don't currently have unique data-cy attributes (the default one for the Button component comes through). 

Current data-cy attribute for the Primary button:
[
![Screen Shot 2020-07-08 at 10 25 02 AM](https://user-images.githubusercontent.com/8022745/86931066-aaa29380-c105-11ea-9fcc-9fc3104a84e1.png)
](url)

Updated data-cy attribute for the Primary Button:
![Screen Shot 2020-07-08 at 10 25 52 AM](https://user-images.githubusercontent.com/8022745/86931175-c86ff880-c105-11ea-96fc-daf2bfc9603c.png)


This PR adds data-cy attributes to the Primary, Secondary, and Cancel button with Modal.ActionFooter.
