### PR TITLE
HSDS-178: Update RadioCard component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1964,9 +1964,9 @@
       }
     },
     "@helpscout/hsds-illos": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@helpscout/hsds-illos/-/hsds-illos-1.8.0.tgz",
-      "integrity": "sha512-4Q++pUlCBG45COw2RmeQO5vNRV/7k13pUHL0UPTD5BQCmpobKZLGG/xKoU4HeayfQL3x92hCjul8QgLRqrLNCA=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@helpscout/hsds-illos/-/hsds-illos-1.9.0.tgz",
+      "integrity": "sha512-LUAeGCrQCyo7iG1uWF3Uchy8LXTyPQu4AM2j9N/3/4wSjDd9r5kVEWZaMtgoceZV1yjZSnUINbVU6ah0NAkPiQ=="
     },
     "@helpscout/motion": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@datepicker-react/hooks": "^2.7.0",
-    "@helpscout/hsds-illos": "1.8.0",
+    "@helpscout/hsds-illos": "1.9.0",
     "@helpscout/motion": "0.0.8",
     "@helpscout/react-utils": "^2.4.0",
     "@helpscout/wedux": "0.0.11",

--- a/src/components/Icon/Icon.css.js
+++ b/src/components/Icon/Icon.css.js
@@ -7,7 +7,7 @@ import styled from 'styled-components'
 
 const bem = BEM('.c-Icon')
 
-const ICON_SIZES = [8, 10, 12, 13, 14, 15, 16, 18, 20, 24, 32, 48, 52]
+const ICON_SIZES = [8, 10, 12, 13, 14, 15, 16, 18, 20, 24, 32, 48, 52, 72]
 
 export const config = {
   caretSize: 13,

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -127,6 +127,7 @@ Icon.propTypes = {
     32,
     48,
     52,
+    72,
     '8',
     '10',
     '12',
@@ -140,6 +141,7 @@ Icon.propTypes = {
     '32',
     '48',
     '52',
+    '72',
   ]),
   /** Provides a name for the component. */
   title: PropTypes.string,

--- a/src/components/RadioCard/RadioCard.css.js
+++ b/src/components/RadioCard/RadioCard.css.js
@@ -28,6 +28,7 @@ export const RadioCardUI = styled('label')`
     transform: translateY(-2px);
   }
 
+  &.is-checked:active,
   &.is-focused,
   &.is-focused.is-checked,
   &:focus-within,
@@ -42,6 +43,7 @@ export const RadioCardUI = styled('label')`
     }
 
     &,
+    &:active,
     &.is-focused,
     &.is-focused.is-checked,
     &:focus-within,

--- a/src/components/RadioCard/RadioCard.css.js
+++ b/src/components/RadioCard/RadioCard.css.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { getColor } from '../../styles/utilities/color'
-import { d300, d300Effect } from '../../styles/mixins/depth.css'
+import { d300Effect, d400Effect } from '../../styles/mixins/depth.css'
 import Heading from '../Heading'
 import Text from '../Text'
 
@@ -17,13 +17,14 @@ export const RadioCardUI = styled('label')`
   min-height: ${({ withContent, withHeading }) =>
     withHeading || withContent ? 'auto' : '100px'};
   height: ${({ height }) => (height ? height : 'auto')};
-  padding: 5px 12px 15px;
+  padding: 14px 12px 14px;
   border-radius: 4px;
-  ${d300}
+  ${d300Effect}
   cursor: pointer;
+  transition: all 0.15s;
 
   &:hover {
-    ${d300Effect}
+    ${d400Effect}
     transform: translateY(-2px);
   }
 
@@ -36,7 +37,17 @@ export const RadioCardUI = styled('label')`
   }
 
   &.is-checked {
-    ${d300Effect}
+    &:hover {
+      transform: scale(1.05) translateY(-2px);
+    }
+
+    &,
+    &.is-focused,
+    &.is-focused.is-checked,
+    &:focus-within,
+    &.is-checked:focus-within {
+      transform: scale(1.05);
+    }
   }
 `
 
@@ -44,13 +55,15 @@ export const IconWrapperUI = styled('div')`
   align-items: center;
   justify-content: center;
   display: flex;
