### PR TITLE
Allow to disable item in a DropList

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -113,6 +113,7 @@ function Combobox({
       key: generateListItemKey(item, index),
       withMultipleSelection,
       renderCustomListItem,
+      isDisabled: item.isDisabled,
       ...getItemProps({ item, index }),
     }
 

--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -84,6 +84,7 @@ function Combobox({
       return stateReducerCommon({
         changes,
         closeOnSelection,
+        items,
         selectedItems,
         state,
         type: `${VARIANTS.COMBOBOX}.${type}`,
@@ -114,7 +115,16 @@ function Combobox({
       withMultipleSelection,
       renderCustomListItem,
       isDisabled: item.isDisabled,
-      ...getItemProps({ item, index }),
+      ...getItemProps({
+        item,
+        index,
+        onClick: event => {
+          if (item.isDisabled) {
+            event.nativeEvent.preventDownshiftDefault = true
+            return
+          }
+        },
+      }),
     }
 
     return <ListItem {...itemProps} />

--- a/src/components/DropList/DropList.ListItem.jsx
+++ b/src/components/DropList/DropList.ListItem.jsx
@@ -77,6 +77,7 @@ const ListItem = forwardRef(
             isSelected,
             isHighlighted: highlightedIndex === index,
             withMultipleSelection,
+            isDisabled,
           })}
         </li>
       )

--- a/src/components/DropList/DropList.ListItem.jsx
+++ b/src/components/DropList/DropList.ListItem.jsx
@@ -22,7 +22,6 @@ const ListItem = forwardRef(
       withMultipleSelection,
       isSelected,
       renderCustomListItem,
-      onClick,
       isDisabled,
       ...itemProps
     },
@@ -47,12 +46,6 @@ const ListItem = forwardRef(
       )
     }
 
-    const handleClick = event => {
-      if (!isDisabled) {
-        onClick(event)
-      }
-    }
-
     function getListItemClassNames(extraClassNames) {
       return classNames(
         'DropListItem',
@@ -69,7 +62,6 @@ const ListItem = forwardRef(
         <li
           className={getListItemClassNames('DropListItem--custom')}
           ref={ref}
-          onClick={handleClick}
           {...itemProps}
         >
           {renderCustomListItem({
@@ -90,7 +82,6 @@ const ListItem = forwardRef(
         ref={ref}
         selected={isSelected}
         withMultipleSelection={withMultipleSelection}
-        onClick={handleClick}
         {...itemProps}
       >
         <span>{isObject(item) ? item[contentKey] : item}</span>

--- a/src/components/DropList/DropList.ListItem.jsx
+++ b/src/components/DropList/DropList.ListItem.jsx
@@ -22,6 +22,8 @@ const ListItem = forwardRef(
       withMultipleSelection,
       isSelected,
       renderCustomListItem,
+      onClick,
+      isDisabled,
       ...itemProps
     },
     ref
@@ -45,10 +47,17 @@ const ListItem = forwardRef(
       )
     }
 
+    const handleClick = event => {
+      if (!isDisabled) {
+        onClick(event)
+      }
+    }
+
     function getListItemClassNames(extraClassNames) {
       return classNames(
         'DropListItem',
         isSelected && 'is-selected',
+        isDisabled && 'is-disabled',
         highlightedIndex === index && 'is-highlighted',
         withMultipleSelection && 'with-multiple-selection',
         isString(extraClassNames) && extraClassNames
@@ -60,6 +69,7 @@ const ListItem = forwardRef(
         <li
           className={getListItemClassNames('DropListItem--custom')}
           ref={ref}
+          onClick={handleClick}
           {...itemProps}
         >
           {renderCustomListItem({
@@ -79,6 +89,7 @@ const ListItem = forwardRef(
         ref={ref}
         selected={isSelected}
         withMultipleSelection={withMultipleSelection}
+        onClick={handleClick}
         {...itemProps}
       >
         <span>{isObject(item) ? item[contentKey] : item}</span>

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -100,6 +100,7 @@ function Select({
       key: generateListItemKey(item, index),
       withMultipleSelection,
       renderCustomListItem,
+      isDisabled: item.isDisabled,
       ...getItemProps({ item, index }),
     }
 

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -79,6 +79,7 @@ function Select({
       return stateReducerCommon({
         changes,
         closeOnSelection,
+        items,
         selectedItems,
         state,
         type: `${VARIANTS.SELECT}.${type}`,
@@ -101,7 +102,16 @@ function Select({
       withMultipleSelection,
       renderCustomListItem,
       isDisabled: item.isDisabled,
-      ...getItemProps({ item, index }),
+      ...getItemProps({
+        item,
+        index,
+        onClick: event => {
+          if (item.isDisabled) {
+            event.nativeEvent.preventDownshiftDefault = true
+            return
+          }
+        },
+      }),
     }
 
     return <ListItem {...itemProps} />

--- a/src/components/DropList/DropList.css.js
+++ b/src/components/DropList/DropList.css.js
@@ -113,6 +113,13 @@ export const ListItemUI = styled('li')`
       background-color: ${getColor('blue.100')};
     }
   }
+
+  &.is-disabled,
+  &.with-multiple-selection.is-disabled {
+    color: ${getColor('charcoal.200')};
+    background-color: transparent;
+    cursor: default;
+  }
 `
 
 export const EmptyListUI = styled('div')`

--- a/src/components/DropList/DropList.downshift.common.js
+++ b/src/components/DropList/DropList.downshift.common.js
@@ -1,6 +1,10 @@
 import { useSelect, useCombobox } from 'downshift'
 import { isObject } from '../../utilities/is'
-import { findItemInArray, getItemContentKeyName } from './DropList.utils'
+import {
+  findItemInArray,
+  getEnabledItemIndex,
+  getItemContentKeyName,
+} from './DropList.utils'
 import { OPEN_ACTION_ORIGIN, VARIANTS } from './DropList.constants'
 
 const { SELECT, COMBOBOX } = VARIANTS
@@ -8,6 +12,7 @@ const { SELECT, COMBOBOX } = VARIANTS
 export function stateReducerCommon({
   changes,
   closeOnSelection,
+  items,
   selectedItems,
   state,
   type,
@@ -66,6 +71,34 @@ export function stateReducerCommon({
       } else {
         return { ...changes, inputValue: '' }
       }
+
+    case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputKeyDownArrowUp}`:
+    case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownArrowUp}`: {
+      const { highlightedIndex } = changes
+
+      return {
+        ...changes,
+        highlightedIndex: getEnabledItemIndex({
+          highlightedIndex,
+          items,
+          arrowKey: 'UP',
+        }),
+      }
+    }
+
+    case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputKeyDownArrowDown}`:
+    case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownArrowDown}`: {
+      const { highlightedIndex } = changes
+
+      return {
+        ...changes,
+        highlightedIndex: getEnabledItemIndex({
+          highlightedIndex,
+          items,
+          arrowKey: 'DOWN',
+        }),
+      }
+    }
 
     default:
       return changes

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -251,6 +251,7 @@ const itemShape = PropTypes.shape({
   label: requiredItemPropsCheck,
   value: requiredItemPropsCheck,
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  isDisabled: PropTypes.bool,
 })
 const dividerShape = PropTypes.shape({
   type: PropTypes.oneOf(['divider', 'Divider']).isRequired,

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -153,6 +153,9 @@ function DropListManager({
   }
 
   function handleSelectedItemChange({ selectedItem }) {
+    if (selectedItem.isDisabled) {
+      return
+    }
     if (withMultipleSelection) {
       if (selectedItem) {
         const { remove } = selectedItem

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -374,6 +374,7 @@ function renderCustomListItem({
   item,
   isSelected,
   isHighlighted,
+  isDisabled,
   withMultipleSelection,
 })
 
@@ -385,6 +386,7 @@ function renderCustomListItem({
     item,
     isSelected,
     isHighlighted,
+    isDisabled,
     withMultipleSelection,
   }) => (
     <div className={classnames(isSelected && 'is-selected')}>

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -15,6 +15,7 @@ import {
   plainItems,
   regularItems,
   simpleGroupedItems,
+  disabledItems,
 } from '../../utilities/specs/dropdown.specs'
 
 <Meta
@@ -422,6 +423,24 @@ function renderCustomListItem({
           </div>
         )}
       />
+    </div>
+  </Story>
+</Canvas>
+
+- Disabled List Items: Sometimes you might need to render the list items that would be disabled, for that you can pass `isDisbaled` flag with an item.
+
+<Canvas>
+  <Story name="Items: disabled list items">
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList items={disabledItems} toggler={<SimpleButton text="Click" />} />
     </div>
   </Story>
 </Canvas>

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -442,7 +442,60 @@ function renderCustomListItem({
         padding: '20px',
       }}
     >
-      <DropList items={disabledItems} toggler={<SimpleButton text="Click" />} />
+      <DropList
+        items={disabledItems}
+        toggler={<SimpleButton text="Click" />}
+        onSelect={selection => {
+          console.log('selection', selection)
+        }}
+      />
+    </div>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Items: disabled list items (combobox)">
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        items={disabledItems}
+        variant="combobox"
+        toggler={<SimpleButton text="Click" />}
+        onSelect={selection => {
+          console.log('selection', selection)
+        }}
+      />
+    </div>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Items: disabled list items (Multiple Selection)">
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        items={disabledItems}
+        closeOnSelection={false}
+        onSelect={selection => {
+          console.log('selection', selection)
+        }}
+        toggler={<SimpleButton text="Submit" />}
+        withMultipleSelection
+      />
     </div>
   </Story>
 </Canvas>

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -892,12 +892,13 @@ describe('Selection', () => {
   })
 
   describe('disabled items', () => {
+    const items = dedupedRegularItems.map(item => ({
+      ...item,
+      isDisabled: true,
+    }))
+
     test('should set an item as disabled and do not allow to select it (select)', async () => {
       const onSelect = jest.fn()
-      const items = dedupedRegularItems.map(item => ({
-        ...item,
-        isDisabled: true,
-      }))
       const { getByText } = render(
         <DropList
           onSelect={onSelect}
@@ -918,10 +919,6 @@ describe('Selection', () => {
 
     test('should set an item as disabled and do not allow to select it (combobox)', async () => {
       const onSelect = jest.fn()
-      const items = dedupedRegularItems.map(item => ({
-        ...item,
-        isDisabled: true,
-      }))
       const { getByText } = render(
         <DropList
           onSelect={onSelect}
@@ -939,6 +936,29 @@ describe('Selection', () => {
       })
       user.click(getByText(regularItems[2].label))
       expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    test('should set an item as disabled and do not allow to select it with custom list', async () => {
+      const onSelect = jest.fn()
+      const { getByText } = render(
+        <DropList
+          onSelect={onSelect}
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+          renderCustomListItem={({ item, isDisabled }) => (
+            <div className={isDisabled ? 'is-disabled' : ''}>{item.label}</div>
+          )}
+        />
+      )
+
+      const exampleItem = getByText(regularItems[2].label)
+      await waitFor(() =>
+        expect(exampleItem.parentElement).toHaveClass('is-disabled')
+      )
+      user.click(exampleItem)
+      expect(onSelect).not.toHaveBeenCalled()
+      expect(exampleItem).toHaveClass('is-disabled')
     })
   })
 })

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -890,4 +890,55 @@ describe('Selection', () => {
       ).toBeTruthy()
     })
   })
+
+  describe('disabled items', () => {
+    test('should set an item as disabled and do not allow to select it (select)', async () => {
+      const onSelect = jest.fn()
+      const items = dedupedRegularItems.map(item => ({
+        ...item,
+        isDisabled: true,
+      }))
+      const { getByText } = render(
+        <DropList
+          onSelect={onSelect}
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+        />
+      )
+
+      await waitFor(() => {
+        expect(getByText(regularItems[2].label).parentElement).toHaveClass(
+          'is-disabled'
+        )
+      })
+      user.click(getByText(regularItems[2].label))
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    test('should set an item as disabled and do not allow to select it (combobox)', async () => {
+      const onSelect = jest.fn()
+      const items = dedupedRegularItems.map(item => ({
+        ...item,
+        isDisabled: true,
+      }))
+      const { getByText } = render(
+        <DropList
+          onSelect={onSelect}
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+          variant={'combobox'}
+        />
+      )
+
+      await waitFor(() => {
+        expect(getByText(regularItems[2].label).parentElement).toHaveClass(
+          'is-disabled'
+        )
+      })
+      user.click(getByText(regularItems[2].label))
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -892,9 +892,9 @@ describe('Selection', () => {
   })
 
   describe('disabled items', () => {
-    const items = dedupedRegularItems.map(item => ({
+    const items = dedupedRegularItems.map((item, index) => ({
       ...item,
-      isDisabled: true,
+      isDisabled: index % 2 === 0,
     }))
 
     test('should set an item as disabled and do not allow to select it (select)', async () => {
@@ -908,13 +908,18 @@ describe('Selection', () => {
         />
       )
 
-      await waitFor(() => {
-        expect(getByText(regularItems[2].label).parentElement).toHaveClass(
-          'is-disabled'
-        )
-      })
+      expect(getByText(regularItems[2].label).parentElement).toHaveClass(
+        'is-disabled'
+      )
+      expect(getByText(regularItems[1].label).parentElement).not.toHaveClass(
+        'is-disabled'
+      )
+
       user.click(getByText(regularItems[2].label))
-      expect(onSelect).not.toHaveBeenCalled()
+
+      await waitFor(() => {
+        expect(onSelect).not.toHaveBeenCalled()
+      })
     })
 
     test('should set an item as disabled and do not allow to select it (combobox)', async () => {
@@ -925,17 +930,19 @@ describe('Selection', () => {
           items={items}
           toggler={<SimpleButton text="Button Toggler" />}
           isMenuOpen
-          variant={'combobox'}
+          variant="combobox"
         />
       )
 
-      await waitFor(() => {
-        expect(getByText(regularItems[2].label).parentElement).toHaveClass(
-          'is-disabled'
-        )
-      })
+      expect(getByText(regularItems[2].label).parentElement).toHaveClass(
+        'is-disabled'
+      )
+
       user.click(getByText(regularItems[2].label))
-      expect(onSelect).not.toHaveBeenCalled()
+
+      await waitFor(() => {
+        expect(onSelect).not.toHaveBeenCalled()
+      })
     })
 
     test('should set an item as disabled and do not allow to select it with custom list', async () => {
@@ -953,12 +960,87 @@ describe('Selection', () => {
       )
 
       const exampleItem = getByText(regularItems[2].label)
-      await waitFor(() =>
-        expect(exampleItem.parentElement).toHaveClass('is-disabled')
-      )
+
+      expect(exampleItem.parentElement).toHaveClass('is-disabled')
+
       user.click(exampleItem)
-      expect(onSelect).not.toHaveBeenCalled()
-      expect(exampleItem).toHaveClass('is-disabled')
+
+      await waitFor(() => {
+        expect(onSelect).not.toHaveBeenCalled()
+        expect(exampleItem).toHaveClass('is-disabled')
+      })
+    })
+
+    test('should skip disabled items when navigating down', async () => {
+      const { getByPlaceholderText, getByText } = render(
+        <DropList
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+          variant="combobox"
+        />
+      )
+
+      user.type(getByPlaceholderText('Search'), '{arrowdown}')
+
+      await waitFor(() => {
+        expect(getByText(regularItems[0].label).parentElement).not.toHaveClass(
+          'is-highlighted'
+        )
+        expect(getByText(regularItems[1].label).parentElement).toHaveClass(
+          'is-highlighted'
+        )
+      })
+
+      user.type(getByPlaceholderText('Search'), '{arrowdown}')
+
+      await waitFor(() => {
+        expect(getByText(regularItems[1].label).parentElement).not.toHaveClass(
+          'is-highlighted'
+        )
+        expect(getByText(regularItems[2].label).parentElement).not.toHaveClass(
+          'is-highlighted'
+        )
+        expect(getByText(regularItems[3].label).parentElement).toHaveClass(
+          'is-highlighted'
+        )
+      })
+    })
+
+    test('should skip disabled items when navigating up', async () => {
+      const { getByPlaceholderText, getByText } = render(
+        <DropList
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+          variant="combobox"
+        />
+      )
+
+      user.type(getByPlaceholderText('Search'), '{arrowup}')
+
+      await waitFor(() => {
+        expect(getByText(regularItems[0].label).parentElement).not.toHaveClass(
+          'is-highlighted'
+        )
+        expect(
+          getByText(regularItems[regularItems.length - 2].label).parentElement
+        ).toHaveClass('is-highlighted')
+      })
+
+      user.type(getByPlaceholderText('Search'), '{arrowup}')
+
+      await waitFor(() => {
+        expect(
+          getByText(regularItems[regularItems.length - 2].label).parentElement
+        ).not.toHaveClass('is-highlighted')
+        expect(
+          getByText(regularItems[regularItems.length - 3].label).parentElement
+        ).not.toHaveClass('is-highlighted')
+        expect(
+          getByText(regularItems[regularItems.length - 4].label).parentElement
+        ).toHaveClass('is-highlighted')
+      })
     })
   })
 })

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -188,3 +188,33 @@ export function requiredItemPropsCheck(props, propName, componentName) {
     )
   }
 }
+
+export function getEnabledItemIndex({ highlightedIndex, items, arrowKey }) {
+  let enabledItemIndex = 0
+
+  if (arrowKey === 'UP') {
+    for (let index = items.length - 1; index >= 0; index--) {
+      if (
+        (highlightedIndex === 0 && !items[index].isDisabled) ||
+        (index <= highlightedIndex && !items[index].isDisabled)
+      ) {
+        enabledItemIndex = index
+        break
+      }
+    }
+  }
+
+  if (arrowKey === 'DOWN') {
+    for (let index = 0; index < items.length; index++) {
+      if (
+        (highlightedIndex === items.length - 1 && !items[index].isDisabled) ||
+        (index >= highlightedIndex && !items[index].isDisabled)
+      ) {
+        enabledItemIndex = index
+        break
+      }
+    }
+  }
+
+  return enabledItemIndex
+}

--- a/src/utilities/specs/dropdown.specs.js
+++ b/src/utilities/specs/dropdown.specs.js
@@ -74,10 +74,13 @@ export const groupAndDividerItems = [
 
 export const regularItems = ItemSpec.generate(15)
 
-export const disabledItems = ItemSpec.generate(10).map(item => ({
-  ...item,
-  isDisabled: true,
-}))
+export const disabledItems = ItemSpec.generate(10).map((item, index) => {
+  if (index % 2 === 0) {
+    item.isDisabled = true
+  }
+
+  return item
+})
 
 export const plainItems = [
   'hello',

--- a/src/utilities/specs/dropdown.specs.js
+++ b/src/utilities/specs/dropdown.specs.js
@@ -74,6 +74,11 @@ export const groupAndDividerItems = [
 
 export const regularItems = ItemSpec.generate(15)
 
+export const disabledItems = ItemSpec.generate(10).map(item => ({
+  ...item,
+  isDisabled: true,
+}))
+
 export const plainItems = [
   'hello',
   'hola',


### PR DESCRIPTION
# Problem/Feature

Purpose of this PR is to allow users to disable items in a menu. The item would not be clickable, or selectable in any other way. Additionally, flag `isDisabled` would be available for a custom item renderer, so that user can easily style the item in this case.

![Screenshot from 2021-04-16 16-43-16](https://user-images.githubusercontent.com/1765264/115041502-de032180-9ed2-11eb-992c-e1374dc980a0.png)
