### PR TITLE
Change transition property name in depth.css

### DIFF
--- a/src/styles/mixins/depth.css.js
+++ b/src/styles/mixins/depth.css.js
@@ -4,7 +4,7 @@ import { getColor } from '../../styles/utilities/color'
 
 const common = `
   background-color: #fff;
-  transition: all 0.16s;
+  transition: box-shadow 0.16s;
   will-change: box-shadow;
 `
 export const d100 = `


### PR DESCRIPTION
# Problem

This change address an issue found in https://github.com/helpscout/hs-app/pull/9287. The `CheckMarkCard` utilize the depth code in `depth.css.js` and it appears that the `transistion: all  0.6s` is causing the jutter seen bellow. 

https://user-images.githubusercontent.com/7111256/105762951-ba0af200-5f1a-11eb-88b1-8f8d8f592f3d.mov

To address this issue we have set the property name on the `transition` to be more narrowly scoped to `box-shadow`

