### PR TITLE
Fixing ChoiceGroup, RadioCard, Choice in preparation for Checkmark

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -192,22 +192,20 @@ Button.propTypes = {
   isSuffix: PropTypes.bool,
   /** Applies the specified style to the button.
    * 'primary': Blue button. Used for primary actions.
-   * 'primaryAlt': Purple button. Used for primary actions.
    * 'secondary': White button with a border. Used for secondary actions.
-   * 'secondaryAlt': White button with a green border. Used for secondary actions.
+   * 'tertiary': White button with a green border. Used for secondary actions.
    * 'default': Borderless button. Used for subtle/tertiary actions.
    * 'link': Button that looks like a `Link`. Used for subtle/tertiary actions.
    */
   kind: PropTypes.oneOf([
     'primary',
-    'primaryAlt',
     'secondary',
-    'secondaryAlt',
+    'tertiary',
     'default',
     'link',
   ]),
-  /** Sets the size of the button. Can be one of "sm", "md" or "lg". */
-  size: PropTypes.string,
+  /** Sets the size of the button. */
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
   /** A special property that... spins the button if `isLoading`. */
   spinButtonOnLoading: PropTypes.bool,
   /** Applies state styles to the button.

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -205,7 +205,7 @@ Button.propTypes = {
     'link',
   ]),
   /** Sets the size of the button. */
-  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'xs', 'xss']),
+  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'lgxl', 'xs', 'xxs']),
   /** A special property that... spins the button if `isLoading`. */
   spinButtonOnLoading: PropTypes.bool,
   /** Applies state styles to the button.

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -205,7 +205,7 @@ Button.propTypes = {
     'link',
   ]),
   /** Sets the size of the button. */
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'xs', 'xss']),
   /** A special property that... spins the button if `isLoading`. */
   spinButtonOnLoading: PropTypes.bool,
   /** Applies state styles to the button.

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
+import { boolean, select } from '@storybook/addon-knobs'
 import Checkbox from './'
 import { ChoiceGroup } from '../'
 
@@ -20,7 +21,19 @@ A Checkbox component is an enhanced version of the default HTML `<input>` `check
 
 <Preview>
   <Story name="default">
-    <ChoiceGroup>
+    <ChoiceGroup
+      multiSelect={boolean('multiSelect', true)}
+      value={select(
+        'Value from props',
+        {
+          zero: [],
+          one: ['hansel'],
+          two: ['hansel', 'mugatu'],
+          three: ['hansel', 'mugatu', 'derek'],
+        },
+        []
+      )}
+    >
       <Checkbox label="Derek" value="derek" />
       <Checkbox label="Hansel" value="hansel" />
       <Checkbox label="Mugatu" value="mugatu" />

--- a/src/components/Choice/Choice.Input.jsx
+++ b/src/components/Choice/Choice.Input.jsx
@@ -33,12 +33,24 @@ class ChoiceInput extends React.PureComponent {
     event.stopPropagation()
   }
 
-  handleOnKeyDown = event => {
-    const isEnter = event.key === key.ENTER
+  runKeyPress = event => {
+    event.stopPropagation()
+    event.preventDefault()
+    const { id, onEnter, value, type } = this.props
+    const checked =
+      type === 'checkbox' ? !event.target.checked : event.target.checked
+    onEnter(value, checked, id)
+  }
 
-    if (isEnter) {
-      const { id, onEnter, value } = this.props
-      onEnter(value, !event.target.checked, id)
+  handleOnKeyUp = event => {
+    if (event.key === ' ') {
+      this.runKeyPress(event)
+    }
+  }
+
+  handleOnKeyDown = event => {
+    if (event.key === key.ENTER) {
+      this.runKeyPress(event)
     }
   }
 
@@ -134,10 +146,11 @@ class ChoiceInput extends React.PureComponent {
           disabled={disabled}
           id={id}
           ref={this.setRef}
-          name={name}
+          name={name || id}
           onBlur={this.handleOnBlur}
           onChange={this.handleOnChange}
           onFocus={this.handleOnFocus}
+          onKeyUp={this.handleOnKeyUp}
           onKeyDown={this.handleOnKeyDown}
           readOnly={readOnly}
           type={type}

--- a/src/components/Choice/Choice.Input.jsx
+++ b/src/components/Choice/Choice.Input.jsx
@@ -190,7 +190,7 @@ ChoiceInput.propTypes = {
   readOnly: PropTypes.bool,
   state: PropTypes.string,
   type: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 
 export default ChoiceInput

--- a/src/components/Choice/Choice.Input.jsx
+++ b/src/components/Choice/Choice.Input.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { key } from '../../constants/Keys'
 import InputBackdropV2 from '../Input/Input.BackdropV2'
 import Icon from '../Icon'
 import { classNames } from '../../utilities/classNames'
@@ -30,6 +31,15 @@ class ChoiceInput extends React.PureComponent {
     onChange(value, event.target.checked, id)
     // Prevents duplicate firing of onChange event
     event.stopPropagation()
+  }
+
+  handleOnKeyDown = event => {
+    const isEnter = event.key === key.ENTER
+
+    if (isEnter) {
+      const { id, onEnter, value } = this.props
+      onEnter(value, !event.target.checked, id)
+    }
   }
 
   handleOnFocus = event => {
@@ -92,7 +102,6 @@ class ChoiceInput extends React.PureComponent {
       value,
       'data-cy': dataCy,
     } = this.props
-
     const { isFocused } = this.state
 
     const componentClassName = classNames(
@@ -129,6 +138,7 @@ class ChoiceInput extends React.PureComponent {
           onBlur={this.handleOnBlur}
           onChange={this.handleOnChange}
           onFocus={this.handleOnFocus}
+          onKeyDown={this.handleOnKeyDown}
           readOnly={readOnly}
           type={type}
           value={value}
@@ -161,6 +171,7 @@ ChoiceInput.defaultProps = {
   onBlur: noop,
   onChange: noop,
   onFocus: noop,
+  onEnter: noop,
   inputRef: noop,
   innerRef: noop,
   readOnly: false,
@@ -186,10 +197,12 @@ ChoiceInput.propTypes = {
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
+  /** Callback when pressing enter whenthe input is focused. */
+  onEnter: PropTypes.func,
   name: PropTypes.string,
   readOnly: PropTypes.bool,
   state: PropTypes.string,
-  type: PropTypes.string,
+  type: PropTypes.oneOf(['checkbox', 'radio']),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 

