### PR TITLE
Datepicker range

### DIFF
--- a/src/components/Datepicker/Datepicker.Context.js
+++ b/src/components/Datepicker/Datepicker.Context.js
@@ -5,6 +5,7 @@ export const datepickerContextDefaultValue = {
   focusedDate: null,
   endDate: null,
   startDate: null,
+  minBookingDays: 1,
   isDateFocused: () => false,
   isDateSelected: () => false,
   isDateHovered: () => false,

--- a/src/components/Datepicker/Datepicker.Context.js
+++ b/src/components/Datepicker/Datepicker.Context.js
@@ -3,6 +3,8 @@ import React from 'react'
 
 export const datepickerContextDefaultValue = {
   focusedDate: null,
+  endDate: null,
+  startDate: null,
   isDateFocused: () => false,
   isDateSelected: () => false,
   isDateHovered: () => false,

--- a/src/components/Datepicker/Datepicker.Context.js
+++ b/src/components/Datepicker/Datepicker.Context.js
@@ -2,10 +2,10 @@
 import React from 'react'
 
 export const datepickerContextDefaultValue = {
-  focusedDate: null,
+  enableRangeSelection: false,
   endDate: null,
+  focusedDate: null,
   startDate: null,
-  minBookingDays: 1,
   isDateFocused: () => false,
   isDateSelected: () => false,
   isDateHovered: () => false,

--- a/src/components/Datepicker/Datepicker.Day.js
+++ b/src/components/Datepicker/Datepicker.Day.js
@@ -22,6 +22,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     isFirstOrLastSelectedDate,
     onDateSelect,
     onDateHover,
+    minBookingDays,
   } = useContext(DatepickerContext)
   const {
     isSelected,
@@ -80,6 +81,15 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     return dateCopy
   }
 
+  function shouldShowRangeMarker() {
+    return (
+      minBookingDays > 1 &&
+      endDateString !== startDateString &&
+      ((isSelectedStartOrEnd && dateString === startDateString) ||
+        (isSelectedStartOrEnd && dateString === endDateString))
+    )
+  }
+
   const dateString = getValidDateTimeString(getCorrectDateToSet(date))
   const startDateString = getValidDateTimeString(getCorrectDateToSet(startDate))
   const endDateString = getValidDateTimeString(getCorrectDateToSet(endDate))
@@ -133,8 +143,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
         </time>
       </DayUI>
 
-      {(isSelectedStartOrEnd && dateString === startDateString) ||
-      (isSelectedStartOrEnd && dateString === endDateString) ? (
+      {shouldShowRangeMarker() ? (
         <SelectedDateMarkerUI
           className={classNames(
             'selected-date-marker',

--- a/src/components/Datepicker/Datepicker.Day.js
+++ b/src/components/Datepicker/Datepicker.Day.js
@@ -8,11 +8,13 @@ import {
   isToday,
   getValidDateTimeString,
 } from './Datepicker.utils'
-import { DayUI } from './Datepicker.css'
+import { DayUI, DayWrapperUI, SelectedDateMarkerUI } from './Datepicker.css'
 
 function Day({ dayLabel, date, leading = false, trailing = false }) {
   const dayRef = useRef(null)
   const {
+    endDate,
+    startDate,
     isDateBlocked,
     isDateFocused,
     isDateHovered,
@@ -66,6 +68,8 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
    * go to the next year
    */
   function getCorrectDateToSet(date) {
+    if (!date) return ''
+
     // Avoid mutation of `date`
     const dateCopy = new Date(date.toString())
 
@@ -76,45 +80,69 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     return dateCopy
   }
 
+  const dateString = getValidDateTimeString(getCorrectDateToSet(date))
+  const startDateString = getValidDateTimeString(getCorrectDateToSet(startDate))
+  const endDateString = getValidDateTimeString(getCorrectDateToSet(endDate))
+
   return (
-    <DayUI
-      className={classNames(
-        'c-DatepickerDay',
-        (trailing || leading) && 'is-from-another-month',
-        isSelected && 'is-selected',
-        isDateToday && 'is-today'
-      )}
-      aria-selected={isSelected}
-      disabled={disabledDate}
-      isSelected={isSelected}
-      isDateToday={isDateToday}
-      onClick={onClick}
-      onMouseEnter={onMouseEnter}
-      ref={dayRef}
-      tabIndex={trailing || leading ? '-1' : '0'}
-      labelColor={getColorFn({
-        selectedFirstOrLastColor: '#FFFFFF',
-        normalColor: getColor('charcoal.600'),
-        selectedColor: '#FFFFFF',
-        rangeHoverColor: getColor('blue.200'),
-        disabledColor: '#808285',
-        inactiveMonthColor: getColor('charcoal.200'),
-        todayColor: getColor('charcoal.700'),
-      })}
-      bgColor={getColorFn({
-        selectedFirstOrLastColor: getColor('blue.500'),
-        normalColor: '#FFFFFF',
-        selectedColor: getColor('blue.500'),
-        rangeHoverColor: getColor('blue.200'),
-        disabledColor: '#FFFFFF',
-        inactiveMonthColor: '#FFFFFF',
-        todayColor: getColor('grey.300'),
-      })}
-    >
-      <time dateTime={getValidDateTimeString(getCorrectDateToSet(date))}>
-        {dayLabel}
-      </time>
-    </DayUI>
+    <DayWrapperUI className="DayWrapper">
+      <DayUI
+        className={classNames(
+          'c-DatepickerDay',
+          (trailing || leading) && 'is-from-another-month',
+          isSelected && 'is-selected',
+          isSelectedStartOrEnd &&
+            dateString === startDateString &&
+            'is-selected-start',
+          isSelectedStartOrEnd &&
+            dateString === endDateString &&
+            'is-selected-end',
+          isDateToday && 'is-today',
+          isWithinHoverRange && 'is-within-hover-range'
+        )}
+        aria-selected={isSelected}
+        disabled={disabledDate}
+        isSelected={isSelected}
+        isDateToday={isDateToday}
+        onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        ref={dayRef}
+        tabIndex={trailing || leading ? '-1' : '0'}
+        labelColor={getColorFn({
+          selectedFirstOrLastColor: '#FFFFFF',
+          normalColor: getColor('charcoal.600'),
+          selectedColor: getColor('blue.500'),
+          rangeHoverColor: getColor('blue.500'),
+          disabledColor: '#808285',
+          inactiveMonthColor: getColor('charcoal.200'),
+          todayColor: getColor('charcoal.700'),
+        })}
+        bgColor={getColorFn({
+          selectedFirstOrLastColor: getColor('blue.500'),
+          normalColor: '#FFFFFF',
+          selectedColor: getColor('blue.200'),
+          rangeHoverColor: getColor('blue.200'),
+          disabledColor: '#FFFFFF',
+          inactiveMonthColor: '#FFFFFF',
+          todayColor: getColor('grey.300'),
+        })}
+      >
+        <time dateTime={getValidDateTimeString(getCorrectDateToSet(date))}>
+          {dayLabel}
+        </time>
+      </DayUI>
+
+      {(isSelectedStartOrEnd && dateString === startDateString) ||
+      (isSelectedStartOrEnd && dateString === endDateString) ? (
+        <SelectedDateMarkerUI
+          className={classNames(
+            'selected-date-marker',
+            dateString === startDateString && 'is-selected-start-marker',
+            dateString === endDateString && 'is-selected-end-marker'
+          )}
+        ></SelectedDateMarkerUI>
+      ) : null}
+    </DayWrapperUI>
   )
 }
 

--- a/src/components/Datepicker/Datepicker.Day.js
+++ b/src/components/Datepicker/Datepicker.Day.js
@@ -13,6 +13,7 @@ import { DayUI, DayWrapperUI, SelectedDateMarkerUI } from './Datepicker.css'
 function Day({ dayLabel, date, leading = false, trailing = false }) {
   const dayRef = useRef(null)
   const {
+    enableRangeSelection,
     endDate,
     startDate,
     isDateBlocked,
@@ -22,7 +23,6 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     isFirstOrLastSelectedDate,
     onDateSelect,
     onDateHover,
-    minBookingDays,
   } = useContext(DatepickerContext)
   const {
     isSelected,
@@ -83,7 +83,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
 
   function shouldShowRangeMarker() {
     return (
-      minBookingDays > 1 &&
+      enableRangeSelection &&
       endDateString !== startDateString &&
       ((isSelectedStartOrEnd && dateString === startDateString) ||
         (isSelectedStartOrEnd && dateString === endDateString))

--- a/src/components/Datepicker/Datepicker.Day.js
+++ b/src/components/Datepicker/Datepicker.Day.js
@@ -103,17 +103,20 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
           'c-DatepickerDay',
           (trailing || leading) && 'is-from-another-month',
           (isSelected || dateString === endDateString) && 'is-selected',
-          isSelectedStartOrEnd &&
+          enableRangeSelection &&
+            isSelectedStartOrEnd &&
             dateString === startDateString &&
             'is-selected-start',
-          (isSelectedStartOrEnd ||
-            isSelected ||
-            dateString === endDateString) &&
+          enableRangeSelection &&
+            (isSelectedStartOrEnd ||
+              isSelected ||
+              dateString === endDateString) &&
             dateString === endDateString &&
             'is-selected-end',
           isDateToday && 'is-today',
           isWithinHoverRange && 'is-within-hover-range'
         )}
+        enableRangeSelection={enableRangeSelection}
         aria-selected={isSelected || dateString === endDateString}
         disabled={disabledDate}
         isSelected={isSelected || dateString === endDateString}

--- a/src/components/Datepicker/Datepicker.Day.js
+++ b/src/components/Datepicker/Datepicker.Day.js
@@ -84,6 +84,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
   function shouldShowRangeMarker() {
     return (
       enableRangeSelection &&
+      (isWithinHoverRange || (startDateString && endDateString)) &&
       endDateString !== startDateString &&
       ((isSelectedStartOrEnd && dateString === startDateString) ||
         (isSelectedStartOrEnd && dateString === endDateString))

--- a/src/components/Datepicker/Datepicker.Day.js
+++ b/src/components/Datepicker/Datepicker.Day.js
@@ -126,6 +126,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
           inactiveMonthColor: '#FFFFFF',
           todayColor: getColor('grey.300'),
         })}
+        type="button"
       >
         <time dateTime={getValidDateTimeString(getCorrectDateToSet(date))}>
           {dayLabel}

--- a/src/components/Datepicker/Datepicker.Day.js
+++ b/src/components/Datepicker/Datepicker.Day.js
@@ -8,7 +8,7 @@ import {
   isToday,
   getValidDateTimeString,
 } from './Datepicker.utils'
-import { DayUI, DayWrapperUI, SelectedDateMarkerUI } from './Datepicker.css'
+import { DayUI, DayWrapperUI, DateRangeBGHelperUI } from './Datepicker.css'
 
 function Day({ dayLabel, date, leading = false, trailing = false }) {
   const dayRef = useRef(null)
@@ -81,19 +81,20 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     return dateCopy
   }
 
-  function shouldShowRangeMarker() {
+  const dateString = getValidDateTimeString(getCorrectDateToSet(date))
+  const startDateString = getValidDateTimeString(startDate)
+  const endDateString = getValidDateTimeString(endDate)
+
+  function shouldShowDateRangeBGHelper() {
+    if (!enableRangeSelection) return false
+
     return (
-      enableRangeSelection &&
       (isWithinHoverRange || (startDateString && endDateString)) &&
       endDateString !== startDateString &&
       ((isSelectedStartOrEnd && dateString === startDateString) ||
-        (isSelectedStartOrEnd && dateString === endDateString))
+        dateString === endDateString)
     )
   }
-
-  const dateString = getValidDateTimeString(getCorrectDateToSet(date))
-  const startDateString = getValidDateTimeString(getCorrectDateToSet(startDate))
-  const endDateString = getValidDateTimeString(getCorrectDateToSet(endDate))
 
   return (
     <DayWrapperUI className="DayWrapper">
@@ -101,19 +102,21 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
         className={classNames(
           'c-DatepickerDay',
           (trailing || leading) && 'is-from-another-month',
-          isSelected && 'is-selected',
+          (isSelected || dateString === endDateString) && 'is-selected',
           isSelectedStartOrEnd &&
             dateString === startDateString &&
             'is-selected-start',
-          isSelectedStartOrEnd &&
+          (isSelectedStartOrEnd ||
+            isSelected ||
+            dateString === endDateString) &&
             dateString === endDateString &&
             'is-selected-end',
           isDateToday && 'is-today',
           isWithinHoverRange && 'is-within-hover-range'
         )}
-        aria-selected={isSelected}
+        aria-selected={isSelected || dateString === endDateString}
         disabled={disabledDate}
-        isSelected={isSelected}
+        isSelected={isSelected || dateString === endDateString}
         isDateToday={isDateToday}
         onClick={onClick}
         onMouseEnter={onMouseEnter}
@@ -144,14 +147,14 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
         </time>
       </DayUI>
 
-      {shouldShowRangeMarker() ? (
-        <SelectedDateMarkerUI
+      {shouldShowDateRangeBGHelper() ? (
+        <DateRangeBGHelperUI
           className={classNames(
             'selected-date-marker',
             dateString === startDateString && 'is-selected-start-marker',
             dateString === endDateString && 'is-selected-end-marker'
           )}
-        ></SelectedDateMarkerUI>
+        ></DateRangeBGHelperUI>
       ) : null}
     </DayWrapperUI>
   )

--- a/src/components/Datepicker/Datepicker.Day.js
+++ b/src/components/Datepicker/Datepicker.Day.js
@@ -19,6 +19,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     isDateSelected,
     isFirstOrLastSelectedDate,
     onDateSelect,
+    onDateHover,
   } = useContext(DatepickerContext)
   const {
     isSelected,
@@ -26,6 +27,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     isWithinHoverRange,
     disabledDate,
     onClick,
+    onMouseEnter,
   } = useDay({
     date,
     isDateBlocked,
@@ -34,6 +36,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     isDateSelected,
     isFirstOrLastSelectedDate,
     onDateSelect: handleDaySelect,
+    onDateHover: handleDayHover,
     dayRef,
   })
 
@@ -47,6 +50,10 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     leading,
     trailing
   )
+
+  function handleDayHover(date) {
+    onDateHover(getCorrectDateToSet(date))
+  }
 
   function handleDaySelect(date) {
     onDateSelect(getCorrectDateToSet(date))
@@ -82,6 +89,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
       isSelected={isSelected}
       isDateToday={isDateToday}
       onClick={onClick}
+      onMouseEnter={onMouseEnter}
       ref={dayRef}
       tabIndex={trailing || leading ? '-1' : '0'}
       labelColor={getColorFn({
@@ -97,7 +105,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
         selectedFirstOrLastColor: getColor('blue.500'),
         normalColor: '#FFFFFF',
         selectedColor: getColor('blue.500'),
-        rangeHoverColor: getColor('blue.600'),
+        rangeHoverColor: getColor('blue.200'),
         disabledColor: '#FFFFFF',
         inactiveMonthColor: '#FFFFFF',
         todayColor: getColor('grey.300'),

--- a/src/components/Datepicker/Datepicker.Day.js
+++ b/src/components/Datepicker/Datepicker.Day.js
@@ -53,6 +53,9 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     leading,
     trailing
   )
+  const dateString = getValidDateTimeString(getCorrectDateToSet(date))
+  const startDateString = getValidDateTimeString(startDate)
+  const endDateString = getValidDateTimeString(endDate)
 
   function handleDayHover(date) {
     onDateHover(getCorrectDateToSet(date))
@@ -81,10 +84,9 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     return dateCopy
   }
 
-  const dateString = getValidDateTimeString(getCorrectDateToSet(date))
-  const startDateString = getValidDateTimeString(startDate)
-  const endDateString = getValidDateTimeString(endDate)
-
+  /** This UI Helper is the light blue background
+   *  that appears on a start and end dates in a range
+   */
   function shouldShowDateRangeBGHelper() {
     if (!enableRangeSelection) return false
 
@@ -96,26 +98,28 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
     )
   }
 
+  function getClassNames() {
+    return classNames(
+      'c-DatepickerDay',
+      (trailing || leading) && 'is-from-another-month',
+      (isSelected || dateString === endDateString) && 'is-selected',
+      enableRangeSelection &&
+        isSelectedStartOrEnd &&
+        dateString === startDateString &&
+        'is-selected-start',
+      enableRangeSelection &&
+        (isSelectedStartOrEnd || isSelected || dateString === endDateString) &&
+        dateString === endDateString &&
+        'is-selected-end',
+      isDateToday && 'is-today',
+      isWithinHoverRange && 'is-within-hover-range'
+    )
+  }
+
   return (
     <DayWrapperUI className="DayWrapper">
       <DayUI
-        className={classNames(
-          'c-DatepickerDay',
-          (trailing || leading) && 'is-from-another-month',
-          (isSelected || dateString === endDateString) && 'is-selected',
-          enableRangeSelection &&
-            isSelectedStartOrEnd &&
-            dateString === startDateString &&
-            'is-selected-start',
-          enableRangeSelection &&
-            (isSelectedStartOrEnd ||
-              isSelected ||
-              dateString === endDateString) &&
-            dateString === endDateString &&
-            'is-selected-end',
-          isDateToday && 'is-today',
-          isWithinHoverRange && 'is-within-hover-range'
-        )}
+        className={getClassNames()}
         enableRangeSelection={enableRangeSelection}
         aria-selected={isSelected || dateString === endDateString}
         disabled={disabledDate}
@@ -145,9 +149,7 @@ function Day({ dayLabel, date, leading = false, trailing = false }) {
         })}
         type="button"
       >
-        <time dateTime={getValidDateTimeString(getCorrectDateToSet(date))}>
-          {dayLabel}
-        </time>
+        <time dateTime={dateString}>{dayLabel}</time>
       </DayUI>
 
       {shouldShowDateRangeBGHelper() ? (

--- a/src/components/Datepicker/Datepicker.Month.js
+++ b/src/components/Datepicker/Datepicker.Month.js
@@ -24,7 +24,11 @@ function Month({ year, month, firstDayOfWeek }) {
     <div className="c-DatepickerMonth">
       <WeekdaysRowUI className="WeekdaysRow">
         {weekdayLabels.map(dayLabel => (
-          <div css={{ textAlign: 'center' }} key={dayLabel}>
+          <div
+            className="WeekdayLabel"
+            css={{ textAlign: 'center' }}
+            key={dayLabel}
+          >
             {dayLabel}
           </div>
         ))}

--- a/src/components/Datepicker/Datepicker.Navigator.js
+++ b/src/components/Datepicker/Datepicker.Navigator.js
@@ -31,6 +31,7 @@ function Navigator({
         className="SequentialNavButton go-previous"
         aria-label={getNavigatorButtonLabel(navigationLevel, 'previous')}
         onClick={goPrevious}
+        type="button"
       >
         <Icon name="arrow-left-single-large" />
         <VisuallyHidden>
@@ -42,6 +43,7 @@ function Navigator({
         onClick={onDeepNavigationClick}
         disabled={navigationLevel === NAVIGATION_LEVELS.YEAR_RANGES}
         aria-live="polite"
+        type="button"
       >
         {label}
       </DeepNavigatorButtonUI>
@@ -50,6 +52,7 @@ function Navigator({
         onClick={goNext}
         disabled={!canNavigateForward}
         aria-label={getNavigatorButtonLabel(navigationLevel, 'next')}
+        type="button"
       >
         <Icon name="arrow-right-single-large" />
         <VisuallyHidden>

--- a/src/components/Datepicker/Datepicker.PeriodCalendar.js
+++ b/src/components/Datepicker/Datepicker.PeriodCalendar.js
@@ -62,6 +62,7 @@ function PeriodCalendar({
           onClick={() => {
             goToDate(new Date(activeYear, index, 1), true)
           }}
+          type="button"
         >
           <time
             dateTime={`${activeYear}-${(index + 1)
@@ -90,6 +91,7 @@ function PeriodCalendar({
             setMode(NAVIGATION_LEVELS.YEAR_BY_YEAR)
             goToDate(new Date(year, 0, 1), false)
           }}
+          type="button"
         >
           <time dateTime={`${year}`}>{year}</time>
         </PeriodButtonUI>

--- a/src/components/Datepicker/Datepicker.css.js
+++ b/src/components/Datepicker/Datepicker.css.js
@@ -183,7 +183,8 @@ export const DayUI = styled('button')`
   }
 
   &.is-selected {
-    border-radius: 0;
+    border-radius: ${({ enableRangeSelection }) =>
+      enableRangeSelection ? '0' : '50%'};
 
     &.is-selected-end,
     &.is-selected-start {

--- a/src/components/Datepicker/Datepicker.css.js
+++ b/src/components/Datepicker/Datepicker.css.js
@@ -110,7 +110,28 @@ export const DaysGridUI = styled('div')`
   justify-content: center;
 `
 
+export const DayWrapperUI = styled('div')`
+  position: relative;
+
+  /* First day per row in the month grid */
+  &:nth-child(7n-6) {
+    .is-selected,
+    .is-within-hover-range {
+      border-radius: 50% 0 0 50% !important;
+    }
+  }
+
+  /* Last day per row in the month grid*/
+  &:nth-child(7n) {
+    .is-selected,
+    .is-within-hover-range {
+      border-radius: 0 50% 50% 0 !important;
+    }
+  }
+`
+
 export const DayUI = styled('button')`
+  position: relative;
   width: 36px;
   height: 36px;
   padding: 0;
@@ -128,6 +149,7 @@ export const DayUI = styled('button')`
   -webkit-font-smoothing: ${({ isSelected, isDateToday }) =>
     isSelected || isDateToday ? 'auto' : 'antialiased'};
   cursor: pointer;
+  z-index: 1;
 
   &:not([disabled]):not(.is-from-another-month):not(.is-selected):hover {
     color: ${getColor('blue.600')};
@@ -142,6 +164,37 @@ export const DayUI = styled('button')`
 
   &[disabled] {
     cursor: default;
+  }
+
+  &.is-within-hover-range:not(.is-selected-start):not(.is-selected-end) {
+    border-radius: 0;
+  }
+
+  &.is-selected {
+    border-radius: 0;
+
+    &.is-selected-end,
+    &.is-selected-start {
+      border-radius: 50%;
+    }
+  }
+`
+
+export const SelectedDateMarkerUI = styled('div')`
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  background: ${getColor('blue.200')};
+  top: 0;
+  left: 0;
+  z-index: 0;
+
+  &.is-selected-start-marker {
+    border-radius: 50% 0 0 50%;
+  }
+
+  &.is-selected-end-marker {
+    border-radius: 0 50% 50% 0;
   }
 `
 

--- a/src/components/Datepicker/Datepicker.css.js
+++ b/src/components/Datepicker/Datepicker.css.js
@@ -110,37 +110,13 @@ export const DaysGridUI = styled('div')`
   justify-content: center;
 `
 
-export const DayWrapperUI = styled('div')`
-  position: relative;
-
-  /* First day per row in the month grid */
-  &:nth-child(7n-6) {
-    .is-selected,
-    .is-within-hover-range {
-      border-radius: 50% 0 0 50% !important;
-    }
-  }
-
-  /* Last day per row in the month grid*/
-  &:nth-child(7n) {
-    .is-selected,
-    .is-within-hover-range {
-      border-radius: 0 50% 50% 0 !important;
-    }
-
-    .is-selected-start-marker {
-      display: none;
-    }
-  }
-`
-
 export const DayUI = styled('button')`
   position: relative;
   width: 36px;
   height: 36px;
   padding: 0;
-  line-height: 32px;
-  border: 2px solid transparent;
+  line-height: 36px;
+  border: 0;
   border-radius: 50%;
   text-align: center;
   font-size: 14px;
@@ -155,52 +131,73 @@ export const DayUI = styled('button')`
   cursor: pointer;
   z-index: 1;
 
-  &:not([disabled]):not(.is-from-another-month):not(.is-selected):hover {
-    color: ${getColor('blue.600')};
-    background: ${getColor('blue.200')};
-    border-color: ${getColor('blue.200')};
-  }
-
   &:focus {
     outline: 0;
-    border-color: ${getColor('blue.500')};
+    border: 2px solid ${getColor('blue.500')};
   }
 
   &[disabled] {
     cursor: default;
   }
 
-  &.is-within-hover-range:not(.is-selected-start):not(.is-selected-end) {
-    border-radius: 0;
-
-    &:hover {
-      border-radius: 0 50% 50% 0 !important;
+  &.is-selected,
+  &.is-selected-start {
+    &:focus {
+      border: 0;
     }
   }
 
-  &.is-within-hover-range.is-selected-start:hover + .is-selected-start-marker {
-    border-radius: 50% !important;
-  }
-
-  &.is-selected {
-    border-radius: ${({ enableRangeSelection }) =>
-      enableRangeSelection ? '0' : '50%'};
-
-    &.is-today {
-      background: ${({ enableRangeSelection }) =>
-        enableRangeSelection ? getColor('blue.200') : ''};
-      color: ${({ enableRangeSelection }) =>
-        enableRangeSelection ? getColor('blue.500') : ''};
+  &.with-range-selection {
+    &.is-selected.is-today,
+    &.is-selected.is-from-another-month:not(.is-selected-end),
+    &.is-within-hover-range.is-today {
+      background-color: ${getColor('blue.200')};
+      color: ${getColor('blue.500')};
     }
 
+    &.is-from-another-month.is-selected-end {
+      color: white;
+    }
+
+    &.is-selected,
+    &.is-within-hover-range {
+      border-radius: 0;
+      font-weight: 500;
+    }
+
+    &.is-within-hover-range:hover,
+    &.is-within-hover-range:nth-child(7n),
+    &.is-selected:nth-child(7n) {
+      border-radius: 0 50% 50% 0;
+    }
+
+    &.is-within-hover-range:nth-child(7n - 6),
+    &.is-selected:nth-child(7n - 6) {
+      border-radius: 50% 0 0 50%;
+    }
+
+    &.is-selected-start,
     &.is-selected-end,
-    &.is-selected-start {
-      border-radius: 50% !important;
+    &.is-selected-start:hover,
+    &.is-selected-end:hover {
+      border-radius: 50%;
     }
   }
+`
 
-  &.is-within-hover-range.is-selected-start {
-    border-radius: 50% !important;
+export const TimeUI = styled('time')`
+  display: block;
+  width: 36px;
+  height: 36px;
+  line-height: 36px;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+
+  .is-selected-start &,
+  .is-selected-end & {
+    background-color: ${getColor('blue.500')};
+    border-radius: 50%;
   }
 `
 
@@ -212,6 +209,10 @@ export const DateRangeBGHelperUI = styled('div')`
   top: 0;
   left: 0;
   z-index: 0;
+
+  .is-within-hover-range:hover &.is-selected-start-marker {
+    border-radius: 50%;
+  }
 
   &.is-selected-start-marker {
     border-radius: 50% 0 0 50%;

--- a/src/components/Datepicker/Datepicker.css.js
+++ b/src/components/Datepicker/Datepicker.css.js
@@ -127,6 +127,10 @@ export const DayWrapperUI = styled('div')`
     .is-within-hover-range {
       border-radius: 0 50% 50% 0 !important;
     }
+
+    .is-selected-start-marker {
+      display: none;
+    }
   }
 `
 
@@ -174,17 +178,25 @@ export const DayUI = styled('button')`
     }
   }
 
+  &.is-within-hover-range.is-selected-start:hover + .is-selected-start-marker {
+    border-radius: 50% !important;
+  }
+
   &.is-selected {
     border-radius: 0;
 
     &.is-selected-end,
     &.is-selected-start {
-      border-radius: 50%;
+      border-radius: 50% !important;
     }
+  }
+
+  &.is-within-hover-range.is-selected-start {
+    border-radius: 50% !important;
   }
 `
 
-export const SelectedDateMarkerUI = styled('div')`
+export const DateRangeBGHelperUI = styled('div')`
   position: absolute;
   width: 36px;
   height: 36px;

--- a/src/components/Datepicker/Datepicker.css.js
+++ b/src/components/Datepicker/Datepicker.css.js
@@ -168,6 +168,10 @@ export const DayUI = styled('button')`
 
   &.is-within-hover-range:not(.is-selected-start):not(.is-selected-end) {
     border-radius: 0;
+
+    &:hover {
+      border-radius: 0 50% 50% 0 !important;
+    }
   }
 
   &.is-selected {

--- a/src/components/Datepicker/Datepicker.css.js
+++ b/src/components/Datepicker/Datepicker.css.js
@@ -130,27 +130,29 @@ export const DayUI = styled('button')`
     isSelected || isDateToday ? 'auto' : 'antialiased'};
   cursor: pointer;
   z-index: 1;
+  transition: box-shadow ease-in-out 0.05s;
+
+  &:not([disabled]):not(.is-from-another-month):not(.is-selected):not(.is-selected-end):not(.is-selected-start):hover {
+    color: ${getColor('blue.600')};
+    background: ${getColor('blue.200')};
+  }
 
   &:focus {
     outline: 0;
-    border: 2px solid ${getColor('blue.500')};
+    box-shadow: inset 0 0 0 2px ${getColor('blue.500')};
+  }
+
+  &:not(.is-selected):focus {
   }
 
   &[disabled] {
     cursor: default;
   }
 
-  &.is-selected,
-  &.is-selected-start {
-    &:focus {
-      border: 0;
-    }
-  }
-
   &.with-range-selection {
-    &.is-selected.is-today,
+    &.is-selected.is-today:not(.is-selected-end):not(.is-selected-start),
     &.is-selected.is-from-another-month:not(.is-selected-end),
-    &.is-within-hover-range.is-today {
+    &.is-within-hover-range.is-today:not(.is-selected-end):not(.is-selected-start) {
       background-color: ${getColor('blue.200')};
       color: ${getColor('blue.500')};
     }
@@ -171,9 +173,13 @@ export const DayUI = styled('button')`
       border-radius: 0 50% 50% 0;
     }
 
-    &.is-within-hover-range:nth-child(7n - 6),
-    &.is-selected:nth-child(7n - 6) {
+    &.is-within-hover-range:not(.is-selected-end):not(.is-selected-start):nth-child(7n-6),
+    &.is-selected:not(.is-selected-end):not(.is-selected-start):nth-child(7n-6) {
       border-radius: 50% 0 0 50%;
+
+      &:not(.is-selected):hover {
+        border-radius: 50%;
+      }
     }
 
     &.is-selected-start,

--- a/src/components/Datepicker/Datepicker.css.js
+++ b/src/components/Datepicker/Datepicker.css.js
@@ -24,7 +24,7 @@ export const DailyCalendarUI = styled('div')`
     justify-items: center;
   `
       : `
-      width: calc(100% - 40px);
+      width: calc(100% - 26px);
       margin: 0 auto;
       `}
 `
@@ -185,6 +185,13 @@ export const DayUI = styled('button')`
   &.is-selected {
     border-radius: ${({ enableRangeSelection }) =>
       enableRangeSelection ? '0' : '50%'};
+
+    &.is-today {
+      background: ${({ enableRangeSelection }) =>
+        enableRangeSelection ? getColor('blue.200') : ''};
+      color: ${({ enableRangeSelection }) =>
+        enableRangeSelection ? getColor('blue.500') : ''};
+    }
 
     &.is-selected-end,
     &.is-selected-start {

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -10,6 +10,7 @@ import DailyCalendar from './Datepicker.DailyCalendar'
 
 function Datepicker({
   allowFutureDatePick = true,
+  enableRangeSelection = false,
   endDate = null,
   firstDayOfWeek = 1,
   minBookingDays = 1,
@@ -46,7 +47,7 @@ function Datepicker({
     onDatesChange: handleDateChange,
     numberOfMonths,
     minBookingDays,
-    exactMinBookingDays: minBookingDays === 1,
+    exactMinBookingDays: !enableRangeSelection,
     maxBookingDate: !allowFutureDatePick ? new Date() : undefined,
   })
 
@@ -76,7 +77,7 @@ function Datepicker({
     if (!data.focusedInput) {
       setDates({ ...data, focusedInput: START_DATE })
     } else {
-      if (minBookingDays > 1 && data.endDate) {
+      if (enableRangeSelection && data.endDate) {
         setDates({ ...data, endDate: null })
       } else {
         setDates(data)
@@ -99,7 +100,7 @@ function Datepicker({
       onDateHover,
       startDate: dates.startDate,
       endDate: dates.endDate,
-      minBookingDays,
+      enableRangeSelection,
     }),
     [
       isDateBlocked,
@@ -111,7 +112,7 @@ function Datepicker({
       onDateHover,
       dates.startDate,
       dates.endDate,
-      minBookingDays,
+      enableRangeSelection,
     ]
   )
 
@@ -155,11 +156,13 @@ function Datepicker({
 Datepicker.propTypes = {
   /** Whether is possible to pick a date in the future */
   allowFutureDatePick: PropTypes.bool,
+  /** Allows the selection of start and end date dates, use `minBookingDays` to enforce a minimun number of dates in the range*/
+  enableRangeSelection: PropTypes.bool,
   /** Pass an ending date to the calendar to select range. Note: Range not supported yet */
   endDate: PropTypes.instanceOf(Date),
   /** Which day of the week is first in the calendar (0 -> sunday, 1 -> monday, etc) */
   firstDayOfWeek: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
-  /** How many days can be selected in a range (minimum). Note: Currently supported 1 */
+  /** How many days can be selected in a range (minimum). */
   minBookingDays: PropTypes.number,
   /** How many months to display at the same time. Note: Currently supported 1 */
   numberOfMonths: PropTypes.number,

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -94,6 +94,7 @@ function Datepicker({
       onDateHover,
       startDate: dates.startDate,
       endDate: dates.endDate,
+      minBookingDays,
     }),
     [
       isDateBlocked,
@@ -105,6 +106,7 @@ function Datepicker({
       onDateHover,
       dates.startDate,
       dates.endDate,
+      minBookingDays,
     ]
   )
 

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { useDatepicker, START_DATE } from '@datepicker-react/hooks'
 import { noop } from '../../utilities/other'
@@ -81,20 +81,35 @@ function Datepicker({
     onDateChange(data)
   }
 
+  // We don't recreate the context value object unless it's needed.
+  // That stop all the childrens from being re-rendering on each datepicker evokation
+  const contextValue = useMemo(
+    () => ({
+      isDateBlocked,
+      isDateFocused,
+      isDateHovered,
+      isDateSelected,
+      isFirstOrLastSelectedDate,
+      onDateSelect,
+      onDateHover,
+      startDate: dates.startDate,
+      endDate: dates.endDate,
+    }),
+    [
+      isDateBlocked,
+      isDateFocused,
+      isDateHovered,
+      isDateSelected,
+      isFirstOrLastSelectedDate,
+      onDateSelect,
+      onDateHover,
+      dates.startDate,
+      dates.endDate,
+    ]
+  )
+
   return (
-    <DatepickerContext.Provider
-      value={{
-        isDateBlocked,
-        isDateFocused,
-        isDateHovered,
-        isDateSelected,
-        isFirstOrLastSelectedDate,
-        onDateSelect,
-        onDateHover,
-        startDate: dates.startDate,
-        endDate: dates.endDate,
-      }}
-    >
+    <DatepickerContext.Provider value={contextValue}>
       <CalendarContainerUI
         className="c-Calendar"
         numberOfMonths={numberOfMonths}

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -12,7 +12,7 @@ function Datepicker({
   allowFutureDatePick = true,
   endDate = null,
   firstDayOfWeek = 1,
-  minBookingDays = 2,
+  minBookingDays = 1,
   numberOfMonths = 1,
   onDateChange = noop,
   startDate = null,

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -45,6 +45,7 @@ function Datepicker({
     focusedInput: dates.focusedInput,
     onDatesChange: handleDateChange,
     numberOfMonths,
+    minBookingDays,
     exactMinBookingDays: minBookingDays === 1,
     maxBookingDate: !allowFutureDatePick ? new Date() : undefined,
   })
@@ -75,7 +76,11 @@ function Datepicker({
     if (!data.focusedInput) {
       setDates({ ...data, focusedInput: START_DATE })
     } else {
-      setDates(data)
+      if (minBookingDays > 1 && data.endDate) {
+        setDates({ ...data, endDate: null })
+      } else {
+        setDates(data)
+      }
     }
 
     onDateChange(data)

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -171,7 +171,7 @@ Datepicker.propTypes = {
     PropTypes.instanceOf(Date),
     PropTypes.string,
   ]),
-  /** Callback when the date is changed */
+  /** Callback when the date is changed, returns selected start date (and end date if a range selection)  */
   onDateChange: PropTypes.func,
 }
 

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -12,7 +12,7 @@ function Datepicker({
   allowFutureDatePick = true,
   endDate = null,
   firstDayOfWeek = 1,
-  minBookingDays = 1,
+  minBookingDays = 2,
   numberOfMonths = 1,
   onDateChange = noop,
   startDate = null,
@@ -33,6 +33,7 @@ function Datepicker({
     isDateBlocked,
     isDateFocused,
     onDateSelect,
+    onDateHover,
     goToDate,
     goToPreviousMonthsByOneMonth,
     goToNextMonthsByOneMonth,
@@ -89,6 +90,7 @@ function Datepicker({
         isDateSelected,
         isFirstOrLastSelectedDate,
         onDateSelect,
+        onDateHover,
       }}
     >
       <CalendarContainerUI

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -91,6 +91,8 @@ function Datepicker({
         isFirstOrLastSelectedDate,
         onDateSelect,
         onDateHover,
+        startDate: dates.startDate,
+        endDate: dates.endDate,
       }}
     >
       <CalendarContainerUI

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useDatepicker, START_DATE } from '@datepicker-react/hooks'
 import { noop } from '../../utilities/other'
@@ -16,8 +16,10 @@ function Datepicker({
   minBookingDays = 1,
   numberOfMonths = 1,
   onDateChange = noop,
+  innerRef = noop,
   startDate = null,
 }) {
+  const datePickerRef = useRef(null)
   const [dates, setDates] = useState({
     startDate: getJSDateFromString(startDate),
     endDate: getJSDateFromString(endDate) || getJSDateFromString(startDate),
@@ -25,6 +27,14 @@ function Datepicker({
   })
   const [prevDates, setPrevDates] = useState({})
   const [deepNavVisible, setDeepNavVisibility] = useState(false)
+
+  useEffect(() => {
+    if (datePickerRef && datePickerRef.current) {
+      innerRef(datePickerRef.current)
+    }
+    // No need to add innerRef prop to the deps list
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datePickerRef])
 
   const {
     activeMonths,
@@ -117,39 +127,41 @@ function Datepicker({
   )
 
   return (
-    <DatepickerContext.Provider value={contextValue}>
-      <CalendarContainerUI
-        className="c-Calendar"
-        numberOfMonths={numberOfMonths}
-        role="dialog"
-      >
-        {!deepNavVisible ? (
-          <DailyCalendar
-            activeMonths={activeMonths}
-            allowFutureDatePick={allowFutureDatePick}
-            firstDayOfWeek={firstDayOfWeek}
-            goToPreviousMonth={goToPreviousMonthsByOneMonth}
-            goToNextMonth={goToNextMonthsByOneMonth}
-            numberOfMonths={numberOfMonths}
-            onDeepNavigationClick={() => {
-              setDeepNavVisibility(!deepNavVisible)
-            }}
-          />
-        ) : (
-          <PeriodCalendar
-            activeMonths={activeMonths}
-            allowFutureDatePick={allowFutureDatePick}
-            goToDate={(newDate, switchCalendar) => {
-              goToDate(newDate)
-              switchCalendar && setDeepNavVisibility(false)
-            }}
-            goToNextYear={goToNextYear}
-            goToPreviousYear={goToPreviousYear}
-            startDate={dates.startDate}
-          />
-        )}
-      </CalendarContainerUI>
-    </DatepickerContext.Provider>
+    <div className="DatepickerContainer" ref={datePickerRef}>
+      <DatepickerContext.Provider value={contextValue}>
+        <CalendarContainerUI
+          className="c-Calendar"
+          numberOfMonths={numberOfMonths}
+          role="dialog"
+        >
+          {!deepNavVisible ? (
+            <DailyCalendar
+              activeMonths={activeMonths}
+              allowFutureDatePick={allowFutureDatePick}
+              firstDayOfWeek={firstDayOfWeek}
+              goToPreviousMonth={goToPreviousMonthsByOneMonth}
+              goToNextMonth={goToNextMonthsByOneMonth}
+              numberOfMonths={numberOfMonths}
+              onDeepNavigationClick={() => {
+                setDeepNavVisibility(!deepNavVisible)
+              }}
+            />
+          ) : (
+            <PeriodCalendar
+              activeMonths={activeMonths}
+              allowFutureDatePick={allowFutureDatePick}
+              goToDate={(newDate, switchCalendar) => {
+                goToDate(newDate)
+                switchCalendar && setDeepNavVisibility(false)
+              }}
+              goToNextYear={goToNextYear}
+              goToPreviousYear={goToPreviousYear}
+              startDate={dates.startDate}
+            />
+          )}
+        </CalendarContainerUI>
+      </DatepickerContext.Provider>
+    </div>
   )
 }
 
@@ -162,6 +174,8 @@ Datepicker.propTypes = {
   endDate: PropTypes.instanceOf(Date),
   /** Which day of the week is first in the calendar (0 -> sunday, 1 -> monday, etc) */
   firstDayOfWeek: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
+  /** Retrieves the Datepicker most outer DOM node */
+  innerRef: PropTypes.func,
   /** How many days can be selected in a range (minimum). */
   minBookingDays: PropTypes.number,
   /** How many months to display at the same time. Note: Currently supported 1 */

--- a/src/components/Datepicker/Datepicker.stories.mdx
+++ b/src/components/Datepicker/Datepicker.stories.mdx
@@ -63,6 +63,7 @@ Implementing these features in `Datepicker` should be straightforward 🤞 and o
         },
         null
       )}
+      minBookingDays={number('Minimum booking days (range)', 1)}
       onDateChange={action('onDateChange')}
     />
   </Story>

--- a/src/components/Datepicker/Datepicker.stories.mdx
+++ b/src/components/Datepicker/Datepicker.stories.mdx
@@ -63,7 +63,6 @@ Implementing these features in `Datepicker` should be straightforward 🤞 and o
         },
         null
       )}
-      minBookingDays={number('Minimum booking days (range)', 1)}
       onDateChange={action('onDateChange')}
     />
   </Story>
@@ -94,3 +93,17 @@ Datepicker is composed of a few components that in normal circumstances you shou
   - Skip to any year faster by using the "deep navigator button" again
 - **Month**: Renders a month inside `DailyCalendar`
 - **Day**: Renders a day inside `Month`
+
+## Stories
+
+#### Date range selection
+
+<Canvas>
+  <Story name="range selection">
+    <Datepicker
+      enableRangeSelection
+      minBookingDays={number('Minimum booking days', 1)}
+      onDateChange={action('onDateChange')}
+    />
+  </Story>
+</Canvas>

--- a/src/components/Datepicker/Datepicker.test.js
+++ b/src/components/Datepicker/Datepicker.test.js
@@ -335,4 +335,149 @@ describe('Datepicker', () => {
 
     expect(getByLabelText(/next years/i).disabled).toBeTruthy()
   })
+
+  describe('Range selection', () => {
+    test('should allow range selection when enableRangeSelection is true', () => {
+      const changeSpy = jest.fn()
+      const someDate = new Date(2020, 10, 25)
+      const { getByText } = render(
+        <Datepicker
+          enableRangeSelection
+          startDate={someDate}
+          onDateChange={changeSpy}
+        />
+      )
+      const startDay = 21
+      const middleDay = 22
+      const endDay = 24
+
+      user.click(getByText(`${startDay}`).parentElement)
+
+      expect(
+        getByText(`${startDay}`).parentElement.classList.contains(
+          'is-selected-start'
+        )
+      ).toBeTruthy()
+
+      user.hover(getByText(`${endDay}`).parentElement)
+
+      expect(
+        getByText(`${middleDay}`).parentElement.classList.contains(
+          'is-within-hover-range'
+        )
+      ).toBeTruthy()
+
+      expect(
+        getByText(`${endDay}`).parentElement.classList.contains(
+          'is-within-hover-range'
+        )
+      ).toBeTruthy()
+
+      user.click(getByText(`${endDay}`).parentElement)
+
+      expect(
+        getByText(`${endDay}`).parentElement.classList.contains(
+          'is-selected-end'
+        )
+      ).toBeTruthy()
+      expect(
+        getByText(`${middleDay}`).parentElement.classList.contains(
+          'is-selected'
+        )
+      ).toBeTruthy()
+      expect(changeSpy).toHaveBeenCalledTimes(2)
+      expect(changeSpy).toHaveBeenCalledWith({
+        endDate: new Date(2020, 10, endDay),
+        focusedInput: null,
+        startDate: new Date(2020, 10, startDay),
+      })
+    })
+
+    test('should allow range selection with minimum days', () => {
+      const changeSpy = jest.fn()
+      const someDate = new Date(2020, 10, 25)
+      const { getByText } = render(
+        <Datepicker
+          enableRangeSelection
+          minBookingDays={4}
+          startDate={someDate}
+          onDateChange={changeSpy}
+        />
+      )
+      const startDay = 21
+      const middleDay = 22
+      const middleDay2 = 23
+      const endDay = 24
+
+      user.click(getByText(`${startDay}`).parentElement)
+
+      expect(
+        getByText(`${startDay}`).parentElement.classList.contains(
+          'is-selected-start'
+        )
+      ).toBeTruthy()
+
+      user.hover(getByText(`${middleDay}`).parentElement)
+
+      expect(
+        getByText(`${middleDay}`).parentElement.getAttribute('disabled')
+      ).toBe('')
+
+      user.hover(getByText(`${middleDay2}`).parentElement)
+
+      expect(
+        getByText(`${middleDay2}`).parentElement.getAttribute('disabled')
+      ).toBe('')
+
+      expect(
+        getByText(`${endDay}`).parentElement.getAttribute('disabled')
+      ).toBe(null)
+
+      user.click(getByText(`${endDay}`).parentElement)
+
+      expect(changeSpy).toHaveBeenCalledTimes(2)
+      expect(changeSpy).toHaveBeenCalledWith({
+        endDate: new Date(2020, 10, endDay),
+        focusedInput: null,
+        startDate: new Date(2020, 10, startDay),
+      })
+    })
+
+    test('should clear previous range if making a new one', () => {
+      const changeSpy = jest.fn()
+      const someDate = new Date(2020, 10, 25)
+      const { getByText } = render(
+        <Datepicker
+          enableRangeSelection
+          startDate={someDate}
+          onDateChange={changeSpy}
+        />
+      )
+      const startDay = 21
+      const endDay = 24
+
+      user.click(getByText(`${startDay}`).parentElement)
+      user.click(getByText(`${endDay}`).parentElement)
+
+      expect(changeSpy).toHaveBeenCalledTimes(2)
+      expect(changeSpy).toHaveBeenCalledWith({
+        endDate: new Date(2020, 10, endDay),
+        focusedInput: null,
+        startDate: new Date(2020, 10, startDay),
+      })
+
+      const startDay2 = 18
+      const endDay2 = 22
+
+      user.click(getByText(`${startDay2}`).parentElement)
+      user.click(getByText(`${endDay2}`).parentElement)
+
+      expect(changeSpy).toHaveBeenCalledTimes(4)
+      expect(changeSpy).toHaveBeenCalledWith({
+        endDate: new Date(2020, 10, endDay2),
+        focusedInput: null,
+        startDate: new Date(2020, 10, startDay2),
+      })
+    })
+  })
 })

--- a/src/components/Datepicker/Datepicker.test.js
+++ b/src/components/Datepicker/Datepicker.test.js
@@ -18,7 +18,7 @@ describe('Datepicker', () => {
       getValidDateTimeString(todayDate)
     )
     expect(todayNode.classList.contains('is-selected')).toBeFalsy()
-    expect(todayNode.getAttribute('aria-selected')).toBe('false')
+    expect(todayNode.getAttribute('aria-selected')).toBeFalsy()
   })
 
   test('should render with a given date if provided', () => {

--- a/src/components/Datepicker/Datepicker.utils.js
+++ b/src/components/Datepicker/Datepicker.utils.js
@@ -54,6 +54,10 @@ export function isMonthInThePast(someDate) {
   )
 }
 
+export function isInsideRange({ check, to, from }) {
+  return check.getTime() <= to.getTime() && check.getTime() >= from.getTime()
+}
+
 /**
  * Extracts a string in the form of `YYYY-MM-DD`
  * @param {Object} someDate Date object to get the string from


### PR DESCRIPTION
# Feature

In this PR we add the ability to select a range of dates in the Datepicker.

<img width="314" alt="Storybook 2020-11-18 15-31-45" src="https://user-images.githubusercontent.com/1414086/99543186-2e716400-29b3-11eb-8ed9-36e70a225569.png">

✅ Use the new `enableRangeSelection` prop (default false)
✅ Restrict the selection to a minimum number of days with `minBookingDays`
✅ After completing a selection range, starting a new one clears the existing one
✅ `onDateChange` returns both `startDate` and `endDate`
✅ Adds `type=button` to days to avoid triggering a form submit event in case you use the datepicker inside one.
✅ Adds a performance improvement with `useMemo`
✅ Adds an outer container div (to allow the use of styled components)
✅ Adds `innerRef` to obtain the DOM node

📹 https://www.loom.com/share/871fd4a5bd6747fc86fd8f8b66cc09d1

