### PR TITLE
Updated MessageCard line-height

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -76,7 +76,7 @@ export const BodyUI = styled.div`
   margin-top: ${({ withMargin }) => (withMargin ? '12px' : '0')};
   color: ${getColor('charcoal.700')};
   font-size: ${editorHtmlFontSize}px;
-  line-height: 26px;
+  line-height: 22px;
   padding: 0 20px;
   flex: 1 1 100%;
   overflow: auto;


### PR DESCRIPTION
## Summary

The line-height of the MessageCard component's body was too large. This PR updates it from 26px to 22px.

You can check it out here: https://deploy-preview-885--hsds-react.netlify.app/?path=/story/%F0%9F%A7%AC-components-conversation-messagecard--default-story

## Before

![Screen Shot 2020-09-18 at 2 58 00 PM](https://user-images.githubusercontent.com/44473/93630110-d1136380-f9bf-11ea-868e-cb304c734a56.png)

## After

![Screen Shot 2020-09-18 at 2 58 28 PM](https://user-images.githubusercontent.com/44473/93630123-d40e5400-f9bf-11ea-8d55-2b551d57f422.png)
