### PR TITLE
Fix CopyCode button sizing issue

### DIFF
--- a/src/components/CopyButton/CopyButton.jsx
+++ b/src/components/CopyButton/CopyButton.jsx
@@ -116,6 +116,7 @@ CopyButton.defaultProps = {
   onClick: noop,
   onReset: noop,
   resetTimeout: 2000,
+  size: 'sm',
 }
 
 export default CopyButton

--- a/src/components/CopyCode/CopyCode.jsx
+++ b/src/components/CopyCode/CopyCode.jsx
@@ -84,7 +84,7 @@ class CopyCode extends React.PureComponent {
   }
 
   render() {
-    const { className, code, maxWidth, ...rest } = this.props
+    const { buttonSize, className, code, maxWidth, ...rest } = this.props
     const componentClassName = classNames('c-CopyCode', className)
 
     return (
@@ -105,6 +105,7 @@ class CopyCode extends React.PureComponent {
           kind="secondary"
           onClick={this.handleCopyClick}
           canRenderFocus
+          size={buttonSize}
         >
           Copy
         </CopyButtonUI>
@@ -115,6 +116,7 @@ class CopyCode extends React.PureComponent {
 
 CopyCode.propTypes = {
   autoFocus: PropTypes.bool,
+  buttonSize: PropTypes.string,
   className: PropTypes.string,
   code: PropTypes.string,
   copyToClipboard: PropTypes.bool,
@@ -128,6 +130,7 @@ CopyCode.propTypes = {
 
 CopyCode.defaultProps = {
   autoFocus: false,
+  buttonSize: 'sm',
   code: '',
   copyToClipboard: true,
   'data-cy': 'CopyCode',

--- a/src/components/CopyCode/README.md
+++ b/src/components/CopyCode/README.md
@@ -10,12 +10,13 @@ This component renders a code snippet with the ability to copy to clipboard, pow
 
 ## Props
 
-| Prop            | Type       | Description                                                    |
-| --------------- | ---------- | -------------------------------------------------------------- |
-| autoFocus       | `boolean`  | Automatically select `code` when component mounts.             |
-| code            | `string`   | The code to be displayed within the container.                 |
-| copyToClipboard | `boolean`  | Enables copying to clipboard.                                  |
-| innerRef        | `function` | Retrieves the DOM node.                                        |
-| language        | `string`   | Can be one of `c`, `java`, `javascript`, `objectivec`, `swift` |
-| maxWidth        | `number`   | Sets the max width of the container.                           |
-| onCopy          | `function` | Callback function when the copy button is clicked.             |
+| Prop            | Type       | Description                                                          |
+| --------------- | ---------- | -------------------------------------------------------------------- |
+| autoFocus       | `boolean`  | Automatically select `code` when component mounts.                   |
+| buttonSize      | `string`   | Sets the size of the button. Can be one of `"sm"`, `"md"` or `"lg"`. |
+| code            | `string`   | The code to be displayed within the container.                       |
+| copyToClipboard | `boolean`  | Enables copying to clipboard.                                        |
+| innerRef        | `function` | Retrieves the DOM node.                                              |
+| language        | `string`   | Can be one of `c`, `java`, `javascript`, `objectivec`, `swift`       |
+| maxWidth        | `number`   | Sets the max width of the container.                                 |
+| onCopy          | `function` | Callback function when the copy button is clicked.                   |


### PR DESCRIPTION
The copy button in the `CopyCode` button was too large. This was a regression caused by changes to Button size styles. 

### Before
<img width="532" alt="Screen Shot 2020-07-22 at 13 33 38" src="https://user-images.githubusercontent.com/7111256/88214544-f8e48600-cc1f-11ea-9b0a-6bdb9a19ae1e.png">

### After
<img width="534" alt="Screen Shot 2020-07-22 at 13 33 07" src="https://user-images.githubusercontent.com/7111256/88214506-ed915a80-cc1f-11ea-9671-0aecbb499a11.png">

