### PR TITLE
Fix Frame performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.6-1",
+  "version": "3.6.6-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.6-0",
+  "version": "3.6.6-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.5",
+  "version": "3.6.6-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.5",
+  "version": "3.6.6-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.6-1",
+  "version": "3.6.6-2",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.6-0",
+  "version": "3.6.6-1",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/Frame/Frame.jsx
+++ b/src/components/Frame/Frame.jsx
@@ -1,6 +1,6 @@
 // from https://github.com/hydrateio/react-styled-frame/blob/master/src/index.js
 // and https://github.com/styled-components/styled-components/issues/659#issuecomment-456894873
-import React, { useContext } from 'react'
+import React, { useContext, useMemo } from 'react'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import Frame, { FrameContext } from 'react-frame-component'
 
@@ -24,17 +24,20 @@ const FrameContent = ({ children, theme }) => {
   // https://github.com/styled-components/styled-components/blob/master/CHANGELOG.md#unreleased
   // it's just not released yet. Once it's is released and we upgraded styled-components everywhere, we can go back to use target="frameContext.document.head"
   const shContext = useContext(StyleSheetContext)
-  const ssmProps = {}
-  if (shContext) {
-    const sheet = shContext.reconstructWithOptions({
-      target: frameContext.document.head,
-    })
-    sheet.names = new Map()
-    sheet.tag = null
-    ssmProps.sheet = sheet
-  } else {
-    ssmProps.target = frameContext.document.head
-  }
+  const ssmProps = useMemo(() => {
+    const ssmProps = {}
+    if (shContext) {
+      const sheet = shContext.reconstructWithOptions({
+        target: frameContext.document.head,
+      })
+      sheet.names = new Map()
+      sheet.tag = null
+      ssmProps.sheet = sheet
+    } else {
+      ssmProps.target = frameContext.document.head
+    }
+    return ssmProps
+  }, [shContext])
 
   return (
     <StyleSheetManager {...ssmProps}>

--- a/src/components/Frame/Frame.jsx
+++ b/src/components/Frame/Frame.jsx
@@ -84,3 +84,4 @@ FrameComponent.defaultProps = {
 }
 
 export const ThemableFrame = withTheme(FrameComponent)
+export { FrameContext }

--- a/src/components/Frame/Frame.jsx
+++ b/src/components/Frame/Frame.jsx
@@ -23,6 +23,9 @@ const FrameContent = ({ children, theme }) => {
   // https://github.com/styled-components/styled-components/pull/3159
   // https://github.com/styled-components/styled-components/blob/master/CHANGELOG.md#unreleased
   // it's just not released yet. Once it's is released and we upgraded styled-components everywhere, we can go back to use target="frameContext.document.head"
+  //
+  // !Update: some performance issue occured, we might keep this way of creating a new sheet around even after
+  // !the styled-component update, to keep the useMemo implementation
   const shContext = useContext(StyleSheetContext)
   const ssmProps = useMemo(() => {
     const ssmProps = {}

--- a/src/components/Frame/Frame.jsx
+++ b/src/components/Frame/Frame.jsx
@@ -53,7 +53,6 @@ const FrameContent = ({ children, theme }) => {
 }
 
 export const FrameComponent = ({
-  style = {},
   theme,
   children,
   initialContent,
@@ -61,21 +60,13 @@ export const FrameComponent = ({
   ...rest
 }) => {
   return (
-    <div className="HSDS-FrameProvider">
-      <Frame
-        style={{
-          display: 'block',
-          overflow: 'scroll',
-          border: 0,
-          ...style,
-        }}
-        initialContent={initialContent}
-        contentDidMount={contentDidMount}
-        {...getValidProps(rest)}
-      >
-        <FrameContent theme={theme}>{children}</FrameContent>
-      </Frame>
-    </div>
+    <Frame
+      initialContent={initialContent}
+      contentDidMount={contentDidMount}
+      {...getValidProps(rest)}
+    >
+      <FrameContent theme={theme}>{children}</FrameContent>
+    </Frame>
   )
 }
 

--- a/src/components/Frame/Frame.jsx
+++ b/src/components/Frame/Frame.jsx
@@ -1,6 +1,7 @@
 // from https://github.com/hydrateio/react-styled-frame/blob/master/src/index.js
 // and https://github.com/styled-components/styled-components/issues/659#issuecomment-456894873
 import React, { useContext, useMemo } from 'react'
+import PropTypes from 'prop-types'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import Frame, { FrameContext } from 'react-frame-component'
 
@@ -71,6 +72,13 @@ export const FrameComponent = ({
       <FrameContent theme={theme}>{children}</FrameContent>
     </Frame>
   )
+}
+
+FrameComponent.propTypes = {
+  /* The initialContent props is the initial html injected into frame. It is only injected once, but allows you to insert any html into the frame (e.g. a head tag, script tags, etc). */
+  initialContent: PropTypes.string,
+  /* Callback that works exactly like componentDidMount. */
+  contentDidMount: PropTypes.func,
 }
 
 FrameComponent.defaultProps = {

--- a/src/components/Frame/Frame.stories.mdx
+++ b/src/components/Frame/Frame.stories.mdx
@@ -15,7 +15,7 @@ A frame component will wrap the content inside an iFrame. It will leverage the S
 
 <Preview>
   <Story name="default">
-    <Frame style={{ height: '500px' }}>
+    <Frame style={{ border: 0, height: '500px' }}>
       <HSDS.Provider>
         <Card>
           <Heading>Card title</Heading>

--- a/src/components/Frame/index.js
+++ b/src/components/Frame/index.js
@@ -1,4 +1,4 @@
 import { FrameComponent } from './Frame'
-export { ThemableFrame } from './Frame'
+export { FrameContext, ThemableFrame } from './Frame'
 
 export default FrameComponent

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.6.6-1',
+  version: '3.6.6-2',
 }

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.6.5',
+  version: '3.6.6-0',
 }

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.6.6-0',
+  version: '3.6.6-1',
 }


### PR DESCRIPTION
## Problem

While testing the new Frame component, we realized that it was clearing the cache on the sheet on every function call (which can be a lot with functional component).

## Solution
By wrapping the cache clearing code in `useMemo`, we make sure to reuse the same sheet if the one from the context didn't changed.

We also did some change on the html structure, and removed the default styles on the Frame component to ease the integration in beacon.