### PR TITLE
Fixes Popover arrow/tip rendering

### DIFF
--- a/src/components/Popover/Popover.css.js
+++ b/src/components/Popover/Popover.css.js
@@ -13,10 +13,14 @@ export const config = {
   background: 'white',
 }
 
+/** Make the border color slightly darker than the popover's
+ * border to account for aliasing that makes the arrow color appear
+ * lighter
+ */
 export const ArrowPopoverUI = styled(ArrowUI)`
   &:before {
     background: ${config.background};
-    border: 1px solid ${config.borderColor};
+    border: 1px solid #acb7c0;
   }
 
   /* ghost */
@@ -25,8 +29,8 @@ export const ArrowPopoverUI = styled(ArrowUI)`
     background: ${config.background};
     position: absolute;
     transform: rotate(45deg);
-    height: calc(${({ size }) => size}px - 4px);
-    width: calc(${({ size }) => size}px - 4px);
+    height: calc(${({ arrowSize }) => arrowSize}px - 4px);
+    width: calc(${({ arrowSize }) => arrowSize}px - 4px);
     margin: 2px;
     border-color: transparent;
     box-shadow: none;
@@ -43,26 +47,38 @@ export const PopoverUI = styled(TooltipUI)`
   padding: ${config.padding};
 
   &[data-placement^='top'] ${ArrowPopoverUI} {
+    &:before {
+      bottom: -2px;
+    }
     &:after {
-      bottom: 1px;
+      bottom: -1px;
     }
   }
 
   &[data-placement^='bottom'] ${ArrowPopoverUI} {
+    &:before {
+      top: -2px;
+    }
     &:after {
-      top: 1px;
+      top: -1px;
     }
   }
 
   &[data-placement^='left'] ${ArrowPopoverUI} {
+    &:before {
+      left: 2px;
+    }
     &:after {
-      left: -1px;
+      left: 1px;
     }
   }
 
   &[data-placement^='right'] ${ArrowPopoverUI} {
+    &:before {
+      left: -2px;
+    }
     &:after {
-      left: 1px;
+      left: -1px;
     }
   }
 `

--- a/src/components/Popover/Popover.jsx
+++ b/src/components/Popover/Popover.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import { classNames } from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import { isPlainContent } from './Popover.utils'
@@ -60,14 +59,17 @@ export const Popover = props => {
     triggerOn,
     ...rest
   } = props
