### PR TITLE
Fix: isMonthInThePast returns false for past dates if the month is greater than this month

### DIFF
--- a/src/components/Datepicker/Datepicker.utils.js
+++ b/src/components/Datepicker/Datepicker.utils.js
@@ -47,11 +47,14 @@ export function isToday(someDate) {
  */
 export function isMonthInThePast(someDate) {
   const today = new Date()
+  const thisYear = today.getFullYear()
+  const someYear = someDate.getFullYear()
 
-  return (
-    someDate.getFullYear() <= today.getFullYear() &&
-    someDate.getMonth() < today.getMonth()
-  )
+  if (someYear === thisYear) {
+    return someDate.getMonth() < today.getMonth()
+  }
+
+  return someYear < thisYear
 }
 
 export function isInsideRange({ check, to, from }) {

--- a/src/components/Datepicker/Datepicker.utils.test.js
+++ b/src/components/Datepicker/Datepicker.utils.test.js
@@ -34,17 +34,18 @@ describe('Datepicker Utils', () => {
     expect(isToday(new Date(1992, 3, 24))).toBeFalsy()
   })
 
-  test('isMonthInThePast', () => {
-    const currentDate = new Date()
-    const pastDate = new Date(2020, 5, 29)
-    const futureDate = new Date(
-      currentDate.getFullYear,
-      currentDate.getMonth + 1,
-      4
-    )
-
-    expect(isMonthInThePast(pastDate)).toBeTruthy()
-    expect(isMonthInThePast(futureDate)).toBeFalsy()
+  test.each([
+    [new Date(2020, 10, 29), new Date(2020, 5, 29), true],
+    [new Date(2021, 1, 11), new Date(2020, 5, 29), true],
+    [new Date(2021, 1, 11), new Date(2021, 1, 11), false],
+    [new Date(2021, 1, 11), new Date(2021, 1, 12), false],
+  ])('isMonthInThePast(%i)', (mockDate, someDate, expected) => {
+    const spyDateFn = jest
+      .spyOn(global, 'Date')
+      .mockImplementation(() => mockDate)
+    expect(isMonthInThePast(someDate)).toEqual(expected)
+    expect(spyDateFn).toHaveBeenCalled()
+    spyDateFn.mockRestore()
   })
 
   test('getValidDateTimeString', () => {


### PR DESCRIPTION
[Jira Issue](https://helpscout.atlassian.net/browse/HSDS-180)

# Problem
There is a bug in the isMonthInThePast function the Datepicker utils that has surfaced and was caught be the 'isMonthInThePast' test in the Datepicker utils tests. The bug surfaced when we rolled over into the new year and since the test is failing we can not make new releases.

This blocked me in trying to release the next patch version 3.10.4.

The issue is with this logic:

```
return (
  someDate.getFullYear() <= today.getFullYear() &&
  someDate.getMonth() < today.getMonth()
)
```

The date used in the test was “May 29, 2020” and because we rolled over into 2021 this condition returned false when it should have returned true. May 29, 2020 is in the past but May is greater than January. We should only check if the month is less than this month if the year is this year.

 # Solution

I updated the test to use the following cases:

- "date" compared to "past date", where the month of the "date" is greater than the month of the "past date"
- "date" compared to "past date", where the month of the "date" is less than the month of the "past date". This condition is what caused tests to break when we rolled over into the new year.
- "date" compared to "same date"
- "date" compared to "future date"

I then updated the util method to get these tests to past. This involved checking if the month was less then this month if the year is the same on both dates being compared. Otherwise, we can simply compare the years.