### PR TITLE
Bug fixes for CopyButton in Safari & Input Tooltip

### DIFF
--- a/src/components/CopyButton/CopyButton.css.js
+++ b/src/components/CopyButton/CopyButton.css.js
@@ -43,7 +43,7 @@ export const CopyButtonUI = styled(Button)`
     min-width: 60px;
 
     &.is-with-icon {
-      min-width: 40px;
+      min-width: 40px !important;
       max-width: 40px;
       padding: 0;
       text-align: center;

--- a/src/components/CopyButton/CopyButton.css.js
+++ b/src/components/CopyButton/CopyButton.css.js
@@ -43,8 +43,9 @@ export const CopyButtonUI = styled(Button)`
     min-width: 60px;
 
     &.is-with-icon {
-      min-width: 40px !important;
-      max-width: 40px;
+      min-width: auto;
+      max-width: auto;
+      width: 40px;
       padding: 0;
       text-align: center;
       background: ${getColor('grey.200')};

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -434,6 +434,7 @@ export class Input extends React.PureComponent {
           animationDelay={0}
           animationDuration={0}
           appendTo={document.body}
+          closeOnContentClick={true}
           display="block"
           placement="top-end"
           title={errorMessage}


### PR DESCRIPTION
This address two issues: 
- Fixes an issue with the Input tooltip not closing as expected when another Tooltip is hovered 
- Fixes a styling issue caused specificity issues in Safari 