### PR TITLE
HSDS-165 Dropdown: update selectedItem propType

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -237,7 +237,13 @@ Dropdown.propTypes = {
   /** Callback to customize how an trigger renders. */
   renderTrigger: PropTypes.any,
   /** Controls the dropdown and sets the "active" item. */
-  selectedItem: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  selectedItem: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+    ),
+  ]),
   /** Callback to determine if the dropdown should update it's `up`/`down` drop direction. Default returns `true`. */
   shouldDropDirectionUpdate: PropTypes.func,
   /** Callback to determine if the dropdown refocus the trigger on close. Default returns `true`. */

--- a/src/components/Dropdown/Dropdown.stories.mdx
+++ b/src/components/Dropdown/Dropdown.stories.mdx
@@ -84,3 +84,16 @@ A Dropdown component is provides the UI to contain a series of actions, presente
     </div>
   </Story>
 </Preview>
+
+#### Multiple Selected Items
+
+<Preview>
+  <Story name="Multiple selected items">
+    <div style={{ height: '250px' }}>
+      <Dropdown
+        items={itemsWithDivider}
+        selectedItem={[...itemsWithDivider].splice(2, 3)}
+      />
+    </div>
+  </Story>
+</Preview>


### PR DESCRIPTION
**[Jira Issue](https://helpscout.atlassian.net/browse/HSDS-165)**

# Problem/Feature

The Dropdown component should support passing multiple selected items in order to support multi-selection when used as a controlled component. The propType definition for the `selectedItem` prop incorrectly excluded arrays from the allowed types. This regression has resulted in warnings being logged in other projects consuming this library.

# Solution

The solution was to update the propType to accurately reflect what is supported by the component. An additional story was added as a basic demonstration of its use.
