### PR TITLE
Fix Checkbox disabled state

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -60,9 +60,9 @@ A Checkbox component is an enhanced version of the default HTML `<input>` `check
 
 <Preview>
   <Story name="Disabled">
-    <ChoiceGroup>
-      <Checkbox label="Derek (Disable)" value="derek" disabled />
-      <Checkbox label="Hansel" value="hansel" disabled />
+    <ChoiceGroup value={['derek', 'hansel']}>
+      <Checkbox label="Derek (Disable)" value="derek" disabled checked />
+      <Checkbox label="Hansel" value="hansel" />
     </ChoiceGroup>
   </Story>
 </Preview>

--- a/src/components/Choice/Choice.Input.jsx
+++ b/src/components/Choice/Choice.Input.jsx
@@ -161,7 +161,7 @@ class ChoiceInput extends React.PureComponent {
           choiceKind={type}
           disabled={disabled}
           kind={kind}
-          isFilled={checked}
+          isFilled={!disabled && checked}
           isFirst={false}
           isFocused={isFocused}
           isNotOnly={false}

--- a/src/components/Choice/Choice.css.js
+++ b/src/components/Choice/Choice.css.js
@@ -60,6 +60,13 @@ export const inputConfig = {
   customSize: 20,
 }
 
+export const InputIconUI = styled('div')`
+  color: ${inputConfig.iconColor};
+  padding: 3px;
+  position: relative;
+  z-index: 1;
+`
+
 export const InputUI = styled('div')`
   align-items: center;
   display: flex;
@@ -87,17 +94,16 @@ export const InputUI = styled('div')`
       border-radius: 4px;
     }
   }
+
+  &.is-disabled {
+    ${InputIconUI} {
+      color: ${getColor('grey.600')} !important;
+    }
+  }
 `
 
 export const InputInputUI = styled('input')`
   ${visuallyHidden()};
-`
-
-export const InputIconUI = styled('div')`
-  color: ${inputConfig.iconColor};
-  padding: 3px;
-  position: relative;
-  z-index: 1;
 `
 
 export const InputPlaceholderUI = styled('div')`

--- a/src/components/ChoiceGroup/ChoiceGroup.jsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.jsx
@@ -134,10 +134,12 @@ class ChoiceGroup extends React.Component {
       React.Children.map(children, (child, index) => {
         const key = get(child, 'props.id') || `${id}-${index}`
         const isSelected = selectedValue.includes(child.props.value)
+        const disabled =
+          get(child, 'props.disabled') || (limitReached && !isSelected)
         const clone = React.isValidElement(child)
           ? React.cloneElement(child, {
               checked: isSelected,
-              disabled: limitReached && !isSelected,
+              disabled,
               maxWidth: choiceMaxWidth,
               height: choiceHeight,
             })


### PR DESCRIPTION
# Problem

Previously the Checkbox component was not rendering its `disabled` state correctly. Also when the Checkbox component was displayed within a `ChoiceGroup` its explicitly set `disabled` state was being overwritten from within the `ChoiceGroup`.

### Before
<img width="177" alt="Screen Shot 2020-08-17 at 13 20 05" src="https://user-images.githubusercontent.com/7111256/90430059-630c1180-e08c-11ea-960b-b989dc1468ff.png">

### After
<img width="172" alt="Screen Shot 2020-08-17 at 13 16 09" src="https://user-images.githubusercontent.com/7111256/90429959-3ce67180-e08c-11ea-9a6b-772a405d3ec7.png">


