### PR TITLE
Change appendTo location for Tooltip inside Nav.Item

### DIFF
--- a/src/components/Nav/Nav.Item.jsx
+++ b/src/components/Nav/Nav.Item.jsx
@@ -44,7 +44,11 @@ export class NavItem extends React.Component {
 
     return (
       <ErrorWrapperUI>
-        <Tooltip data-cy="NavItemErrorTooltip" title={error}>
+        <Tooltip
+          data-cy="NavItemErrorTooltip"
+          title={error}
+          appendTo={document.body}
+        >
           <Icon
             data-cy="NavItemErrorIcon"
             name="alert"


### PR DESCRIPTION

![Screen Recording 2020-07-15 at 02 19 29 PM](https://user-images.githubusercontent.com/203992/87580964-38eabc80-c6a6-11ea-8b35-f64aaa7411f3.gif)


This update change the append location for error Tooltip inside a Nav.Item component (from `parent` to the `document.body`)