### PR TITLE
Prevent MessageCard image from resizing

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -7,6 +7,9 @@ import Card from '../Card'
 import Button from '../Button'
 import Heading from '../Heading'
 import Image from '../Image'
+
+export const MAX_IMAGE_SIZE = 278
+
 const fontFamily = makeFontFamily('Barlow')
 
 export const MessageCardUI = styled(Card)`
@@ -272,7 +275,7 @@ export const ImageUI = styled(Image)`
   border-radius: 3px;
   height: ${({ height }) => height};
   width: ${({ width }) => width};
-  max-height: 278px;
+  max-height: ${MAX_IMAGE_SIZE}px;
 `
 
 export const ImageContainerUI = styled('div')`
@@ -281,5 +284,5 @@ export const ImageContainerUI = styled('div')`
   width: 100%;
   margin-top: 20px;
   padding: 0 10px;
-  max-height: 278px;
+  max-height: ${MAX_IMAGE_SIZE}px;
 `

--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -271,6 +271,9 @@ export const ActionButtonUI = styled(Button)`
 
 export const ImageUI = styled(Image)`
   border-radius: 3px;
+  height: ${({ height }) => height || 'auto'};
+  width: ${({ width }) => width || '100%'};
+  max-height: 278px;
 `
 
 export const ImageContainerUI = styled('div')`
@@ -279,4 +282,5 @@ export const ImageContainerUI = styled('div')`
   width: 100%;
   margin-top: 20px;
   padding: 0 10px;
+  max-height: 278px;
 `

--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -271,8 +271,8 @@ export const ActionButtonUI = styled(Button)`
 
 export const ImageUI = styled(Image)`
   border-radius: 3px;
-  height: ${({ height }) => height || 'auto'};
-  width: ${({ width }) => width || '100%'};
+  height: ${({ height }) => `${height}px` || 'auto'};
+  width: ${({ width }) => `${width}px` || '100%'};
   max-height: 278px;
 `
 

--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -270,8 +270,8 @@ export const ActionButtonUI = styled(Button)`
 
 export const ImageUI = styled(Image)`
   border-radius: 3px;
-  height: ${({ height }) => `${height}px` || 'auto'};
-  width: ${({ width }) => `${width}px` || '100%'};
+  height: ${({ height }) => height};
+  width: ${({ width }) => width};
   max-height: 278px;
 `
 

--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -14,7 +14,7 @@ export const MessageCardUI = styled(Card)`
   background-color: white;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  padding: 20px 0 25px;
+  padding: 12px 0 10px;
   width: 300px;
   word-break: break-word;
   display: flex;
@@ -59,7 +59,6 @@ export const MessageCardUI = styled(Card)`
 export const TitleUI = styled(Heading)`
   ${fontFamily};
   line-height: 22px !important;
-  margin-top: 5px;
   padding: 0 20px;
   flex: 0 0 auto;
 `

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -18,11 +18,7 @@ import Truncate from '../Truncate'
 
 const MAX_IMAGE_SIZE = 278
 
-const sizeWithRatio = (
-  recalculatedSide,
-  otherSide,
-  defaultValue = recalculatedSide
-) =>
+const sizeWithRatio = (recalculatedSide, otherSide, defaultValue) =>
   // Check if other side is smaller than max size to not recalculate unnecessarily this side as it doesn't need any scaling
   // other condition checks that the image fits the boundaries
   otherSide < MAX_IMAGE_SIZE
@@ -110,8 +106,8 @@ export class MessageCard extends React.PureComponent {
         <ImageUI
           src={image.url}
           alt={image.altText || 'Message image'}
-          width={width || '100%'}
-          height={height || 'auto'}
+          width={width ? `${width}px` : '100%'}
+          height={height ? `${height}px` : 'auto'}
         />
       </ImageContainerUI>
     )
@@ -131,10 +127,13 @@ export class MessageCard extends React.PureComponent {
     }
 
     if (width > height) {
-      return { height: sizeWithRatio(height, width), width: '100%' }
+      return {
+        height: sizeWithRatio(height, width, height),
+        width: Math.min(width, MAX_IMAGE_SIZE),
+      }
     } else {
       return {
-        width: sizeWithRatio(width, height, '100%'),
+        width: sizeWithRatio(width, height, MAX_IMAGE_SIZE),
         height: Math.min(height, MAX_IMAGE_SIZE),
       }
     }

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -10,13 +10,12 @@ import {
   BodyUI,
   ImageContainerUI,
   ImageUI,
+  MAX_IMAGE_SIZE,
   MessageCardUI,
   SubtitleUI,
   TitleUI,
 } from './MessageCard.css'
 import Truncate from '../Truncate'
