### PR TITLE
Allow to use data-bypass for Nav.Item

### DIFF
--- a/src/components/Nav/Nav.Item.jsx
+++ b/src/components/Nav/Nav.Item.jsx
@@ -35,6 +35,7 @@ export class NavItem extends React.Component {
       location,
       strict,
       to,
+      'data-bypass': this.props['data-bypass'],
     }
   }
 
@@ -136,6 +137,8 @@ NavItem.propTypes = {
   innerRef: PropTypes.func,
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,
+  /** Data attr for bypassing external router handler. */
+  'data-bypass': PropTypes.string,
 }
 
 NavItem.defaultProps = {

--- a/src/components/Nav/Nav.Item.jsx
+++ b/src/components/Nav/Nav.Item.jsx
@@ -26,7 +26,15 @@ export class NavItem extends React.Component {
   }
 
   getLinkProps() {
-    const { disabled, exact, isActive, location, strict, to } = this.props
+    const {
+      disabled,
+      exact,
+      isActive,
+      location,
+      strict,
+      to,
+      'data-bypass': dataBypass,
+    } = this.props
 
     return {
       disabled,
@@ -35,7 +43,7 @@ export class NavItem extends React.Component {
       location,
       strict,
       to,
-      'data-bypass': this.props['data-bypass'],
+      'data-bypass': dataBypass,
     }
   }
 

--- a/src/components/Nav/Nav.Item.jsx
+++ b/src/components/Nav/Nav.Item.jsx
@@ -138,7 +138,7 @@ NavItem.propTypes = {
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,
   /** Data attr for bypassing external router handler. */
-  'data-bypass': PropTypes.string,
+  'data-bypass': PropTypes.bool,
 }
 
 NavItem.defaultProps = {

--- a/src/components/Nav/Nav.test.js
+++ b/src/components/Nav/Nav.test.js
@@ -119,3 +119,12 @@ describe('Nav.Item Error', () => {
     expect(el.length).toBeTruthy()
   })
 })
+
+describe('Nav.Item data-bypass', () => {
+  test('Pushes data-bypass attribute to the link element', () => {
+    const wrapper = mountWithRouter(<Item data-bypass={true} />)
+    const link = wrapper.find('a')
+
+    expect(link.prop('data-bypass')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
# Problem

This PR adds possibility to provide data-bypass attribute for a Nav.Item component and it would be set on actual link html element.
Context for the change is this story: https://helpscout.atlassian.net/browse/HSAPP-3810. In this case, we are blocking route change on React router, however there's Backbone router on top of this all that still changes the route. `data-bypass` is a special attribute to tell Backbone app to not use its router. 

Similar functionality is already present for a `Button` component