### PR TITLE
Add withTriggerWrapper prop on Tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -57,6 +57,7 @@ const Tooltip = props => {
     renderContent,
     title,
     triggerOn,
+    withTriggerWrapper,
     zIndex: zIndexProp,
     ...rest
   } = props
@@ -67,7 +68,6 @@ const Tooltip = props => {
   const [isEntered, setEntered] = useState(animationDuration === 0)
 
   const scope = getCurrentScope ? getCurrentScope() : null
-  const trigger = triggerOn === 'hover' ? 'mouseenter' : triggerOn
 
   const hasRenderContent = renderContent && isFunction(renderContent)
   const hasRender = renderProp && isFunction(renderProp)
@@ -149,7 +149,7 @@ const Tooltip = props => {
     placement,
     plugins,
     render,
-    trigger,
+    trigger: triggerOn === 'hover' ? 'mouseenter' : triggerOn,
     showOnCreate: isOpen,
     ...rest,
     ...extraProps,
@@ -163,8 +163,22 @@ const Tooltip = props => {
     ) : null
   }
 
-  return (
-    <Tippy {...tippyProps}>
+  let trigger
+
+  if (
+    !withTriggerWrapper &&
+    React.isValidElement(children) &&
+    React.Children.count(children) === 1
+  ) {
+    const component = React.Children.only(children)
+    const triggerProps = {
+      className: classNames('TooltipTrigger', component.props.className),
+      'data-cy': component.props['data-cy'] || dataCy,
+      tabIndex: component.props['tabIndex'] || 0,
+    }
+    trigger = React.cloneElement(component, triggerProps)
+  } else {
+    trigger = (
       <TooltipTriggerUI
         tabIndex="0"
         display={display}
@@ -173,8 +187,10 @@ const Tooltip = props => {
       >
         {children}
       </TooltipTriggerUI>
-    </Tippy>
-  )
+    )
+  }
+
+  return <Tippy {...tippyProps}>{trigger}</Tippy>
 }
 
 Tooltip.defaultProps = {
@@ -187,6 +203,7 @@ Tooltip.defaultProps = {
   isOpen: false,
   placement: 'top',
   triggerOn: 'mouseenter focus',
+  withTriggerWrapper: true,
 }
 
 Tooltip.propTypes = {
@@ -216,6 +233,8 @@ Tooltip.propTypes = {
   triggerOn: PropTypes.string,
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,
+  /** Wrap the trigger with a span */
+  withTriggerWrapper: PropTypes.bool,
 }
 
 export default Tooltip

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -41,6 +41,24 @@ Tooltip is powered by [react-tippy](https://github.com/atomiks/tippyjs-react) an
 
 ### Stories
 
+#### Without trigger wrapper
+
+We wrap all children with a span to ensure that any children will work with Tippy.
+It requires a forwardable ref to work correctly. Having a `span` ensure that Tippy can attach events to any children.
+In some cases, we want to remove that span, the `withTriggerWrapper` will allow us to do exactly that:
+
+**Warning:** If there is multiple children or if the children is not a valid React element, we will still wrap everything with a span
+
+<Canvas>
+  <Story name="without trigger wrapper">
+    <div style={{ padding: '20%', textAlign: 'center' }}>
+      <Tooltip title="Hello" withTriggerWrapper={false}>
+        <button>No wrapping span Trigger</button>
+      </Tooltip>
+    </div>
+  </Story>
+</Canvas>
+
 #### With custom content
 
 <Canvas>

--- a/src/components/Tooltip/Tooltip.test.js
+++ b/src/components/Tooltip/Tooltip.test.js
@@ -31,6 +31,26 @@ describe('Children', () => {
 
     expect(el.length).toBeTruthy()
   })
+
+  test('Wraps the chidlren with a span', () => {
+    const wrapper = mount(
+      <Tooltip title="Pop">
+        <div className="ron" />
+      </Tooltip>
+    )
+
+    expect(wrapper.find('.TooltipTrigger').first().hasClass('ron')).toBeFalsy()
+  })
+
+  test('Can render directly a children', () => {
+    const wrapper = mount(
+      <Tooltip title="Pop" withTriggerWrapper={false}>
+        <div className="ron" />
+      </Tooltip>
+    )
+
+    expect(wrapper.find('.TooltipTrigger').hasClass('ron')).toBeTruthy()
+  })
 })
 
 describe('Tippy', () => {


### PR DESCRIPTION

# Problem/Feature

![Screen Recording 2021-03-23 at 02 14 30 PM](https://user-images.githubusercontent.com/203992/112197799-d8bbfb00-8be2-11eb-89cb-d2b7837261f3.gif)


This prop will allow us to remove the wrapping span around the tooltip trigger. That span exists to ensure a valid trigger for Tippy. It needs a forwardable component to attach any events on the trigger. In some scenario, that span become an issue:

- Focusable button, we need the button to have the focus state, not the wrapping span
- Group of components were we style based on the children position (first child, last child, etc) 

To make that new prop work, the children needs to be a unique and valid child:

```javascript
<Tooltip title="Hello" withTriggerWrapper={false}>
  <button>No wrapping span Trigger</button>
</Tooltip>
```

If we pass a non-valid react element, it will be wrap with the span even though the flag is turned off

```javascript
<Tooltip title="Hello" withTriggerWrapper={false}>
  No wrapping span Trigger
</Tooltip>
```

We did decide to have the wrapping `span` on by default, to stay compatible with the way the tooltip was implemented in hs-app 