### PR TITLE
HSAPP-2163 Make links focusable on non-webkit browsers

### DIFF
--- a/src/components/Link/Link.css.js
+++ b/src/components/Link/Link.css.js
@@ -6,6 +6,7 @@ export const LinkUI = styled('a')`
   ${linkStyles};
 
   &:focus {
+    outline: 5px auto Highlight;
     outline: 5px auto -webkit-focus-ring-color;
     outline-offset: -2px;
   }


### PR DESCRIPTION
[Jira issue](https://helpscout.atlassian.net/browse/HSAPP-2163) 

# Problem
The SPF and DKIM links on the Outgoing Mail tab do not come into focus when using the keyboard. This issue is seen on Firefox only. 

![Screen Recording 2021-01-19 at 09 11 34 AM](https://user-images.githubusercontent.com/5752727/105061205-802b7e80-5a36-11eb-9d8b-f4a76a7046bf.gif)
 
# Solution
The SPF and DKIM links are `Link` components. In the `:focus` pseudo-class, an outline is specified only for webkit browsers. I specify an outline for non-webkit browsers using the `Highlight` system color.