### PR TITLE
CheckMarkCard additions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.7-1",
+  "version": "3.6.7-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.7-0",
+  "version": "3.6.7-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.6",
+  "version": "3.6.7-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.6",
+  "version": "3.6.7-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.7-1",
+  "version": "3.6.7-2",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.6.7-0",
+  "version": "3.6.7-1",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/CheckMarkCard/CheckMarkCard.css.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.css.js
@@ -70,6 +70,7 @@ export const MarkUI = styled('div')`
   transition: opacity 0.15s;
   will-change: opacity;
   background: ${({ color }) => color};
+  z-index: 100;
 
   .mark-icon {
     color: white;

--- a/src/components/CheckMarkCard/CheckMarkCard.css.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.css.js
@@ -45,28 +45,48 @@ export const CheckMarkCardUI = styled('label')`
       transform: translateY(0);
     }
   }
+
+  &.is-locked {
+    cursor: default;
+    border-color: transparent;
+    box-shadow: 0px 0px 0 2px ${getColor('lavender.600')};
+
+    &:hover {
+      transform: translateY(0);
+    }
+  }
 `
 
-export const CheckMarkUI = styled('div')`
+export const MarkUI = styled('div')`
   position: absolute;
   top: -2px;
   left: -2px;
   height: 28px;
   width: 28px;
   border-radius: 4px 0px 5px;
-  background: ${getColor('blue.500')};
-  opacity: 0;
+  opacity: ${({ kind }) => (kind ? '1' : '0')};
   transition: opacity 0.15s;
   will-change: opacity;
+  background: ${({ kind }) => getMarkColor(kind)};
 
-  .is-checked & {
-    opacity: 1;
-  }
-
-  .checkmark-icon {
+  .mark-icon {
     color: white;
     position: absolute;
-    top: calc(50% - 13px);
-    left: calc(50% - 13px);
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
   }
 `
+
+function getMarkColor(kind) {
+  switch (kind) {
+    case 'checkmark':
+      return getColor('blue.500')
+
+    case 'lock-closed':
+      return getColor('lavender.600')
+
+    default:
+      return getColor('blue.500')
+  }
+}

--- a/src/components/CheckMarkCard/CheckMarkCard.css.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.css.js
@@ -46,10 +46,12 @@ export const CheckMarkCardUI = styled('label')`
     }
   }
 
-  &.is-locked {
+  &.with-status {
     cursor: default;
     border-color: transparent;
-    box-shadow: 0px 0px 0 2px ${getColor('lavender.600')};
+    box-shadow: 0px 0px 0 2px
+      ${({ withStatus }) =>
+        Boolean(withStatus) ? withStatus.color : 'rgba(0, 0, 0, 0.1)'};
 
     &:hover {
       transform: translateY(0);
@@ -64,10 +66,10 @@ export const MarkUI = styled('div')`
   height: 28px;
   width: 28px;
   border-radius: 4px 0px 5px;
-  opacity: ${({ kind }) => (kind ? '1' : '0')};
+  opacity: ${({ markShown }) => (markShown ? '1' : '0')};
   transition: opacity 0.15s;
   will-change: opacity;