-  width: 52px;
-  height: 52px;
-  margin-bottom: ${({ withContent, withHeading }) =>
-    withHeading || withContent ? '0' : '5px'};
+  width: auto;
+  height: ${({ iconSize }) => (iconSize ? `${iconSize}px` : 'auto')};
+  min-height: ${({ iconSize }) => (iconSize ? `${iconSize}px` : '52px')};
+  margin-bottom: ${({ withHeading }) => (withHeading ? '0' : '10px')};
   color: ${getColor('charcoal.200')};
+  opacity: 0.5;
 
   &.is-checked {
+    opacity: 1;
     color: ${getColor('charcoal.500')};
   }
 `

--- a/src/components/RadioCard/RadioCard.jsx
+++ b/src/components/RadioCard/RadioCard.jsx
@@ -129,6 +129,7 @@ class RadioCard extends React.PureComponent {
       isFocused,
       height,
       maxWidth,
+      iconSize,
       title,
       value,
       ...rest
@@ -153,6 +154,7 @@ class RadioCard extends React.PureComponent {
           )}
           withHeading={Boolean(heading)}
           withContent={Boolean(content)}
+          iconSize={iconSize}
         >
           {this.getIconMarkup()}
         </IconWrapperUI>

--- a/src/components/RadioCard/RadioCard.stories.mdx
+++ b/src/components/RadioCard/RadioCard.stories.mdx
@@ -3,6 +3,10 @@ import { boolean } from '@storybook/addon-knobs'
 import { ChoiceGroup } from '../index'
 import RadioCard from './'
 
+import MessagesFirstVisit from '@helpscout/hsds-illos/messages-first-visit'
+import MessagesManual from '@helpscout/hsds-illos/messages-manual'
+import MessagesSequence from '@helpscout/hsds-illos/messages-sequence'
+
 <Meta
   title="Components/Forms/RadioCard"
   component={RadioCard}
@@ -102,6 +106,40 @@ This component provides richer context to the of the default HTML `<input>` of t
         content="some content"
         heading="Buoy"
         value="buoy"
+      />
+    </ChoiceGroup>
+  </Story>
+</Canvas>
+
+#### With illos
+
+<Canvas>
+  <Story name="with illos">
+    <ChoiceGroup
+      align="horizontal"
+      choiceMaxWidth="160px"
+      choiceHeight="160px"
+      isResponsive
+      multiSelect={false}
+      value={['first']}
+    >
+      <RadioCard
+        icon={<MessagesFirstVisit />}
+        content="First visit"
+        value="first"
+        iconSize="72"
+      />
+      <RadioCard
+        icon={<MessagesSequence />}
+        content="Sequence"
+        value="sequence"
+        iconSize="72"
+      />
+      <RadioCard
+        icon={<MessagesManual />}
+        content="Manual"
+        value="manual"
+        iconSize="72"
       />
     </ChoiceGroup>
   </Story>


### PR DESCRIPTION
[JIRA issue](https://helpscout.atlassian.net/browse/HSDS-178)

# Feature

Purpose of this PR is to update RadioCard component to the newest design. The use of it can be found here: https://www.figma.com/file/JwgxQmv2KyQTKwoiuyxHGq/Spec%2F-Messages-1.5

The demo implementation: https://codepen.io/team/helpscout/pen/5d458fb128e71e612ef1ad7202b178cd

The main changes are in "checked" state, the whole card gets larger. Additional there's some opacity added for "non-checked" cards.

# Solution

The implementation isn't precisely as in codepen, as there are used images and fixed sizes to achieve the result. However it looks and behaves very similarly. The only thing not implemented as part of this story is change of the font color - that's because it collides with the existing usage of this component.

The solution is to use `scale` transform function to make the card larger. The card itself doesn't have a fixed size, so there's no easy way to know how many pixels the component should be larger with. Also, using `scale` makes the implementation much simpler, without the need to use absolute position and wrap into some additional HTML elements.

As part of this PR I've also added additional available Icon size, as it would be needed in the place where it would be used (Messages builder). Additionally, IconWrapper component has possiblity to adjust better to the size of Icon. This change doesn't break anything, but adds another possibility to the usage. 

There's new story added to the storybook of this component that shows an example of usage with hsds-illos.

https://c.hlp.sc/YEuRgQmD