--- a/src/components/Choice/Choice.jsx
+++ b/src/components/Choice/Choice.jsx
@@ -306,7 +306,7 @@ Choice.propTypes = {
   /** Retrieves the `input` DOM node. */
   inputRef: PropTypes.func,
   /** Label for the input. */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /** Name for the input. */
   name: PropTypes.string,
   /** Callback when the input is blurred. */

--- a/src/components/Choice/Choice.jsx
+++ b/src/components/Choice/Choice.jsx
@@ -7,7 +7,6 @@ import HelpText from '../HelpText'
 import Text from '../Text'
 import VisuallyHidden from '../VisuallyHidden'
 import ChoiceGroupContext from '../ChoiceGroup/ChoiceGroup.Context'
-import { includes } from '../../utilities/arrays'
 import { classNames } from '../../utilities/classNames'
 import { createUniqueIDFactory } from '../../utilities/id'
 import { noop } from '../../utilities/other'
@@ -165,7 +164,7 @@ class Choice extends React.PureComponent {
 
     const isChecked =
       (contextProps.selectedValue &&
-        includes(contextProps.selectedValue, value)) ||
+        contextProps.selectedValue.includes(value)) ||
       checked ||
       false
 
@@ -180,7 +179,6 @@ class Choice extends React.PureComponent {
       inputRef,
       innerRef,
       kind,
-
       name: contextProps.name || name,
       onBlur: this.handleOnBlurWithContext(contextProps),
       onFocus: this.handleOnFocusWithContext(contextProps),
@@ -243,7 +241,6 @@ class Choice extends React.PureComponent {
       ...rest
     } = this.props
     const { checked, id: choiceID } = this.state
-
     const componentClassName = classNames(
       'c-Choice',
       `is-${type}`,

--- a/src/components/Choice/Choice.jsx
+++ b/src/components/Choice/Choice.jsx
@@ -38,12 +38,28 @@ class Choice extends React.PureComponent {
     this.props.onChange(value, checked)
   }
 
+  handleOnEnter = (value, checked) => {
+    this.setState({ checked })
+
+    this.props.onEnter(value, checked)
+  }
+
   handleOnBlur = event => {
     this.props.onBlur(event)
   }
 
   handleOnFocus = event => {
     this.props.onFocus(event)
+  }
+
+  handleOnEnterWithContext = contextProps => {
+    return (...args) => {
+      this.handleOnEnter.apply(null, args)
+
+      if (contextProps.onEnter) {
+        contextProps.onEnter.apply(null, args)
+      }
+    }
   }
 
   handleOnBlurWithContext = contextProps => {
@@ -169,6 +185,7 @@ class Choice extends React.PureComponent {
       onBlur: this.handleOnBlurWithContext(contextProps),
       onFocus: this.handleOnFocusWithContext(contextProps),
       onChange: this.handleOnChangeWithContext(contextProps),
+      onEnter: this.handleOnEnterWithContext(contextProps),
       readOnly,
       state,
       type,
@@ -274,6 +291,7 @@ Choice.defaultProps = {
   onBlur: noop,
   onChange: noop,
   onFocus: noop,
+  onEnter: noop,
   inputRef: noop,
   innerRef: noop,
   isBlock: false,
@@ -315,6 +333,8 @@ Choice.propTypes = {
   onChange: PropTypes.func,
   /** Callback when the input is focused. */
   onFocus: PropTypes.func,
+  /** Callback when pressing enter whenthe input is focused. */
+  onEnter: PropTypes.func,
   /** Disable editing of the input. */
   readOnly: PropTypes.bool,
   /** Stacks the input above the label. */

--- a/src/components/Choice/Choice.test.js
+++ b/src/components/Choice/Choice.test.js
@@ -203,6 +203,22 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalledWith('Value', false)
     wrapper.unmount()
   })
+
+  test('onEnter changes value and triggers callback', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Choice onEnter={spy} value="Value" checked />)
+    const input = wrapper.find('input')
+
+    input.simulate('keydown', { key: 'Enter' })
+
+    expect(spy).toHaveBeenCalledWith('Value', false)
+
+    wrapper.setProps({ checked: false })
+    input.simulate('keydown', { key: 'Enter' })
+
+    expect(spy).toHaveBeenCalledWith('Value', true)
+    wrapper.unmount()
+  })
 })
 
 describe('States', () => {

--- a/src/components/Choice/Choice.test.js
+++ b/src/components/Choice/Choice.test.js
@@ -219,6 +219,22 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalledWith('Value', true)
     wrapper.unmount()
   })
+
+  test('onEnter changes value and triggers callback using space', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Choice onEnter={spy} value="Value" checked />)
+    const input = wrapper.find('input')
+
+    input.simulate('keyup', { key: ' ' })
+
+    expect(spy).toHaveBeenCalledWith('Value', false)
+
+    wrapper.setProps({ checked: false })
+    input.simulate('keyup', { key: ' ' })
+
+    expect(spy).toHaveBeenCalledWith('Value', true)
+    wrapper.unmount()
+  })
 })
 
 describe('States', () => {

--- a/src/components/Choice/ChoiceInput.test.js
+++ b/src/components/Choice/ChoiceInput.test.js
@@ -72,6 +72,16 @@ describe('Events', () => {
 
     expect(spy).toHaveBeenCalled()
   })
+
+  test('Can trigger onEnter callback', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input onEnter={spy} checked value="Value" />)
+    const input = wrapper.find('input')
+
+    input.simulate('keydown', { key: 'Enter' })
+
+    expect(spy).toHaveBeenCalled()
+  })
 })
 
 describe('States', () => {

--- a/src/components/Choice/ChoiceInput.test.js
+++ b/src/components/Choice/ChoiceInput.test.js
@@ -82,6 +82,16 @@ describe('Events', () => {
 
     expect(spy).toHaveBeenCalled()
   })
+
+  test('Can trigger onEnter callback using space', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input onEnter={spy} checked value="Value" />)
+    const input = wrapper.find('input')
+
+    input.simulate('keyup', { key: ' ' })
+
+    expect(spy).toHaveBeenCalled()
+  })
 })
 
 describe('States', () => {

--- a/src/components/ChoiceGroup/ChoiceGroup.jsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.jsx
@@ -19,7 +19,7 @@ class ChoiceGroup extends React.Component {
 
     this.state = {
       id: uniqueID(),
-      selectedValue: props.value ? [].concat(props.value) : [],
+      selectedValue: this.getInitialSelectedValue(props),
     }
   }
 
@@ -37,9 +37,20 @@ class ChoiceGroup extends React.Component {
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.value !== this.props.value) {
       this.setState({
-        selectedValue: [].concat(nextProps.value),
+        selectedValue: this.getInitialSelectedValue(nextProps),
       })
     }
+  }
+
+  getInitialSelectedValue(props) {
+    const { value, multiSelect } = props
+    let selectedValue = value ? [].concat(value) : []
+
+    if (!multiSelect && selectedValue.length > 1) {
+      selectedValue = selectedValue[0]
+    }
+
+    return selectedValue
   }
 
   getMultiSelectValue(value, checked) {
@@ -89,12 +100,17 @@ class ChoiceGroup extends React.Component {
 
   getChildrenMarkup = () => {
     const { isResponsive, choiceMaxWidth, children } = this.props
-    const { id } = this.state
+    const { id, selectedValue } = this.state
 
     return (
       children &&
       React.Children.map(children, (child, index) => {
         const key = get(child, 'props.id') || `${id}-${index}`
+        const clone = React.isValidElement(child)
+          ? React.cloneElement(child, {
+              checked: selectedValue.includes(child.props.value),
+            })
+          : child
 
         return (
           <FormGroup.Choice
@@ -102,7 +118,7 @@ class ChoiceGroup extends React.Component {
             maxWidth={choiceMaxWidth}
             isResponsive={isResponsive}
           >
-            {child}
+            {clone}
           </FormGroup.Choice>
         )
       })

--- a/src/components/ChoiceGroup/ChoiceGroup.jsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.jsx
@@ -63,6 +63,16 @@ class ChoiceGroup extends React.Component {
     onChange(selectedValue)
   }
 
+  handleOnEnter = (value, checked) => {
+    const { multiSelect, onEnter } = this.props
+    const selectedValue = multiSelect
+      ? this.getMultiSelectValue(value, checked)
+      : [value]
+
+    this.setState({ selectedValue })
+    onEnter(selectedValue)
+  }
+
   getContextProps = () => {
     const { onBlur, onFocus, name } = this.props
     const { selectedValue } = this.state
@@ -70,6 +80,7 @@ class ChoiceGroup extends React.Component {
     return {
       onBlur,
       onChange: this.handleOnChange,
+      onEnter: this.handleOnEnter,
       onFocus,
       name,
       selectedValue,
@@ -109,6 +120,7 @@ class ChoiceGroup extends React.Component {
       onBlur,
       onChange,
       onFocus,
+      onEnter,
       multiSelect,
       name,
       ...rest
@@ -147,6 +159,7 @@ ChoiceGroup.defaultProps = {
   onBlur: noop,
   onChange: noop,
   onFocus: noop,
+  onEnter: noop,
   multiSelect: true,
 }
 
@@ -168,6 +181,7 @@ ChoiceGroup.propTypes = {
   onChange: PropTypes.func,
   /** Callback when an input is focused. */
   onFocus: PropTypes.func,
+  onEnter: PropTypes.func,
   /** The default value of input group. */
   value: PropTypes.any,
   /** Allow multiple choice selection */

--- a/src/components/ChoiceGroup/ChoiceGroup.test.js
+++ b/src/components/ChoiceGroup/ChoiceGroup.test.js
@@ -106,7 +106,23 @@ describe('ChoiceGroup', () => {
 
       input.simulate('keydown', { key: 'Enter' })
 
-      expect(spy).toHaveBeenCalledWith(['1'])
+      expect(spy).toHaveBeenCalled()
+    })
+
+    test('Can trigger onEnter callback with space', () => {
+      const spy = jest.fn()
+      const wrapper = mount(
+        <ChoiceGroup onEnter={spy}>
+          <Radio value="1" />
+          <Radio value="2" />
+          <Radio value="3" />
+        </ChoiceGroup>
+      )
+      const input = wrapper.find('.c-Radio').first().find('input')
+
+      input.simulate('keyup', { key: ' ' })
+
+      expect(spy).toHaveBeenCalled()
     })
   })
 

--- a/src/components/ChoiceGroup/ChoiceGroup.test.js
+++ b/src/components/ChoiceGroup/ChoiceGroup.test.js
@@ -92,6 +92,22 @@ describe('ChoiceGroup', () => {
 
       expect(spy).toHaveBeenCalledWith(['1'])
     })
+
+    test('Can trigger onEnter callback', () => {
+      const spy = jest.fn()
+      const wrapper = mount(
+        <ChoiceGroup onEnter={spy}>
+          <Radio value="1" />
+          <Radio value="2" />
+          <Radio value="3" />
+        </ChoiceGroup>
+      )
+      const input = wrapper.find('.c-Radio').first().find('input')
+
+      input.simulate('keydown', { key: 'Enter' })
+
+      expect(spy).toHaveBeenCalledWith(['1'])
+    })
   })
 
   describe('MultiSelect', () => {

--- a/src/components/ChoiceGroup/ChoiceGroup.test.js
+++ b/src/components/ChoiceGroup/ChoiceGroup.test.js
@@ -4,7 +4,6 @@ import ChoiceGroup from './ChoiceGroup'
 import FormGroup from '../FormGroup'
 import Checkbox from '../Checkbox'
 import Radio from '../Radio'
-import RadioCard from '../RadioCard'
 
 describe('ChoiceGroup', () => {
   describe('ClassName', () => {
@@ -28,21 +27,6 @@ describe('ChoiceGroup', () => {
       expect(el.length).toBeTruthy()
     })
 
-    test('Renders multiple child content', () => {
-      const wrapper = mount(
-        <ChoiceGroup>
-          <Radio />
-          <Radio />
-          <Radio />
-        </ChoiceGroup>
-      )
-      const component = wrapper.find(ChoiceGroup)
-      const el = wrapper.find(Radio)
-
-      expect(el.length).toBe(3)
-      expect(component.hasClass('is-multi-select')).toBeFalsy()
-    })
-
     test('Wraps child component in a FormGroup.Choice', () => {
       const wrapper = mount(
         <ChoiceGroup>
@@ -58,22 +42,6 @@ describe('ChoiceGroup', () => {
       expect(radio.length).toBe(3)
       expect(formGroup.first().find(Radio).length).toBeTruthy()
     })
-
-    test('Can render RadioCard components', () => {
-      const wrapper = mount(
-        <ChoiceGroup>
-          <RadioCard />
-          <RadioCard />
-          <RadioCard />
-        </ChoiceGroup>
-      )
-      const formGroup = wrapper.find(FormGroup.Choice)
-      const radio = wrapper.find(RadioCard)
-
-      expect(formGroup.length).toBe(3)
-      expect(radio.length).toBe(3)
-      expect(formGroup.first().find(RadioCard).length).toBeTruthy()
-    })
   })
 
   describe('Events', () => {
@@ -86,10 +54,7 @@ describe('ChoiceGroup', () => {
           <Radio />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find('.c-Radio')
-        .first()
-        .find('input')
+      const input = wrapper.find('.c-Radio').first().find('input')
 
       input.simulate('blur')
 
@@ -105,10 +70,7 @@ describe('ChoiceGroup', () => {
           <Radio />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find('.c-Radio')
-        .first()
-        .find('input')
+      const input = wrapper.find('.c-Radio').first().find('input')
 
       input.simulate('focus')
 
@@ -124,29 +86,11 @@ describe('ChoiceGroup', () => {
           <Radio value="3" />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find('.c-Radio')
-        .first()
-        .find('input')
+      const input = wrapper.find('.c-Radio').first().find('input')
 
-      input.simulate('change')
+      input.simulate('change', { target: { checked: true } })
 
-      expect(spy).toHaveBeenCalledWith('1')
-    })
-
-    test('Can trigger onChange callback for multiSelect', () => {
-      const spy = jest.fn()
-      const wrapper = mount(
-        <ChoiceGroup onChange={spy}>
-          <Checkbox value="1" />
-          <Checkbox value="2" />
-          <Checkbox value="3" />
-        </ChoiceGroup>
-      )
-      const input = wrapper.find('input')
-
-      input.last().simulate('change', { target: { checked: true } })
-      expect(spy).toHaveBeenCalledWith(['3'])
+      expect(spy).toHaveBeenCalledWith(['1'])
     })
   })
 
@@ -166,7 +110,7 @@ describe('ChoiceGroup', () => {
 
     test('Does not have multiSelect className, if applicable', () => {
       const wrapper = mount(
-        <ChoiceGroup value="katinka">
+        <ChoiceGroup value="katinka" multiSelect={false}>
           <Radio value="derek" />
           <Radio value="hansel" />
           <Radio value="mugatu" />
@@ -177,43 +121,50 @@ describe('ChoiceGroup', () => {
       expect(o.hasClass('is-multi-select')).not.toBeTruthy()
     })
 
-    test('Does not multiSelect for Radio children', () => {
+    test('Can multiSelect', () => {
+      const spy = jest.fn()
       const wrapper = mount(
-        <ChoiceGroup value="katinka">
-          <Radio value="derek" />
-          <Radio value="hansel" />
-          <Radio value="mugatu" />
-        </ChoiceGroup>
-      )
-      const o = wrapper.find(ChoiceGroup)
-
-      expect(o.state().multiSelect).toBeFalsy()
-    })
-
-    test('Does auto-multiSelect for Checkbox children', () => {
-      const wrapper = mount(
-        <ChoiceGroup value="katinka">
+        <ChoiceGroup onChange={spy}>
           <Checkbox value="derek" />
           <Checkbox value="hansel" />
           <Checkbox value="mugatu" />
         </ChoiceGroup>
       )
-      const o = wrapper.find(ChoiceGroup)
+      const input = wrapper.find(Checkbox).at(0).find('input')
+      const input2 = wrapper.find(Checkbox).at(1).find('input')
+      const input3 = wrapper.find(Checkbox).at(2).find('input')
 
-      expect(o.state().multiSelect).toBeTruthy()
+      input.simulate('change', { target: { checked: true } })
+      expect(spy).toHaveBeenCalledWith(['derek'])
+
+      input2.simulate('change', { target: { checked: true } })
+      expect(spy).toHaveBeenCalledWith(['derek', 'hansel'])
+
+      input3.simulate('change', { target: { checked: true } })
+      expect(spy).toHaveBeenCalledWith(['derek', 'hansel', 'mugatu'])
     })
 
-    test('Can disable multiSelect for Checbox children, if defined', () => {
+    test('multiSelect can be turned off', () => {
+      const spy = jest.fn()
       const wrapper = mount(
-        <ChoiceGroup value="katinka" multiSelect={false}>
+        <ChoiceGroup onChange={spy} multiSelect={false}>
           <Checkbox value="derek" />
           <Checkbox value="hansel" />
           <Checkbox value="mugatu" />
         </ChoiceGroup>
       )
-      const o = wrapper.find(ChoiceGroup)
+      const input = wrapper.find(Checkbox).at(0).find('input')
+      const input2 = wrapper.find(Checkbox).at(1).find('input')
+      const input3 = wrapper.find(Checkbox).at(2).find('input')
 
-      expect(o.state().multiSelect).not.toBeTruthy()
+      input.simulate('change', { target: { checked: true } })
+      expect(spy).toHaveBeenCalledWith(['derek'])
+
+      input2.simulate('change', { target: { checked: true } })
+      expect(spy).toHaveBeenCalledWith(['hansel'])
+
+      input3.simulate('change', { target: { checked: true } })
+      expect(spy).toHaveBeenCalledWith(['mugatu'])
     })
   })
 
@@ -227,12 +178,7 @@ describe('ChoiceGroup', () => {
         </ChoiceGroup>
       )
 
-      expect(
-        wrapper
-          .find('input')
-          .first()
-          .props().name
-      ).toBe('MUGATU')
+      expect(wrapper.find('input').first().props().name).toBe('MUGATU')
     })
   })
 
@@ -263,22 +209,6 @@ describe('ChoiceGroup', () => {
       const radios = wrapper.find('input')
 
       expect(radios.get(0).props.checked).toBeFalsy()
-      expect(radios.get(1).props.checked).toBeTruthy()
-      expect(radios.get(2).props.checked).toBeFalsy()
-    })
-
-    test('Can check multiple values', () => {
-      const values = ['derek', 'hansel']
-      const wrapper = mount(
-        <ChoiceGroup value={values}>
-          <Radio value="derek" />
-          <Radio value="hansel" />
-          <Radio value="mugatu" />
-        </ChoiceGroup>
-      )
-      const radios = wrapper.find('input')
-
-      expect(radios.get(0).props.checked).toBeTruthy()
       expect(radios.get(1).props.checked).toBeTruthy()
       expect(radios.get(2).props.checked).toBeFalsy()
     })

--- a/src/components/CopyCode/CopyCode.jsx
+++ b/src/components/CopyCode/CopyCode.jsx
@@ -16,6 +16,7 @@ require('prismjs/components/prism-java')
 require('prismjs/components/prism-swift')
 require('prismjs/components/prism-c')
 require('prismjs/components/prism-objectivec')
+require('prismjs/components/prism-markup')
 
 class CopyCode extends React.PureComponent {
   node
@@ -69,7 +70,9 @@ class CopyCode extends React.PureComponent {
   }
 
   getCodeMarkup() {
-    const { code, language } = this.props
+    const { code } = this.props
+    const language =
+      this.props.language === 'html' ? 'markup' : this.props.language
 
     function createMarkup() {
       const html = Prism.highlight(code, Prism.languages[language], language)
@@ -139,7 +142,15 @@ CopyCode.propTypes = {
   /** Retrieves the DOM node. */
   innerRef: PropTypes.func,
   /** Language syntax */
-  language: PropTypes.oneOf([`c`, `java`, `javascript`, `objectivec`, `swift`]),
+  language: PropTypes.oneOf([
+    'c',
+    'java',
+    'javascript',
+    'objectivec',
+    'swift',
+    'html',
+    'markup',
+  ]),
   /** Sets the max width of the container. */
   maxWidth: PropTypes.number,
   /** Callback function when the copy button is clicked. */

--- a/src/components/Input/Input.BackdropV2.css.js
+++ b/src/components/Input/Input.BackdropV2.css.js
@@ -20,11 +20,11 @@ export const config = {
   transition:
     'box-shadow 100ms ease, background-color 100ms ease, border-color 100ms ease',
   custom: {
-    backgroundColor: getColor('grey.400'),
+    backgroundColor: getColor('grey.500'),
     backgroundColorFocused: getColor('grey.500'),
-    borderColor: getColor('grey.400'),
-    backgroundColorFill: getColor('green.500'),
-    borderColorFill: getColor('green.500'),
+    borderColor: getColor('grey.500'),
+    backgroundColorFill: getColor('blue.500'),
+    borderColorFill: getColor('blue.500'),
     boxShadow: 'none',
   },
 }

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -778,10 +778,10 @@ Input.propTypes = {
   hintText: PropTypes.any,
   /** ID for the input. */
   id: PropTypes.string,
-  /** Text to appear before the input. */
-  inlinePrefix: PropTypes.string,
-  /** Text to after before the input. */
-  inlineSuffix: PropTypes.string,
+  /** Text or component (usually an Icon) to render before the input. */
+  inlinePrefix: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  /** Text or component (usually an Icon) to render after the input. */
+  inlineSuffix: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /** Retrieves the `input` DOM node. */
   inputRef: PropTypes.func,
   /** Helps render component without right borders. */

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -767,7 +767,7 @@ Input.propTypes = {
   /** Icon that renders when the state is `error`. */
   errorIcon: PropTypes.string,
   /** Error message that renders into a Tooltip. */
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   /** Determines the amount of time (`ms`) for the component to focus on mount. */
   forceAutoFocusTimeout: PropTypes.number,
   /** If `true` and `enter + special` key is pressed, a return will be inserted */
@@ -839,7 +839,7 @@ Input.propTypes = {
   /** Determines the size of the input. */
   size: PropTypes.oneOf(['xs', 'xssm', 'sm', 'md', 'lg']),
   /** Change input to state color. */
-  state: PropTypes.oneOf(['error', 'success', 'warning']),
+  state: PropTypes.oneOf(['error', 'success', 'warning', '']),
   /** Component to render after the input. */
   suffix: PropTypes.any,
   /** Determines the input type. */

--- a/src/components/Radio/Radio.stories.mdx
+++ b/src/components/Radio/Radio.stories.mdx
@@ -47,10 +47,11 @@ import Radio from './'
 
 <Preview>
   <Story name="In a group">
-    <ChoiceGroup>
+    <ChoiceGroup multiSelect={false}>
       <Radio
         label="Derek"
         value="derek"
+        name="derek"
         helpText="Help description"
         disabled={boolean('disabled', false)}
         stacked={boolean('stacked', false)}
@@ -63,6 +64,7 @@ import Radio from './'
       <Radio
         label="Hansel"
         value="hansel"
+        name="hansel"
         helpText="Help description"
         disabled={boolean('disabled', false)}
         stacked={boolean('stacked', false)}
@@ -75,6 +77,7 @@ import Radio from './'
       <Radio
         label="Mugatu"
         value="mugatu"
+        name="mugatu"
         helpText="Help description"
         disabled={boolean('disabled', false)}
         stacked={boolean('stacked', false)}

--- a/src/components/RadioCard/RadioCard.css.js
+++ b/src/components/RadioCard/RadioCard.css.js
@@ -1,105 +1,64 @@
 import styled from 'styled-components'
-
 import { getColor } from '../../styles/utilities/color'
 import Heading from '../Heading'
 import Text from '../Text'
 
-export const config = {
-  boxShadow: `
-    0px 0px 0px 1px rgba(0, 0, 0, 0.05),
-    0px 5px 10px 0px ${getColor('grey.300')},
-    0px 3px 3px 0px rgba(0, 0, 0, 0.05)
-  `,
-  boxShadowHover: `
-    0px 0px 0px 1px ${getColor('grey.500')},
-    0px 5px 10px 1px ${getColor('grey.300')},
-    0px 3px 3px 0px rgba(0, 0, 0, 0.05)
-  `,
-  borderRadius: 4,
-  focusOutlineWidth: '2px',
-  focusOutlineColor: getColor('blue.500'),
-  iconColor: getColor('grey.600'),
-  iconColorChecked: getColor('charcoal.500'),
-  iconWrapperSize: 52,
-  iconWrapperMargin: 5,
-  padding: '5px 12px 15px',
-  maxWidth: '75px',
-  width: '100%',
-  transition: 'box-shadow 200ms linear',
-  willChange: 'box-shadow, border',
-}
-
 export const RadioCardUI = styled('label')`
-  align-items: center;
-  border-radius: 4px;
-  /* box-shadow: ${config.boxShadow}; */
-  border: 1px solid rgba(0, 0, 0, 0.04);
-  box-shadow: 0px 5px 8px rgba(99, 116, 134, 0.03), 0px 2px 8px rgba(0, 0, 0, 0.04);
-  cursor: pointer;
+  box-sizing: border-box;
+  position: relative;
   display: flex;
+  align-items: center;
   flex-direction: column;
   justify-content: center;
-  max-width: ${({ maxWidth }) => (maxWidth ? maxWidth : config.maxWidth)};
+  width: 100%;
+  max-width: ${({ maxWidth }) => (maxWidth ? maxWidth : '80px')};
   min-width: 0;
-  padding: ${config.padding};
-  position: relative;
-  width: ${config.width};
+  min-height: ${({ withContent, withHeading }) =>
+    withHeading || withContent ? 'auto' : '100px'};
+  padding: 5px 12px 15px;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  box-shadow: 0px 5px 8px rgba(99, 116, 134, 0.03),
+    0px 2px 8px rgba(0, 0, 0, 0.04);
   transition: all 0.15s;
-  will-change: ${config.willChange};
+  will-change: box-shadow, border;
+  cursor: pointer;
 
   &:hover {
     border: 1px solid ${getColor('grey.500')};
-    box-shadow: 0px 5px 8px rgba(99, 116, 134, 0.03), 0px 2px 8px rgba(0, 0, 0, 0.04);
-    transform: translateY(-2px)
+    box-shadow: 0px 5px 8px rgba(99, 116, 134, 0.03),
+      0px 2px 8px rgba(0, 0, 0, 0.04);
+    transform: translateY(-2px);
   }
 
   &.is-focused,
   &.is-focused.is-checked,
   &:focus-within,
   &.is-checked:focus-within {
-    border: 2px solid ${getColor('blue.500')};
+    border-color: transparent;
     border-radius: 7px;
+    box-shadow: 0px 0px 0 2px ${getColor('blue.500')};
   }
 
   &.is-checked {
     border: 1px solid ${getColor('grey.500')};
-    box-shadow: 0px 5px 8px rgba(99, 116, 134, 0.03), 0px 2px 8px rgba(0, 0, 0, 0.04);
+    box-shadow: 0px 5px 8px rgba(99, 116, 134, 0.03),
+      0px 2px 8px rgba(0, 0, 0, 0.04);
   }
 `
 
 export const IconWrapperUI = styled('div')`
   align-items: center;
-  color: ${config.iconColor};
-  display: flex;
-  height: ${config.iconWrapperSize}px;
   justify-content: center;
-  margin-bottom: ${config.iconWrapperMargin}px;
-  width: ${config.iconWrapperSize}px;
+  display: flex;
+  width: 52px;
+  height: 52px;
+  margin-bottom: ${({ withContent, withHeading }) =>
+    withHeading || withContent ? '0' : '5px'};
+  color: ${getColor('charcoal.200')};
 
   &.is-checked {
-    color: ${config.iconColorChecked};
-  }
-`
-
-export const FocusUI = styled('div')`
-  animation: BackdropFocusFadeIn 200ms;
-  border-radius: ${config.borderRadius + 2}px;
-  bottom: -3px;
-  box-shadow: 0 0 0 ${config.focusOutlineWidth} ${config.focusOutlineColor};
-  left: -3px;
-  pointer-events: none;
-  position: absolute;
-  right: -3px;
-  top: -3px;
-  z-index: 1;
-
-  @keyframes BackdropFocusFadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
+    color: ${getColor('charcoal.500')};
   }
 `
 
@@ -112,7 +71,7 @@ export const HeadingUI = styled(Heading)`
 
 export const ContentUI = styled(Text)`
   font-size: 13px;
-  margin-bottom: 25px;
+  margin-bottom: 10px;
   color: ${getColor('charcoal.200')};
   text-align: center;
 `

--- a/src/components/RadioCard/RadioCard.css.js
+++ b/src/components/RadioCard/RadioCard.css.js
@@ -26,13 +26,15 @@ export const config = {
   maxWidth: '75px',
   width: '100%',
   transition: 'box-shadow 200ms linear',
-  willChange: 'box-shadow',
+  willChange: 'box-shadow, border',
 }
 
 export const RadioCardUI = styled('label')`
   align-items: center;
-  border-radius: ${config.borderRadius}px;
-  box-shadow: ${config.boxShadow};
+  border-radius: 4px;
+  /* box-shadow: ${config.boxShadow}; */
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  box-shadow: 0px 5px 8px rgba(99, 116, 134, 0.03), 0px 2px 8px rgba(0, 0, 0, 0.04);
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -42,15 +44,26 @@ export const RadioCardUI = styled('label')`
   padding: ${config.padding};
   position: relative;
   width: ${config.width};
-  transition: ${config.transition};
+  transition: all 0.15s;
   will-change: ${config.willChange};
 
   &:hover {
-    box-shadow: ${config.boxShadowHover};
+    border: 1px solid ${getColor('grey.500')};
+    box-shadow: 0px 5px 8px rgba(99, 116, 134, 0.03), 0px 2px 8px rgba(0, 0, 0, 0.04);
+    transform: translateY(-2px)
+  }
+
+  &.is-focused,
+  &.is-focused.is-checked,
+  &:focus-within,
+  &.is-checked:focus-within {
+    border: 2px solid ${getColor('blue.500')};
+    border-radius: 7px;
   }
 
   &.is-checked {
-    box-shadow: ${config.boxShadowHover};
+    border: 1px solid ${getColor('grey.500')};
+    box-shadow: 0px 5px 8px rgba(99, 116, 134, 0.03), 0px 2px 8px rgba(0, 0, 0, 0.04);
   }
 `
 

--- a/src/components/RadioCard/RadioCard.jsx
+++ b/src/components/RadioCard/RadioCard.jsx
@@ -11,7 +11,6 @@ import Radio from '../Radio'
 import {
   RadioCardUI,
   IconWrapperUI,
-  FocusUI,
   ContentUI,
   HeadingUI,
 } from './RadioCard.css'
@@ -26,26 +25,26 @@ class RadioCard extends React.PureComponent {
 
     this.state = {
       id: props.id || uniqueID(),
-      isFocused: props.isFocused,
+    }
+
+    this.radioCardRef = React.createRef()
+  }
+
+  componentDidMount() {
+    if (this.props.isFocused && this.inputNode) {
+      this.inputNode.focus()
     }
   }
 
   handleOnBlur = event => {
-    this.setState({
-      isFocused: false,
-    })
+    this.radioCardRef.current.classList.remove('is-focused')
     this.props.onBlur(event)
   }
 
   handleOnFocus = event => {
-    this.showFocus()
+    this.radioCardRef.current.focus()
+    this.radioCardRef.current.classList.add('is-focused')
     this.props.onFocus(event)
-  }
-
-  showFocus = () => {
-    this.setState({
-      isFocused: true,
-    })
   }
 
   getContentMarkup = () => {
@@ -102,12 +101,6 @@ class RadioCard extends React.PureComponent {
     )
   }
 
-  getFocusMarkup = () => {
-    const { isFocused } = this.state
-
-    return isFocused && <FocusUI className="c-RadioCard__focus" />
-  }
-
   getCardMarkup = contextProps => {
     const {
       checked,
@@ -115,12 +108,13 @@ class RadioCard extends React.PureComponent {
       content,
       heading,
       icon,
+      isFocused,
       maxWidth,
       title,
       value,
       ...rest
     } = this.props
-    const { id, isFocused } = this.state
+    const { id } = this.state
 
     const isChecked =
       (contextProps.selectedValue &&
@@ -140,6 +134,7 @@ class RadioCard extends React.PureComponent {
         className={componentClassName}
         title={title}
         maxWidth={maxWidth}
+        ref={this.radioCardRef}
       >
         <IconWrapperUI
           className={classNames(
@@ -161,7 +156,6 @@ class RadioCard extends React.PureComponent {
           onFocus={this.handleOnFocus}
           value={value}
         />
-        {this.getFocusMarkup()}
       </RadioCardUI>
     )
   }

--- a/src/components/RadioCard/RadioCard.jsx
+++ b/src/components/RadioCard/RadioCard.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import Icon from '../Icon'
 import ChoiceGroupContext from '../ChoiceGroup/ChoiceGroup.Context'
 import { classNames } from '../../utilities/classNames'
-import { includes } from '../../utilities/arrays'
 import { createUniqueIDFactory } from '../../utilities/id'
 import { isFunction, isString } from '../../utilities/is'
 import { noop } from '../../utilities/other'
@@ -32,6 +31,7 @@ class RadioCard extends React.PureComponent {
 
   componentDidMount() {
     if (this.props.isFocused && this.inputNode) {
+      this.radioCardRef.current.classList.add('is-focused')
       this.inputNode.focus()
     }
   }
@@ -42,7 +42,6 @@ class RadioCard extends React.PureComponent {
   }
 
   handleOnFocus = event => {
-    this.radioCardRef.current.focus()
     this.radioCardRef.current.classList.add('is-focused')
     this.props.onFocus(event)
   }
@@ -116,15 +115,9 @@ class RadioCard extends React.PureComponent {
     } = this.props
     const { id } = this.state
 
-    const isChecked =
-      (contextProps.selectedValue &&
-        includes(contextProps.selectedValue, value)) ||
-      checked
-
     const componentClassName = classNames(
       'c-RadioCard',
-      isChecked && 'is-checked',
-      isFocused && 'is-focused',
+      checked && 'is-checked',
       className
     )
 
@@ -133,14 +126,18 @@ class RadioCard extends React.PureComponent {
         htmlFor={id}
         className={componentClassName}
         title={title}
+        withHeading={Boolean(heading)}
+        withContent={Boolean(content)}
         maxWidth={maxWidth}
         ref={this.radioCardRef}
       >
         <IconWrapperUI
           className={classNames(
             'c-RadioCard__iconWrapper',
-            isChecked && 'is-checked'
+            checked && 'is-checked'
           )}
+          withHeading={Boolean(heading)}
+          withContent={Boolean(content)}
         >
           {this.getIconMarkup()}
         </IconWrapperUI>
@@ -148,7 +145,7 @@ class RadioCard extends React.PureComponent {
         {this.getContentMarkup()}
         <Radio
           {...rest}
-          checked={isChecked}
+          checked={checked}
           kind="custom"
           id={id}
           inputRef={this.setInputNodeRef}

--- a/src/components/RadioCard/RadioCard.stories.mdx
+++ b/src/components/RadioCard/RadioCard.stories.mdx
@@ -28,12 +28,8 @@ This component provides richer context to the of the default HTML `<input>` `rad
       multiSelect={false}
     >
       <RadioCard icon="fab-chat" value="chat" />
-      <RadioCard
-        icon="fab-antenna"
-        value="antenna"
-        isFocused={boolean('isFocused', true)}
-      />
-      <RadioCard icon="fab-buoy" value="buoy" />
+      <RadioCard icon="fab-antenna" value="antenna" />
+      <RadioCard icon="fab-buoy" value="buoy" isFocused />
       <RadioCard icon="fab-search" value="search" />
       <RadioCard icon="fab-question" value="question" />
     </ChoiceGroup>
@@ -64,7 +60,7 @@ This component provides richer context to the of the default HTML `<input>` `rad
       choiceMaxWidth="214px"
       isResponsive
       multiSelect={boolean('multiSelect', false)}
-      value={['chat']}
+      value={['chat', 'buoy']}
     >
       <RadioCard
         icon="fab-chat"

--- a/src/components/RadioCard/RadioCard.stories.mdx
+++ b/src/components/RadioCard/RadioCard.stories.mdx
@@ -25,10 +25,14 @@ This component provides richer context to the of the default HTML `<input>` `rad
       align="horizontal"
       value="chat"
       isResponsive
-      multiSelect={boolean('multiSelect', false)}
+      multiSelect={false}
     >
       <RadioCard icon="fab-chat" value="chat" />
-      <RadioCard icon="fab-antenna" value="antenna" />
+      <RadioCard
+        icon="fab-antenna"
+        value="antenna"
+        isFocused={boolean('isFocused', true)}
+      />
       <RadioCard icon="fab-buoy" value="buoy" />
       <RadioCard icon="fab-search" value="search" />
       <RadioCard icon="fab-question" value="question" />
@@ -57,9 +61,10 @@ This component provides richer context to the of the default HTML `<input>` `rad
   <Story name="with headings">
     <ChoiceGroup
       align="horizontal"
-      value="chat"
       choiceMaxWidth="214px"
       isResponsive
+      multiSelect={boolean('multiSelect', false)}
+      value={['chat']}
     >
       <RadioCard
         icon="fab-chat"

--- a/src/components/RadioCard/RadioCard.stories.mdx
+++ b/src/components/RadioCard/RadioCard.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
+import { boolean } from '@storybook/addon-knobs'
 import { ChoiceGroup } from '../index'
 import RadioCard from './'
 
@@ -20,7 +21,12 @@ This component provides richer context to the of the default HTML `<input>` `rad
 
 <Preview>
   <Story name="default">
-    <ChoiceGroup align="horizontal" value="chat" isResponsive>
+    <ChoiceGroup
+      align="horizontal"
+      value="chat"
+      isResponsive
+      multiSelect={boolean('multiSelect', false)}
+    >
       <RadioCard icon="fab-chat" value="chat" />
       <RadioCard icon="fab-antenna" value="antenna" />
       <RadioCard icon="fab-buoy" value="buoy" />

--- a/src/components/RadioCard/RadioCard.test.js
+++ b/src/components/RadioCard/RadioCard.test.js
@@ -150,35 +150,24 @@ describe('Ref', () => {
 describe('Focus', () => {
   test('Does not render focus, by default', () => {
     const wrapper = mount(<RadioCard />)
-    const o = wrapper.find('.c-RadioCard__focus').first()
+    const o = wrapper.find('.is-focused').first()
 
     expect(o.length).toBe(0)
   })
 
   test('Can preset focus using props', () => {
     const wrapper = mount(<RadioCard isFocused />)
-    const o = wrapper.find('.c-RadioCard__focus').first()
+    const o = wrapper.find('.is-focused').first()
 
     expect(o.length).toBeTruthy()
   })
 
-  test('Renders FocusUI on blur/focus of input', () => {
+  test('Adds and removes focus className, if focused or blurred', () => {
     const wrapper = mount(<RadioCard />)
-    const input = wrapper.find('input')
-
-    input.simulate('focus')
-
-    expect(wrapper.find('.c-RadioCard__focus').first().length).toBeTruthy()
-
-    input.simulate('blur')
-
-    expect(wrapper.find('.c-RadioCard__focus').first().length).toBe(0)
-  })
-
-  test('Adds focus className, if focused', () => {
-    const wrapper = mount(<RadioCard isFocused />)
-
-    expect(wrapper.getDOMNode().classList.contains('is-focused')).toBe(true)
+    wrapper.find('input').first().simulate('focus')
+    expect(wrapper.getDOMNode().classList.contains('is-focused')).toBeTruthy()
+    wrapper.find('input').first().simulate('blur')
+    expect(wrapper.getDOMNode().classList.contains('is-focused')).toBeFalsy()
   })
 })
 

--- a/src/components/RadioCard/RadioCard.test.js
+++ b/src/components/RadioCard/RadioCard.test.js
@@ -157,15 +157,16 @@ describe('Focus', () => {
 
   test('Can preset focus using props', () => {
     const wrapper = mount(<RadioCard isFocused />)
-    const o = wrapper.find('.is-focused').first()
 
-    expect(o.length).toBeTruthy()
+    expect(wrapper.getDOMNode().classList.contains('is-focused')).toBeTruthy()
   })
 
   test('Adds and removes focus className, if focused or blurred', () => {
     const wrapper = mount(<RadioCard />)
+
     wrapper.find('input').first().simulate('focus')
     expect(wrapper.getDOMNode().classList.contains('is-focused')).toBeTruthy()
+
     wrapper.find('input').first().simulate('blur')
     expect(wrapper.getDOMNode().classList.contains('is-focused')).toBeFalsy()
   })

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -456,6 +456,7 @@ Select.propTypes = {
     PropTypes.arrayOf(PropTypes.any),
     PropTypes.object,
     PropTypes.string,
+    PropTypes.number,
   ]),
   /** Placeholder text for the select. */
   placeholder: PropTypes.string,

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -451,10 +451,11 @@ Select.propTypes = {
   onChange: PropTypes.func,
   /** Callback when select is focused. */
   onFocus: PropTypes.func,
-  /** Array of options with the shape: { disabled: PropTypes.bool, label: PropTypes.string,value: PropTypes.string } */
+  /** Array of options with the shape: { disabled: PropTypes.bool, label: PropTypes.string, value: PropTypes.string } */
   options: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.any),
     PropTypes.object,
+    PropTypes.string,
   ]),
   /** Placeholder text for the select. */
   placeholder: PropTypes.string,


### PR DESCRIPTION
# Feature (and problems)

**Feature** 👉 We need a new component, `Checkmark`!

The solution is very similar to `RadioCard`, so much this component could be named `CheckCard`...

`RadioCard` normally gets used with `ChoiceGroup` like so:

```jsx
<ChoiceGroup>
      <RadioCard icon="fab-chat" value="chat" />
      <RadioCard icon="fab-antenna" value="antenna" />
      <RadioCard icon="fab-buoy" value="buoy" />
      <RadioCard icon="fab-search" value="search" />
      <RadioCard icon="fab-question" value="question" />
</ChoiceGroup>
```

We'd like to continue using this pattern

### Problem 1: multiSelect

`ChoiceGroup` has a `multiSelect` option, that like the name indicates allows you to select more than one choice in the group, usually with radio inputs you turn this off and with checkbox you turn it on.

A while back, @cocoabythefire mentioned she was having some issues with this and when we looked at the code we saw that indeed something a little strange was happening here, she managed to fix somehow in place in HS App.

This PR fixes the issue:

- Allows the correct use of `multiSelect` via a prop
- `multiSelect` defaults to `true`, the reason I chose `true` is because in most uses in HS App it was declared as false where needed. I have another PR for HS App (https://github.com/helpscout/hs-app/pull/8824) that adds the prop in the rest of the cases where necessary.
- ChoiceGroup was "magically" setting this for you if it detected a `Radio` or `RadioCard` setting it to `false` in those cases, I removed this because the implementation was brittle and making some assumptions, this can easily be handled by the user by just using the prop manually.


## Problem 2: RadioCard focus

The focus state on RadioCard is broken at the moment in multiple scenarios, and the styles do not match what we have in figma https://www.figma.com/file/Wp9mDxTvWicSTWtezj2ImkMP/HSDS-Product?node-id=2582%3A9509

I removed the `FocusUI` way of rendering the focus state (using a `div` and `setState` under the hood) in favour of a css solution that correctly renders a focus state (try using tab now 😉)

## Problem 3: No keyboard interaction

Now that focus is working properly, pressing Space or Enter on a Choice (RadioCard, Radio, Checkbox) should interact (select/deselect) just like you would expect.

This PR implements this functionality.

## Problem 4: Styles

Besides the focus styles, we had a slight mismatch with styles and animations based on the codepen and figma links below

## Testing

Check the following stories:

- Checkbox: https://deploy-preview-872--hsds-react.netlify.app/?path=/story/%F0%9F%A7%AC-components-forms-checkbox--default-story
- Radio: https://deploy-preview-872--hsds-react.netlify.app/?path=/story/%F0%9F%A7%AC-components-forms-radio--in-a-group
- RadioCard: https://deploy-preview-872--hsds-react.netlify.app/?path=/story/%F0%9F%A7%AC-components-forms-radiocard--with-headings

Test using the keyboard

## Relevant Links
Jira: https://helpscout.atlassian.net/browse/HSDS-157
Spec: https://paper.dropbox.com/doc/Spec-Custom-Avatars-for-Beacon--A4mkPLCiSo7B4lkN3xccvN8rAg-c2gwAHcAr6dvs2amX6qE6
Figma: https://www.figma.com/file/Wp9mDxTvWicSTWtezj2ImkMP/HSDS-Product?node-id=5015%3A49
Codepen prototype: https://codepen.io/team/helpscout/full/5d458fb128e71e612ef1ad7202b178cd