-
-const MAX_IMAGE_SIZE = 278
 
 const sizeWithRatio = (recalculatedSide, otherSide, defaultValue) =>
   // Check if other side is smaller than max size to not recalculate unnecessarily this side as it doesn't need any scaling

--- a/src/components/MessageCard/MessageCard.stories.mdx
+++ b/src/components/MessageCard/MessageCard.stories.mdx
@@ -50,6 +50,8 @@ This component renders a Message Card Notification with (optional) Title, Subtit
       subtitle={text('Subtitle', 'The J&G Team is here')}
       title={text('Title', 'Need help?')}
       image={{
+        height: '230',
+        width: '800',
         url:
           'http://matthewjamestaylor.com/img/illustrations/large/how-to-convert-a-liquid-layout-to-fixed-width.jpg',
       }}

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -192,8 +192,8 @@ describe('image', () => {
     )
     const image = wrapper.find(ImageUI)
 
-    expect(image.prop('width')).toEqual(100)
-    expect(image.prop('height')).toEqual(200)
+    expect(image.prop('width')).toEqual('100px')
+    expect(image.prop('height')).toEqual('200px')
   })
 
   test('Scales size of image when larger than fits and width is bigger', () => {
@@ -208,8 +208,8 @@ describe('image', () => {
     )
     const image = wrapper.find(ImageUI)
 
-    expect(image.prop('height')).toEqual(104.25)
-    expect(image.prop('width')).toEqual('100%')
+    expect(image.prop('height')).toEqual('104.25px')
+    expect(image.prop('width')).toEqual('278px')
   })
 
   test('Scales size of image when larger than fits and height is bigger', () => {
@@ -224,8 +224,8 @@ describe('image', () => {
     )
     const image = wrapper.find(ImageUI)
 
-    expect(image.prop('height')).toEqual(278)
-    expect(image.prop('width')).toEqual(104.25)
+    expect(image.prop('height')).toEqual('278px')
+    expect(image.prop('width')).toEqual('104.25px')
   })
 
   test('Sets default size of image when not provided', () => {

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -7,6 +7,7 @@ import {
   BodyUI,
   ActionUI,
   ImageUI,
+  ImageContainerUI,
 } from './MessageCard.css'
 import { Animate } from '../index'
 import { MessageCardButton as Button } from './MessageCard.Button'
@@ -191,8 +192,40 @@ describe('image', () => {
     )
     const image = wrapper.find(ImageUI)
 
-    expect(image.prop('width')).toEqual('100')
-    expect(image.prop('height')).toEqual('200')
+    expect(image.prop('width')).toEqual(100)
+    expect(image.prop('height')).toEqual(200)
+  })
+
+  test('Scales size of image when larger than fits and width is bigger', () => {
+    const wrapper = mount(
+      <MessageCard
+        image={{
+          url: 'https://path.to/image.png',
+          width: '800',
+          height: '300',
+        }}
+      />
+    )
+    const image = wrapper.find(ImageUI)
+
+    expect(image.prop('height')).toEqual(104.25)
+    expect(image.prop('width')).toEqual('100%')
+  })
+
+  test('Scales size of image when larger than fits and height is bigger', () => {
+    const wrapper = mount(
+      <MessageCard
+        image={{
+          url: 'https://path.to/image.png',
+          width: '300',
+          height: '800',
+        }}
+      />
+    )
+    const image = wrapper.find(ImageUI)
+
+    expect(image.prop('height')).toEqual(278)
+    expect(image.prop('width')).toEqual(104.25)
   })
 
   test('Sets default size of image when not provided', () => {


### PR DESCRIPTION
# Problem

The size of the MessageCard image is now set to be the size of original image. This approach has an issue that when the original image is really big, it would cause the Message UI to jump after loading image to adjust to the actually displayed size..

Because of that, it's necessary to recalculate the dimensions of an image so that it fits the given boundaries. Boundaries has been defined as a 278x278 square (based on the available width within a MessageCard). The image would keep aspect ration, independent if it wider or taller, adjusting to the longer side. The image container would be visible before image renders, as a transparent space, preventing the card to resize afterwards.

How it looked before: https://c.hlp.sc/YEuRPR4B (there's a short, but visible moment when the whole card gets bigger when image is loaded)
How it looks now: https://c.hlp.sc/YEuRPRYj (notice that the card has the same size for the whole time)

Related JIRA ticket: https://helpscout.atlassian.net/browse/BEMBED-266
