### PR TITLE
Add support for image below Message body

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -6,6 +6,7 @@ import { d600Effect } from '../../styles/mixins/depth.css'
 import Card from '../Card'
 import Button from '../Button'
 import Heading from '../Heading'
+import Image from '../Image'
 const fontFamily = makeFontFamily('Barlow')
 
 export const MessageCardUI = styled(Card)`
@@ -266,4 +267,16 @@ export const ActionButtonUI = styled(Button)`
   font-family: ${FONT_FAMILY};
   height: 54px !important;
   line-height: normal !important;
+`
+
+export const ImageUI = styled(Image)`
+  border-radius: 3px;
+`
+
+export const ImageContainerUI = styled('div')`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-top: 20px;
+  padding: 0 10px;
 `

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -11,6 +11,8 @@ import {
   SubtitleUI,
   BodyUI,
   ActionUI,
+  ImageUI,
+  ImageContainerUI,
 } from './MessageCard.css'
 import Truncate from '../Truncate'
 
@@ -81,6 +83,21 @@ export class MessageCard extends React.PureComponent {
     ) : null
   }
 
+  renderImage() {
+    const { image } = this.props
+
+    return image ? (
+      <ImageContainerUI>
+        <ImageUI
+          src={image.url}
+          alt={'Message image'}
+          width={image.width || '100%'}
+          height={image.height || 'auto'}
+        />
+      </ImageContainerUI>
+    ) : null
+  }
+
   renderAction() {
     const { action } = this.props
     return action ? (
@@ -117,6 +134,7 @@ export class MessageCard extends React.PureComponent {
           {this.renderTitle()}
           {this.renderSubtitle()}
           {this.renderBody()}
+          {this.renderImage()}
           {children}
           {this.renderAction()}
         </MessageCardUI>
@@ -164,6 +182,12 @@ MessageCard.propTypes = {
   subtitle: PropTypes.string,
   /** Title of the Message. */
   title: PropTypes.string,
+  /** Definition of the Message image */
+  image: PropTypes.shape({
+    url: PropTypes.string,
+    width: PropTypes.string,
+    height: PropTypes.string,
+  }),
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,
 }

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -90,7 +90,7 @@ export class MessageCard extends React.PureComponent {
       <ImageContainerUI>
         <ImageUI
           src={image.url}
-          alt={'Message image'}
+          alt={image.altText || 'Message image'}
           width={image.width || '100%'}
           height={image.height || 'auto'}
         />
@@ -184,9 +184,10 @@ MessageCard.propTypes = {
   title: PropTypes.string,
   /** Definition of the Message image */
   image: PropTypes.shape({
-    url: PropTypes.string,
+    url: PropTypes.string.isRequired,
     width: PropTypes.string,
     height: PropTypes.string,
+    altText: PropTypes.string,
   }),
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,

--- a/src/components/MessageCard/MessageCard.stories.mdx
+++ b/src/components/MessageCard/MessageCard.stories.mdx
@@ -42,6 +42,21 @@ This component renders a Message Card Notification with (optional) Title, Subtit
   </Story>
 </Canvas>
 
+# With image
+
+<Canvas>
+  <Story name="With image">
+    <MessageCard
+      subtitle={text('Subtitle', 'The J&G Team is here')}
+      title={text('Title', 'Need help?')}
+      image={{
+        url:
+          'http://matthewjamestaylor.com/img/illustrations/large/how-to-convert-a-liquid-layout-to-fixed-width.jpg',
+      }}
+    />
+  </Story>
+</Canvas>
+
 #### Reference
 
 - **Designer**: Buzz

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -204,6 +204,26 @@ describe('image', () => {
     expect(image.prop('width')).toEqual('100%')
     expect(image.prop('height')).toEqual('auto')
   })
+
+  test('Sets provided alt text', () => {
+    const wrapper = mount(
+      <MessageCard
+        image={{ url: 'https://path.to/image.png', altText: 'Alt text' }}
+      />
+    )
+    const image = wrapper.find('img')
+
+    expect(image.prop('alt')).toEqual('Alt text')
+  })
+
+  test('Sets default alt text', () => {
+    const wrapper = mount(
+      <MessageCard image={{ url: 'https://path.to/image.png' }} />
+    )
+    const image = wrapper.find('img')
+
+    expect(image.prop('alt')).toEqual('Message image')
+  })
 })
 
 describe('Action', () => {

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -1,7 +1,13 @@
 import React from 'react'
 import { mount, render } from 'enzyme'
 import { MessageCard } from './MessageCard'
-import { TitleUI, SubtitleUI, BodyUI, ActionUI } from './MessageCard.css'
+import {
+  TitleUI,
+  SubtitleUI,
+  BodyUI,
+  ActionUI,
+  ImageUI,
+} from './MessageCard.css'
 import { Animate } from '../index'
 import { MessageCardButton as Button } from './MessageCard.Button'
 
@@ -152,6 +158,51 @@ describe('Subtitle', () => {
 
     expect(o.length).toBe(1)
     expect(o.html()).toContain('Santa!')
+  })
+})
+
+describe('image', () => {
+  test('Does not render image if is not passed down as a prop', () => {
+    const wrapper = mount(<MessageCard />)
+    const image = wrapper.find('img')
+
+    expect(image).toHaveLength(0)
+  })
+
+  test('Renders image if it is passed down as a prop', () => {
+    const wrapper = mount(
+      <MessageCard image={{ url: 'https://path.to/image.png' }} />
+    )
+    const image = wrapper.find('img')
+
+    expect(image).toHaveLength(1)
+    expect(image.prop('src')).toEqual('https://path.to/image.png')
+  })
+
+  test('Sets size of image when provided', () => {
+    const wrapper = mount(
+      <MessageCard
+        image={{
+          url: 'https://path.to/image.png',
+          width: '100',
+          height: '200',
+        }}
+      />
+    )
+    const image = wrapper.find(ImageUI)
+
+    expect(image.prop('width')).toEqual('100')
+    expect(image.prop('height')).toEqual('200')
+  })
+
+  test('Sets default size of image when not provided', () => {
+    const wrapper = mount(
+      <MessageCard image={{ url: 'https://path.to/image.png' }} />
+    )
+    const image = wrapper.find(ImageUI)
+
+    expect(image.prop('width')).toEqual('100%')
+    expect(image.prop('height')).toEqual('auto')
   })
 })
 


### PR DESCRIPTION
# Feature

Related JIRA ticket: https://helpscout.atlassian.net/browse/BEMBED-235
Related figma: https://www.figma.com/file/JwgxQmv2KyQTKwoiuyxHGq/Spec%2F-Messages-1.5?node-id=0%3A1

We need to be able to display Image on the Message Card, below the body. There could be only one image per message at the moment. Image would be resized to the original size that it was uploaded with, and centered when width of image is smaller than width of message card.


