### PR TITLE
Fix inline code render issue within MessageCard

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -175,8 +175,7 @@ export const BodyUI = styled.div`
   }
 
   code.inline-code {
-    display: inline-flex;
-    align-items: center;
+    display: inline-block;
     color: ${getColor('red.500')};
     caret-color: ${getColor('red.500')};
     padding: 0 7px;
@@ -186,9 +185,13 @@ export const BodyUI = styled.div`
     background: ${getColor('grey.300')};
     border-radius: 4px;
     font-family: var(--HSDSGlobalFontFamilyMono);
-    height: 24px;
+    min-height: 24px;
     line-height: 24px;
-    vertical-align: baseline;
+
+    b,
+    strong {
+      color: ${getColor('red.500')};
+    }
   }
 
   pre {


### PR DESCRIPTION
# Problem
The inline code element in MessageCard was not render correctly if the text was on multiple line

# Fix
<img width="323" alt="Image 2020-08-21 at 1 43 37 PM" src="https://user-images.githubusercontent.com/203992/90919517-96181300-e3b4-11ea-9168-a169dad64de4.png">

We improve the original implementation in the Editor, and bring those change inside hsds-react. We make sure that the height is not fixed, and now rely on `display: inline-block` to make sure the content stays inside the parent element

