### PR TITLE
Fix MessageCard paddings

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -17,7 +17,7 @@ export const MessageCardUI = styled(Card)`
   background-color: white;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  padding: 12px 0 10px;
+  padding: 17px 0 25px;
   width: 300px;
   word-break: break-word;
   display: flex;
@@ -285,4 +285,8 @@ export const ImageContainerUI = styled('div')`
   margin-top: 20px;
   padding: 0 10px;
   max-height: ${MAX_IMAGE_SIZE}px;
+
+  &:last-child {
+    margin-bottom: -15px;
+  }
 `


### PR DESCRIPTION
# Problem/Feature

In one of the previous PRs I've changed the paddings inside a MessageCard component, but it turned out that there is a visual bug in certain use cases. I am changing them (almost) back here + proper adjustment to the styles of an image inside a Card.
The image would be pushed closer to the bottom border of a Card when it's the last item inside.

This PR relates to this JIRA: https://helpscout.atlassian.net/browse/BEMBED-266 and this PR: https://github.com/helpscout/hsds-react/pull/916
