### PR TITLE
Use effect only shadow for MessageCard component

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import { makeFontFamily, setFontSize } from '../../styles/utilities/font'
 import { getColor } from '../../styles/utilities/color'
 import { FONT_FAMILY } from '../../styles/configs/constants'
-import { d600 } from '../../styles/mixins/depth.css'
+import { d600Effect } from '../../styles/mixins/depth.css'
 import Card from '../Card'
 import Button from '../Button'
 import Heading from '../Heading'
@@ -26,7 +26,7 @@ export const MessageCardUI = styled(Card)`
     border-bottom-left-radius: 4px;
   }
   &.is-with-box-shadow {
-    ${d600}
+    ${d600Effect}
   }
   &.is-mobile {
     width: 100%;

--- a/src/styles/mixins/depth.css.js
+++ b/src/styles/mixins/depth.css.js
@@ -55,6 +55,10 @@ export const d600 = `
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1),
                   0 4px 6px rgba(0, 0, 0, 0.15);
 `
+export const d600Effect = `
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1),
+                  0 4px 6px rgba(0, 0, 0, 0.15);
+`
 export const d700 = `
   ${common}
   box-shadow: 0 2px 3px rgba(64, 82, 97, 0.2),


### PR DESCRIPTION
# Problem/Feature

We've recently found an issue on Beacon/Messages where the `MessageCard` component wasn't resizing correctly in some cases. After tracking down the bug, we found that it was coming from the HSDS [v3.9.3 release](https://github.com/helpscout/hsds-react/releases/tag/v3.9.3), where we added the depth component and refactored `MessageCard` to use the depth mixins.

In particular, the issue comes from the `will-change: box-shadow;` property that seems to be affecting the order in which property changes are calculated. Since we have a dynamic-height iframe that cares about when the `height` property changes, we were running into a conflict there.

My fix was to add a `d600Effect` depth constant that only applies the `box-shadow` styles.

# Question

I can't say I fully understand the `will-change` property, but I've noticed we're using it in a few places within HSDS, and since [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) suggests that we should only use this as a last resort, I was wondering if there was a particular reason why we sometimes use this optimization? Also, when we do need it, should we be applying it and removing it with JS as MDN suggests instead of doing it with CSS?