### PR TITLE
Fix props typo in Popover component

### DIFF
--- a/src/components/Popover/Popover.jsx
+++ b/src/components/Popover/Popover.jsx
@@ -83,7 +83,7 @@ export const Popover = props => {
       className={getClassName(className)}
       innerRef={innerRef}
       render={render}
-      trigger={triggerOn}
+      triggerOn={triggerOn}
       placement={placement}
     />
   )


### PR DESCRIPTION
The `Popover` component was not passing the correct prop to the underlying `Tooltip` component. 

This PR fixes that issue.