### PR TITLE
Add disabled support to SelectDropdown component

### DIFF
--- a/src/components/Select/Select.css.js
+++ b/src/components/Select/Select.css.js
@@ -85,6 +85,11 @@ export const SelectArrowsUI = styled('div')`
   &.is-error {
     right: 40px;
   }
+
+  ${({ disabled }) => {
+    const color = disabled ? 'charcoal.200' : 'charcoal.600'
+    return `color: ${getColor(color)} !important;`
+  }}
 `
 
 function getFirefoxStyles() {

--- a/src/components/SelectDropdown/SelectDropdown.css.js
+++ b/src/components/SelectDropdown/SelectDropdown.css.js
@@ -1,6 +1,8 @@
 import InputBackdropV2 from '../Input/Input.BackdropV2'
 import styled from 'styled-components'
 
+import { getColor } from '../../styles/utilities/color'
+
 export const SelectDropdownUI = styled('div')`
   .c-DropdownTrigger {
     display: block;
@@ -41,12 +43,16 @@ export const InputUI = styled('div')`
 export const LabelUI = styled('div')`
   --HSDSGlobalFontSize: 14px;
   font-size: 14px;
-  color: #2a3b47;
   max-width: 100%;
   padding-right: 20px;
   position: relative;
   text-decoration: none !important;
   z-index: 2;
+
+  ${({ disabled }) => {
+    const color = disabled ? 'charcoal.200' : 'charcoal.600'
+    return `color: ${getColor(color)} !important;`
+  }}
 
   * {
     text-decoration: none !important;

--- a/src/components/SelectDropdown/SelectDropdown.jsx
+++ b/src/components/SelectDropdown/SelectDropdown.jsx
@@ -131,7 +131,7 @@ export class SelectDropdown extends React.PureComponent {
   }
 
   renderTrigger() {
-    const { state } = this.props
+    const { disabled, state } = this.props
     const { isFocused } = this.state
     const isError = state === 'error'
 
@@ -139,7 +139,7 @@ export class SelectDropdown extends React.PureComponent {
       <InputUI
         className={classNames('c-SelectDropdownTrigger', isError && 'is-error')}
       >
-        <LabelUI className="c-SelectDropdownTriggerLabel">
+        <LabelUI className="c-SelectDropdownTriggerLabel" disabled={disabled}>
           <Text truncate>{this.getLabel()}</Text>
         </LabelUI>
         <SelectArrows state={state} />

--- a/src/components/SelectDropdown/SelectDropdown.jsx
+++ b/src/components/SelectDropdown/SelectDropdown.jsx
@@ -142,7 +142,7 @@ export class SelectDropdown extends React.PureComponent {
         <LabelUI className="c-SelectDropdownTriggerLabel" disabled={disabled}>
           <Text truncate>{this.getLabel()}</Text>
         </LabelUI>
-        <SelectArrows state={state} />
+        <SelectArrows state={state} disabled={disabled} />
         {this.renderError()}
         <BackdropUI isFocused={isFocused} state={state} />
       </InputUI>

--- a/src/components/SelectDropdown/SelectDropdown.stories.js
+++ b/src/components/SelectDropdown/SelectDropdown.stories.js
@@ -12,6 +12,7 @@ export default {
 export const Default = () => {
   return (
     <SelectDropdown
+      disabled={boolean('disabled', false)}
       autoInput={false}
       items={createSpec({
         id: faker.random.uuid(),


### PR DESCRIPTION
This add disabled styling support to the `SelectDropdown` component. 

### Before (label text)
<img width="519" alt="Screen Shot 2020-07-10 at 17 20 03" src="https://user-images.githubusercontent.com/7111256/87207490-9f03c800-c2d1-11ea-9dba-862417c318ec.png">

### After
<img width="553" alt="Screen Shot 2020-07-13 at 18 09 31" src="https://user-images.githubusercontent.com/7111256/87362361-07ea7a80-c534-11ea-8422-f65e69382a39.png">