-
   const render = ({ scope, ...tooltipProps }) => {
     const toolTipComponent = (
       <TooltipAnimationUI>
         <PopoverUI {...tooltipProps} data-cy="PopoverContent">
           <PopoverHeader header={header} renderHeader={renderHeader} />
           <PopoverContent content={content} renderContent={renderContent} />
-          <ArrowPopoverUI size={arrowSize} data-popper-arrow />
+          <ArrowPopoverUI
+            className="ArrowPopoverUI"
+            arrowSize={arrowSize}
+            data-popper-arrow
+          />
         </PopoverUI>
       </TooltipAnimationUI>
     )
@@ -77,7 +79,7 @@ export const Popover = props => {
 
   return (
     <Tooltip
-      {...getValidProps(rest)}
+      {...rest}
       className={getClassName(className)}
       innerRef={innerRef}
       render={render}
@@ -88,12 +90,15 @@ export const Popover = props => {
 }
 
 Popover.defaultProps = {
+  arrowSize: 14,
   'data-cy': 'Popover',
   innerRef: noop,
   triggerOn: 'click',
 }
 
 Popover.propTypes = {
+  /** Size of the "arrow" or "tip" for the popover */
+  arrowSize: PropTypes.number,
   /** Custom class names to be added to the component. */
   className: PropTypes.string,
   /** Body content to render within the component. */

--- a/src/components/Popover/Popover.test.js
+++ b/src/components/Popover/Popover.test.js
@@ -1,6 +1,8 @@
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 import { mount } from 'enzyme'
 import Popover from './Popover'
+import { ArrowPopoverUI } from './Popover.css'
 
 describe('className', () => {
   test('Can render custom className', () => {
@@ -21,16 +23,24 @@ describe('Tooltip', () => {
 
     expect(el).toBeTruthy()
   })
+
+  test('Renders arrow', () => {
+    const wrapper = mount(<Popover content="Hello" />)
+
+    expect(wrapper.find(ArrowPopoverUI).length).toBeTruthy()
+  })
 })
 
 describe('renderContent', () => {
   test('Can render content', () => {
-    let wrapper = mount(<Popover isOpen content="Hello" />)
+    let wrapper = mount(<Popover content="Hello" />)
+
     expect(wrapper.find('PopoverContent').text()).toContain('Hello')
   })
 
   test('Can render header', () => {
-    let wrapper = mount(<Popover isOpen header="Hello" />)
+    let wrapper = mount(<Popover header="Hello" />)
+
     expect(wrapper.find('PopoverHeader').text()).toContain('Hello')
   })
 

--- a/src/components/Tooltip/Tooltip.css.js
+++ b/src/components/Tooltip/Tooltip.css.js
@@ -11,18 +11,18 @@ export const TooltipTriggerUI = styled.span`
 `
 
 export const ArrowUI = styled.span`
-  height: ${({ size }) => size}px;
-  pointer-events: none;
   position: absolute;
-  width: ${({ size }) => size}px;
+  height: ${({ arrowSize }) => arrowSize}px;
+  width: ${({ arrowSize }) => arrowSize}px;
+  pointer-events: none;
 
   &:before {
     content: '';
     background: ${config.background};
     position: absolute;
     transform: rotate(45deg);
-    height: calc(${({ size }) => size}px - 4px);
-    width: calc(${({ size }) => size}px - 4px);
+    height: calc(${({ arrowSize }) => arrowSize}px - 4px);
+    width: calc(${({ arrowSize }) => arrowSize}px - 4px);
     margin: 2px;
     left: 0;
   }

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -91,16 +91,22 @@ const Tooltip = props => {
 
   const renderTooltip = ({ scope, ...props }) => {
     let titleContent = null
+
     if (typeof title === 'string') {
       titleContent = <span dangerouslySetInnerHTML={{ __html: title }} />
     } else {
       titleContent = title
     }
+
     const toolTipComponent = (
       <TooltipAnimationUI>
         <TooltipUI {...props}>
           {renderContent ? renderContent() : titleContent}
-          <ArrowUI size={arrowSize} data-popper-arrow />
+          <ArrowUI
+            className="c-Tooltip_ArrowUI"
+            arrowSize={arrowSize}
+            data-popper-arrow
+          />
         </TooltipUI>
       </TooltipAnimationUI>
     )


### PR DESCRIPTION
## Problem

Arrows ("tips") on the `<Popover />` are not rendering correctly, a regression from the refactoring of tooltips and popovers done recently.

## Cause

No size was being passed to the arrow.

## Solution

- Pass a default size of 14px, the arrows in Figma have a size of "10" (the arrow is just a little square rotated 45 degrees), to get an actual arrow of that size using a little math you arrive to the number of ~14 (the size of the diagonal):

<img width="416" alt="Screen Shot 2020-08-05 at 12 31 08 PM" src="https://user-images.githubusercontent.com/1414086/89402713-91e2c900-d717-11ea-9b5e-c1bf83bf5b0f.png">

<img width="416" alt="Screen Shot 2020-08-05 at 12 46 25 PM" src="https://user-images.githubusercontent.com/1414086/89404083-b2138780-d719-11ea-8eb0-6ce4e6a8219d.png">


- When the little square gets rotated, the browser does some _antialiasing_ which causes the little border of the arrow to appear lighter, I have made the border slightly darker to compensate for this effect

- I removed `getValidProps` from the component, as it was causing the `isOpen` prop to not be passed down.

- Also, renamed the prop `size` on the `ArrowUI` of the `Tooltip` and the `Popover` to `arrowSize` as size is a valid html attribute that was being passed to the DOM element.

- Adjusted and made sure all popover positions look fine:

![popover](https://user-images.githubusercontent.com/1414086/89403322-690f0380-d718-11ea-9d2e-f23429fa7168.gif)

- Updated tests
