### PR TITLE
CopyInput can render as a Text Copy Button instead of Copy Icon

### DIFF
--- a/src/components/CopyInput/CopyInput.jsx
+++ b/src/components/CopyInput/CopyInput.jsx
@@ -35,7 +35,7 @@ class CopyInput extends React.PureComponent {
   }
 
   render() {
-    const { className, ...rest } = this.props
+    const { className, buttonLabel, ...rest } = this.props
     const componentClassName = classNames('c-CopyInput', className)
 
     return (
@@ -59,8 +59,8 @@ class CopyInput extends React.PureComponent {
             style={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }}
             tabIndex={'-1'}
             innerRef={node => (this.copyButtonNode = node)}
-            icon="copy-small"
-            label={false}
+            icon={buttonLabel ? null : 'copy-small'}
+            label={buttonLabel}
           />
         }
       />
@@ -69,6 +69,7 @@ class CopyInput extends React.PureComponent {
 }
 
 CopyInput.defaultProps = {
+  buttonLabel: null,
   copyToClipboard: true,
   'data-cy': 'CopyInput',
   innerRef: noop,
@@ -78,6 +79,8 @@ CopyInput.defaultProps = {
 }
 
 CopyInput.propTypes = {
+  /** Button label to use in place of copy icon (default is no label) */
+  buttonLabel: PropTypes.string,
   /** Enables copying to clipboard. */
   copyToClipboard: PropTypes.bool,
   /** Custom class names to be added to the component. */

--- a/src/components/CopyInput/CopyInput.stories.mdx
+++ b/src/components/CopyInput/CopyInput.stories.mdx
@@ -29,6 +29,17 @@ This component renders a content with the ability to copy to clipboard, powered 
   </Story>
 </Preview>
 
+<Preview>
+  <Story name="text button">
+    <CopyInput
+      value="testing"
+      onCopy={action('Copy')}
+      readOnly={boolean('readOnly', false)}
+      buttonLabel={'Copy'}
+    />
+  </Story>
+</Preview>
+
 #### Reference
 
 - **Designer**: Nikki

--- a/src/components/CopyInput/CopyInput.test.js
+++ b/src/components/CopyInput/CopyInput.test.js
@@ -20,6 +20,19 @@ describe('ClassName', () => {
   })
 })
 
+describe('Button label', () => {
+  test('Can display with a text copy button', () => {
+    const buttonLabel = 'Copy Me'
+    const wrapper = render(<CopyInput buttonLabel={buttonLabel} />)
+    const el = wrapper.find('.c-CopyInput')
+
+    expect(el.length).toBeTruthy()
+
+    const buttonText = wrapper.find('.c-CopyButton').text()
+    expect(buttonText).toContain(buttonLabel)
+  })
+})
+
 describe('Copy button', () => {
   test('Clicking copy will call the onCopy handler', () => {
     const onCopySpy = jest.fn()


### PR DESCRIPTION
# Problem/Feature

In HSDS v3 we lost the ability to display CopyInput with a text button. See Jira Issue: https://helpscout.atlassian.net/browse/HSDS-159

# Solution

Adds an optional `buttonLabel` prop which defaults to null, but if provided, will be used as the copy button's text in place of a copy icon (which is still the default!)

![Screen Shot 2020-07-29 at 9 38 43 AM](https://user-images.githubusercontent.com/657935/88830079-50d03f00-d182-11ea-8b1b-9af14abb99d6.png)


New Story:
- CopyInput "text button"
 http://localhost:8900/?path=/story/%F0%9F%A7%AC-components-forms-copyinput--text-button

New Test also added so please check that it passes!
