### PR TITLE
Added onBodyClick prop to MessageCard component

### DIFF
--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -133,7 +133,7 @@ MessageCard.defaultProps = {
   in: true,
   isMobile: false,
   isWithBoxShadow: true,
-  onBodyClick: () => {},
+  onBodyClick: noop,
 }
 
 MessageCard.propTypes = {
@@ -158,7 +158,7 @@ MessageCard.propTypes = {
   isMobile: PropTypes.bool,
   /** Adds a box shadow. */
   isWithBoxShadow: PropTypes.bool,
-  /** Callback invoked when the body of the Message is clicked. **/
+  /** Callback invoked when the body of the Message is clicked. */
   onBodyClick: PropTypes.func,
   /** Subtitle of the Message. */
   subtitle: PropTypes.string,

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -61,7 +61,7 @@ export class MessageCard extends React.PureComponent {
   }
 
   renderBody() {
-    const { title, subtitle } = this.props
+    const { onBodyClick, title, subtitle } = this.props
     let { body } = this.props
     const withMargin = title || subtitle
 
@@ -71,7 +71,11 @@ export class MessageCard extends React.PureComponent {
     }
 
     return body ? (
-      <BodyUI withMargin={withMargin} data-cy="beacon-message-body-content">
+      <BodyUI
+        onClick={onBodyClick}
+        withMargin={withMargin}
+        data-cy="beacon-message-body-content"
+      >
         <div dangerouslySetInnerHTML={{ __html: body }} />
       </BodyUI>
     ) : null
@@ -129,6 +133,7 @@ MessageCard.defaultProps = {
   in: true,
   isMobile: false,
   isWithBoxShadow: true,
+  onBodyClick: () => {},
 }
 
 MessageCard.propTypes = {
@@ -153,9 +158,11 @@ MessageCard.propTypes = {
   isMobile: PropTypes.bool,
   /** Adds a box shadow. */
   isWithBoxShadow: PropTypes.bool,
-  /** Title of the Message. */
-  subtitle: PropTypes.string,
+  /** Callback invoked when the body of the Message is clicked. **/
+  onBodyClick: PropTypes.func,
   /** Subtitle of the Message. */
+  subtitle: PropTypes.string,
+  /** Title of the Message. */
   title: PropTypes.string,
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -107,6 +107,18 @@ describe('Body', () => {
 
     expect(o.render().find('br').length).toBe(1)
   })
+
+  test('Accepts a custom onBodyClick callback', () => {
+    const body = 'some text with a <a href="#">link</a> in it'
+    const callback = jest.fn()
+    const wrapper = mount(<MessageCard body={body} onBodyClick={callback} />)
+
+    wrapper.simulate('click')
+    expect(callback).not.toHaveBeenCalled()
+
+    wrapper.find(BodyUI).simulate('click')
+    expect(callback).toHaveBeenCalled()
+  })
 })
 
 describe('Title', () => {


### PR DESCRIPTION
# Problem/Feature

This PR adds an `onBodyClick` prop to the `MessageCard` component. We need this in order to implement a fix for [a bug](https://helpscout.atlassian.net/browse/BEMBED-228) in Beacon, where links in a Message's body open inside the Beacon iframe.

## How to test

Pass a function as the `onBodyClick` prop to a `MessageCard`. The function should be called when you click on any element of the Message's body, but not when clicking on other parts of the Message (Title, Subtitle, Action CTA, etc).