-  background: ${({ kind }) => getMarkColor(kind)};
+  background: ${({ color }) => color};
 
   .mark-icon {
     color: white;
@@ -76,17 +78,10 @@ export const MarkUI = styled('div')`
     left: 50%;
     transform: translate(-50%, -50%);
   }
-`
 
-function getMarkColor(kind) {
-  switch (kind) {
-    case 'checkmark':
-      return getColor('blue.500')
-
-    case 'lock-closed':
-      return getColor('lavender.600')
-
-    default:
-      return getColor('blue.500')
+  .TooltipTrigger {
+    display: block;
+    width: 100%;
+    height: 100%;
   }
-}
+`

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -114,6 +114,7 @@ export class CheckMarkCard extends React.Component {
               className={`${iconName}-icon mark-icon`}
               name={iconName}
               size={iconSize}
+              appendTo={document.body}
             />
           </Tooltip>
         ) : (

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -109,12 +109,15 @@ export class CheckMarkCard extends React.Component {
         markShown={Boolean(iconName)}
       >
         {Boolean(tooltip) ? (
-          <Tooltip title={tooltip} triggerOn="mouseenter">
+          <Tooltip
+            title={tooltip}
+            triggerOn="mouseenter"
+            appendTo={document.body}
+          >
             <Icon
               className={`${iconName}-icon mark-icon`}
               name={iconName}
               size={iconSize}
-              appendTo={document.body}
             />
           </Tooltip>
         ) : (

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -131,7 +131,6 @@ export class CheckMarkCard extends React.Component {
     const {
       children,
       disabled,
-      isLocked,
       label,
       maxWidth,
       height,

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -109,7 +109,7 @@ export class CheckMarkCard extends React.Component {
         markShown={Boolean(iconName)}
       >
         {Boolean(tooltip) ? (
-          <Tooltip title={tooltip}>
+          <Tooltip title={tooltip} triggerOn="mouseenter">
             <Icon
               className={`${iconName}-icon mark-icon`}
               name={iconName}

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -191,16 +191,16 @@ CheckMarkCard.propTypes = {
   disabled: PropTypes.bool,
   /** ID for the input. */
   id: PropTypes.string,
-  /** Callback to obtain the <input> node. */
+  /** Callback to obtain the html `input` node. */
   inputRef: PropTypes.func,
   /** Whether the card should be focused */
   isFocused: PropTypes.bool,
-  /** Give the card special status styles, it also disables the input
-   * status: Not needed, but if provided it will add a class name of "is-YOUR_STATUS" to the component
-   * iconName: Icon to render
-   * iconSize: Size of the icon, default 20
-   * color: color of the Card (border and background of the mark)
-   * tooltipText: If a tooltip is desired, provide the message here
+  /** Give the card special status styles, it also disables the input <br>
+   * `status`: Not needed, but if provided it will add a class name of "is-YOUR_STATUS" to the component <br>
+   * `iconName`: Icon to render <br>
+   * `iconSize`: Size of the icon, default 20 <br>
+   * `color`: color of the Card (border and background of the mark) <br>
+   * `tooltipText`: If a tooltip is desired, provide the message here <br>
    */
   withStatus: PropTypes.shape({
     status: PropTypes.string,

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -111,7 +111,7 @@ export class CheckMarkCard extends React.Component {
         {Boolean(tooltip) ? (
           <Tooltip
             title={tooltip}
-            triggerOn="mouseenter"
+            triggerOn="mouseenter focus"
             appendTo={document.body}
           >
             <Icon

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -195,7 +195,13 @@ CheckMarkCard.propTypes = {
   inputRef: PropTypes.func,
   /** Whether the card should be focused */
   isFocused: PropTypes.bool,
-  /** Give the card special status styles, it also disables the input */
+  /** Give the card special status styles, it also disables the input
+   * status: Not needed, but if provided it will add a class name of "is-YOUR_STATUS" to the component
+   * iconName: Icon to render
+   * iconSize: Size of the icon, default 20
+   * color: color of the Card (border and background of the mark)
+   * tooltipText: If a tooltip is desired, provide the message here
+   */
   withStatus: PropTypes.shape({
     status: PropTypes.string,
     iconName: PropTypes.string,

--- a/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
+++ b/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
@@ -27,15 +27,27 @@ This component provides richer context to the of the default HTML `<input>` of t
         derek
       </CheckMarkCard>
       <br />
-      <CheckMarkCard label="Hansel" value="hansel">
+      <CheckMarkCard
+        label="Hansel"
+        value="hansel"
+        disabled={boolean('disabled', true)}
+      >
         hansel
       </CheckMarkCard>
       <br />
-      <CheckMarkCard label="Matilda" value="matilda" checked>
+      <CheckMarkCard
+        label="Matilda"
+        value="matilda"
+        checked={boolean('checked', true)}
+      >
         matilda
       </CheckMarkCard>
       <br />
-      <CheckMarkCard label="Mugatu" value="mugatu" disabled>
+      <CheckMarkCard
+        label="Mugatu"
+        value="mugatu"
+        isLocked={boolean('isLocked', true)}
+      >
         mugatu
       </CheckMarkCard>
     </div>
@@ -68,6 +80,9 @@ This component provides richer context to the of the default HTML `<input>` of t
       choiceMaxWidth="170px"
       choiceHeight="160px"
       multiSelectLimit={number('multiSelectLimit', 2)}
+      onChange={value => {
+        console.log(`onChange(selectedValue: ${value.toString()})`)
+      }}
     >
       <CheckMarkCard label="Derek" value="derek">
         <Avatar size="xl" image={AvatarSpec.generate().image} name="Derek" />
@@ -147,6 +162,26 @@ This component provides richer context to the of the default HTML `<input>` of t
           }}
         >
           Tokyo
+        </div>
+      </CheckMarkCard>
+      <CheckMarkCard label="Elaine" value="elaine" isLocked>
+        <Avatar size="xl" image={AvatarSpec.generate().image} name="Elaine" />
+        <div
+          style={{
+            fontSize: '14px',
+            color: '#314351',
+            margin: '14px 0 5px',
+          }}
+        >
+          Elaine
+        </div>
+        <div
+          style={{
+            color: '#93A1B0',
+            fontSize: '13px',
+          }}
+        >
+          Queens
         </div>
       </CheckMarkCard>
     </ChoiceGroup>

--- a/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
+++ b/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
 import { boolean, number, text, select } from '@storybook/addon-knobs'
+import { getColor } from '../../styles/utilities/color'
 import CheckMarkCard from './CheckMarkCard'
 import { Avatar, ChoiceGroup } from '../index'
 import AvatarSpec from '../../utilities/specs/avatar.specs'
@@ -46,7 +47,13 @@ This component provides richer context to the of the default HTML `<input>` of t
       <CheckMarkCard
         label="Mugatu"
         value="mugatu"
-        isLocked={boolean('isLocked', true)}
+        withStatus={{
+          status: 'locked',
+          iconName: 'lock-closed',
+          iconSize: '20',
+          color: getColor('lavender.600'),
+          tooltipText: 'This is locked, leave it alone',
+        }}
       >
         mugatu
       </CheckMarkCard>

--- a/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
+++ b/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
@@ -171,7 +171,17 @@ This component provides richer context to the of the default HTML `<input>` of t
           Tokyo
         </div>
       </CheckMarkCard>
-      <CheckMarkCard label="Elaine" value="elaine" isLocked>
+      <CheckMarkCard
+        label="Elaine"
+        value="elaine"
+        withStatus={{
+          status: 'locked',
+          iconName: 'lock-closed',
+          iconSize: '20',
+          color: getColor('lavender.600'),
+          tooltipText: 'This is locked, leave it alone',
+        }}
+      >
         <Avatar size="xl" image={AvatarSpec.generate().image} name="Elaine" />
         <div
           style={{

--- a/src/components/CheckMarkCard/CheckMarkCard.test.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.test.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import { getColor } from '../../styles/utilities/color'
 import CheckMarkCard from '../CheckMarkCard'
 import Checkbox from '../Checkbox'
 import Icon from '../Icon'
+import Tooltip from '../Tooltip'
 import VisuallyHidden from '../VisuallyHidden'
 
 describe('className', () => {
@@ -79,28 +81,48 @@ describe('Checked', () => {
   })
 })
 
-describe('Locked', () => {
-  test('Applies locked styles, if provided', () => {
-    const wrapper = mount(<CheckMarkCard isLocked />)
+describe('with status', () => {
+  const withStatus = {
+    status: 'locked',
+    iconName: 'lock-closed',
+    iconSize: '20',
+    color: getColor('lavender.600'),
+  }
+  test('Applies withStatus styles', () => {
+    const wrapper = mount(<CheckMarkCard withStatus={withStatus} />)
 
-    expect(wrapper.getDOMNode().classList.contains('is-locked')).toBeTruthy()
+    expect(wrapper.getDOMNode().classList.contains('with-status')).toBeTruthy()
+    expect(
+      wrapper.getDOMNode().classList.contains(`is-${withStatus.status}`)
+    ).toBeTruthy()
     expect(wrapper.find(Icon).first().props().name).toBe('lock-closed')
+    expect(wrapper.find(Tooltip).length).toBeFalsy()
 
-    wrapper.setProps({ isLocked: false })
+    wrapper.setProps({ withStatus: undefined })
 
-    expect(wrapper.getDOMNode().classList.contains('is-locked')).toBeFalsy()
+    expect(wrapper.getDOMNode().classList.contains('with-status')).toBeFalsy()
   })
 
-  test('When locked, the input should be disabled', () => {
-    const wrapper = mount(<CheckMarkCard isLocked />)
+  test('the input should be disabled', () => {
+    const wrapper = mount(<CheckMarkCard withStatus={withStatus} />)
 
     expect(wrapper.find(Checkbox).first().props().disabled).toBeTruthy()
   })
 
-  test('locked styles take precedent over checked', () => {
-    const wrapper = mount(<CheckMarkCard isLocked checked />)
+  test('adds tooltip to mark if provided', () => {
+    withStatus.tooltipText = 'hello'
+    const wrapper = mount(<CheckMarkCard withStatus={withStatus} />)
 
-    expect(wrapper.getDOMNode().classList.contains('is-locked')).toBeTruthy()
+    expect(wrapper.find(Tooltip).length).toBeTruthy()
+    expect(wrapper.find(Tooltip).first().props().title).toBe('hello')
+  })
+
+  test('with status styles take precedent over checked', () => {
+    const wrapper = mount(<CheckMarkCard withStatus={withStatus} checked />)
+
+    expect(
+      wrapper.getDOMNode().classList.contains(`is-${withStatus.status}`)
+    ).toBeTruthy()
     expect(wrapper.getDOMNode().classList.contains('is-checked')).toBeFalsy()
     expect(wrapper.find(Icon).first().props().name).toBe('lock-closed')
   })

--- a/src/components/CheckMarkCard/CheckMarkCard.test.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import CheckMarkCard from '../CheckMarkCard'
 import Checkbox from '../Checkbox'
+import Icon from '../Icon'
 import VisuallyHidden from '../VisuallyHidden'
 
 describe('className', () => {
@@ -69,11 +70,39 @@ describe('Checked', () => {
   test('Applies checked styles, if provided', () => {
     const wrapper = mount(<CheckMarkCard checked />)
 
-    expect(wrapper.getDOMNode().classList.contains('is-checked')).toBe(true)
+    expect(wrapper.getDOMNode().classList.contains('is-checked')).toBeTruthy()
+    expect(wrapper.find(Icon).first().props().name).toBe('checkmark')
 
     wrapper.setProps({ checked: false })
 
-    expect(wrapper.getDOMNode().classList.contains('is-checked')).toBe(false)
+    expect(wrapper.getDOMNode().classList.contains('is-checked')).toBeFalsy()
+  })
+})
+
+describe('Locked', () => {
+  test('Applies locked styles, if provided', () => {
+    const wrapper = mount(<CheckMarkCard isLocked />)
+
+    expect(wrapper.getDOMNode().classList.contains('is-locked')).toBeTruthy()
+    expect(wrapper.find(Icon).first().props().name).toBe('lock-closed')
+
+    wrapper.setProps({ isLocked: false })
+
+    expect(wrapper.getDOMNode().classList.contains('is-locked')).toBeFalsy()
+  })
+
+  test('When locked, the input should be disabled', () => {
+    const wrapper = mount(<CheckMarkCard isLocked />)
+
+    expect(wrapper.find(Checkbox).first().props().disabled).toBeTruthy()
+  })
+
+  test('locked styles take precedent over checked', () => {
+    const wrapper = mount(<CheckMarkCard isLocked checked />)
+
+    expect(wrapper.getDOMNode().classList.contains('is-locked')).toBeTruthy()
+    expect(wrapper.getDOMNode().classList.contains('is-checked')).toBeFalsy()
+    expect(wrapper.find(Icon).first().props().name).toBe('lock-closed')
   })
 })
 
@@ -81,11 +110,11 @@ describe('Disabled', () => {
   test('Applies disabled styles, if provided', () => {
     const wrapper = mount(<CheckMarkCard disabled />)
 
-    expect(wrapper.getDOMNode().classList.contains('is-disabled')).toBe(true)
+    expect(wrapper.getDOMNode().classList.contains('is-disabled')).toBeTruthy()
 
     wrapper.setProps({ disabled: false })
 
-    expect(wrapper.getDOMNode().classList.contains('is-disabled')).toBe(false)
+    expect(wrapper.getDOMNode().classList.contains('is-disabled')).toBeFalsy()
   })
 })
 
@@ -122,14 +151,6 @@ describe('Events', () => {
 })
 
 describe('Ref', () => {
-  test('Can retrieve the input node from inputRef', () => {
-    const spy = jest.fn()
-    const wrapper = mount(<CheckMarkCard inputRef={spy} />)
-    const o = wrapper.find('input').getDOMNode()
-
-    expect(spy).toHaveBeenCalledWith(o)
-  })
-
   test('Can retrieve the input node from inputRef', () => {
     const spy = jest.fn()
     const wrapper = mount(<CheckMarkCard inputRef={spy} />)

--- a/src/components/ChoiceGroup/ChoiceGroup.jsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
-import equal from 'fast-deep-equal'
 import ChoiceGroupContext from './ChoiceGroup.Context'
 import FormGroup from '../FormGroup'
 import FormLabelContext from '../FormLabel/Context'
@@ -24,17 +23,6 @@ class ChoiceGroup extends React.Component {
       selectedValue,
       limitReached: this.getSelectLimitState(props, selectedValue),
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    if (
-      nextProps.value === this.props.value &&
-      equal(nextState.selectedValue, this.state.selectedValue)
-    ) {
-      return false
-    }
-
-    return true
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -101,7 +89,7 @@ class ChoiceGroup extends React.Component {
   }
 
   handleOnEnter = (value, checked) => {
-    const { multiSelect, onEnter } = this.props
+    const { multiSelect, onEnter, onChange } = this.props
     const selectedValue = multiSelect
       ? this.getMultiSelectValue(value, checked)
       : value
@@ -109,6 +97,7 @@ class ChoiceGroup extends React.Component {
 
     this.setState({ selectedValue, limitReached })
     onEnter(selectedValue)
+    onChange(selectedValue)
   }
 
   getContextProps = () => {

--- a/src/components/ChoiceGroup/ChoiceGroup.test.js
+++ b/src/components/ChoiceGroup/ChoiceGroup.test.js
@@ -54,10 +54,7 @@ describe('ChoiceGroup', () => {
           <Radio />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find('.c-Radio')
-        .first()
-        .find('input')
+      const input = wrapper.find('.c-Radio').first().find('input')
 
       input.simulate('blur')
 
@@ -73,10 +70,7 @@ describe('ChoiceGroup', () => {
           <Radio />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find('.c-Radio')
-        .first()
-        .find('input')
+      const input = wrapper.find('.c-Radio').first().find('input')
 
       input.simulate('focus')
 
@@ -92,10 +86,7 @@ describe('ChoiceGroup', () => {
           <Radio value="3" />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find('.c-Radio')
-        .first()
-        .find('input')
+      const input = wrapper.find('.c-Radio').first().find('input')
 
       input.simulate('change', { target: { checked: true } })
 
@@ -103,41 +94,39 @@ describe('ChoiceGroup', () => {
     })
 
     test('Can trigger onEnter callback', () => {
-      const spy = jest.fn()
+      const enterSpy = jest.fn()
+      const changeSpy = jest.fn()
       const wrapper = mount(
-        <ChoiceGroup onEnter={spy}>
+        <ChoiceGroup onEnter={enterSpy} onChange={changeSpy}>
           <Radio value="1" />
           <Radio value="2" />
           <Radio value="3" />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find('.c-Radio')
-        .first()
-        .find('input')
+      const input = wrapper.find('.c-Radio').first().find('input')
 
       input.simulate('keydown', { key: 'Enter' })
 
-      expect(spy).toHaveBeenCalled()
+      expect(enterSpy).toHaveBeenCalled()
+      expect(changeSpy).toHaveBeenCalled()
     })
 
     test('Can trigger onEnter callback with space', () => {
-      const spy = jest.fn()
+      const enterSpy = jest.fn()
+      const changeSpy = jest.fn()
       const wrapper = mount(
-        <ChoiceGroup onEnter={spy}>
+        <ChoiceGroup onEnter={enterSpy} onChange={changeSpy}>
           <Radio value="1" />
           <Radio value="2" />
           <Radio value="3" />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find('.c-Radio')
-        .first()
-        .find('input')
+      const input = wrapper.find('.c-Radio').first().find('input')
 
       input.simulate('keyup', { key: ' ' })
 
-      expect(spy).toHaveBeenCalled()
+      expect(enterSpy).toHaveBeenCalled()
+      expect(changeSpy).toHaveBeenCalled()
     })
   })
 
@@ -177,18 +166,9 @@ describe('ChoiceGroup', () => {
           <Checkbox value="mugatu" />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find(Checkbox)
-        .at(0)
-        .find('input')
-      const input2 = wrapper
-        .find(Checkbox)
-        .at(1)
-        .find('input')
-      const input3 = wrapper
-        .find(Checkbox)
-        .at(2)
-        .find('input')
+      const input = wrapper.find(Checkbox).at(0).find('input')
+      const input2 = wrapper.find(Checkbox).at(1).find('input')
+      const input3 = wrapper.find(Checkbox).at(2).find('input')
 
       input.simulate('change', { target: { checked: true } })
       expect(spy).toHaveBeenCalledWith(['derek'])
@@ -209,18 +189,9 @@ describe('ChoiceGroup', () => {
           <Checkbox value="mugatu" />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find(Checkbox)
-        .at(0)
-        .find('input')
-      const input2 = wrapper
-        .find(Checkbox)
-        .at(1)
-        .find('input')
-      const input3 = wrapper
-        .find(Checkbox)
-        .at(2)
-        .find('input')
+      const input = wrapper.find(Checkbox).at(0).find('input')
+      const input2 = wrapper.find(Checkbox).at(1).find('input')
+      const input3 = wrapper.find(Checkbox).at(2).find('input')
 
       input.simulate('change', { target: { checked: true } })
       expect(spy).toHaveBeenCalledWith('derek')
@@ -284,53 +255,32 @@ describe('ChoiceGroup', () => {
           <Checkbox value="paul" />
         </ChoiceGroup>
       )
-      const input = wrapper
-        .find(Checkbox)
-        .at(0)
-        .find('input')
-      const input2 = wrapper
-        .find(Checkbox)
-        .at(1)
-        .find('input')
-      const input3 = wrapper
-        .find(Checkbox)
-        .at(2)
-        .find('input')
+      const input = wrapper.find(Checkbox).at(0).find('input')
+      const input2 = wrapper.find(Checkbox).at(1).find('input')
+      const input3 = wrapper.find(Checkbox).at(2).find('input')
 
       input.simulate('change', { target: { checked: true } })
       expect(wrapper.state('limitReached')).toBeFalsy()
       expect(
-        wrapper
-          .find('.c-ChoiceGroup')
-          .first()
-          .hasClass('limit-reached')
+        wrapper.find('.c-ChoiceGroup').first().hasClass('limit-reached')
       ).toBeFalsy()
 
       input2.simulate('change', { target: { checked: true } })
       expect(wrapper.state('limitReached')).toBeFalsy()
       expect(
-        wrapper
-          .find('.c-ChoiceGroup')
-          .first()
-          .hasClass('limit-reached')
+        wrapper.find('.c-ChoiceGroup').first().hasClass('limit-reached')
       ).toBeFalsy()
 
       input3.simulate('change', { target: { checked: true } })
       expect(wrapper.state('limitReached')).toBeTruthy()
       expect(
-        wrapper
-          .find('.c-ChoiceGroup')
-          .first()
-          .hasClass('limit-reached')
+        wrapper.find('.c-ChoiceGroup').first().hasClass('limit-reached')
       ).toBeTruthy()
 
       input2.simulate('change', { target: { checked: false } })
       expect(wrapper.state('limitReached')).toBeFalsy()
       expect(
-        wrapper
-          .find('.c-ChoiceGroup')
-          .first()
-          .hasClass('limit-reached')
+        wrapper.find('.c-ChoiceGroup').first().hasClass('limit-reached')
       ).toBeFalsy()
     })
 
@@ -345,18 +295,9 @@ describe('ChoiceGroup', () => {
         </ChoiceGroup>
       )
 
-      const input = wrapper
-        .find(Checkbox)
-        .at(0)
-        .find('input')
-      const input2 = wrapper
-        .find(Checkbox)
-        .at(1)
-        .find('input')
-      const input3 = wrapper
-        .find(Checkbox)
-        .at(2)
-        .find('input')
+      const input = wrapper.find(Checkbox).at(0).find('input')
+      const input2 = wrapper.find(Checkbox).at(1).find('input')
+      const input3 = wrapper.find(Checkbox).at(2).find('input')
 
       input.simulate('keyup', { key: ' ' })
       expect(wrapper.state('limitReached')).toBeFalsy()
@@ -382,12 +323,7 @@ describe('ChoiceGroup', () => {
         </ChoiceGroup>
       )
 
-      expect(
-        wrapper
-          .find('input')
-          .first()
-          .props().name
-      ).toBe('MUGATU')
+      expect(wrapper.find('input').first().props().name).toBe('MUGATU')
     })
   })
 

--- a/src/components/Tooltip/Tooltip.css.js
+++ b/src/components/Tooltip/Tooltip.css.js
@@ -36,7 +36,7 @@ export const TooltipUI = styled.div`
   /* in case scoping is not working */
   box-sizing: border-box;
   font-family: var(--HSDSGlobalFontFamily);
-
+  width: fit-content;
   background-color: ${config.background};
   border-radius: 3px;
   color: ${config.text};

--- a/src/components/Tooltip/Tooltip.css.js
+++ b/src/components/Tooltip/Tooltip.css.js
@@ -36,7 +36,7 @@ export const TooltipUI = styled.div`
   /* in case scoping is not working */
   box-sizing: border-box;
   font-family: var(--HSDSGlobalFontFamily);
-  width: fit-content;
+  width: max-content;
   background-color: ${config.background};
   border-radius: 3px;
   color: ${config.text};

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -165,7 +165,12 @@ const Tooltip = props => {
 
   return (
     <Tippy {...tippyProps}>
-      <TooltipTriggerUI tabIndex="0" display={display} data-cy={dataCy}>
+      <TooltipTriggerUI
+        tabIndex="0"
+        display={display}
+        data-cy={dataCy}
+        className="TooltipTrigger"
+      >
         {children}
       </TooltipTriggerUI>
     </Tippy>

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.6.7-0',
+  version: '3.6.7-1',
 }

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.6.6',
+  version: '3.6.7-0',
 }

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.6.7-1',
+  version: '3.6.7-2',
 }


### PR DESCRIPTION
This PR adds a new way to style the CheckMarkCard.

<img width="727" alt="Screen Shot 2020-08-27 at 1 32 43 PM" src="https://user-images.githubusercontent.com/1414086/91437262-e5a18780-e869-11ea-91b7-53e045247fed.png">


Changes:

- Use the prop `withStatus`:
```js
	const withStatus = {
      status: 'locked',
      iconName: 'lock-closed',
      iconSize: '20',
      color: getColor('lavender.600'),
      tooltipText: 'This is locked, leave it alone',
    }
```
- `withStatus` takes precedence over `checked` (in case both are provided for some reason)
- If `tooltipText` is provided, a Tooltip with the provided string will be rendered.
- CheckmarkCard now keeps track of it's own checked status
- ChoiceGroup's `onChange` is now triggered with keyboard events
- Removed the `shouldComponentUpdate` lifecycle on ChoiceGroup because we need to rerender its contents even when the values have not changed (think when pagination is used)
- Updated stories