### PR TITLE
Improve accessibility of Attachment remove button

### DIFF
--- a/src/components/Attachment/Attachment.css.js
+++ b/src/components/Attachment/Attachment.css.js
@@ -110,7 +110,8 @@ export const AttachmentUI = styled.a`
 
   ${bem.element('closeButton')} {
     ${cardStyles()};
-    display: none;
+    display: block;
+    clip: rect(0, 0, 0, 0);
     border-radius: 9999px !important;
     position: absolute;
     right: 0;
@@ -119,9 +120,14 @@ export const AttachmentUI = styled.a`
     z-index: 1;
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     ${bem.element('closeButton')} {
-      display: block;
+      clip: unset;
     }
+  }
+
+  ${bem.element('closeButton')}:focus {
+    clip: unset;
   }
 `

--- a/src/components/Attachment/Attachment.jsx
+++ b/src/components/Attachment/Attachment.jsx
@@ -44,6 +44,8 @@ export class Attachment extends React.PureComponent {
   }
 
   handleOnRemoveClick = event => {
+    // prevent from opening a link set on attachment if remove button clicked
+    event.preventDefault()
     this.props.onRemoveClick(event, this.getAttachmentProps())
   }
 
@@ -122,6 +124,7 @@ export class Attachment extends React.PureComponent {
         onClick={this.handleOnRemoveClick}
         size="tiny"
         title="Remove"
+        aria-label="Remove attachment"
       />
     ) : null
 


### PR DESCRIPTION
# Problem/Feature

Currently it's not possible to navigate to remove button of an Attachment preview with keyboard. This PR adds a functionality to show remove button not only on hover, but also on focus. Additionally there's a change on how hiding of a button is done. Previously it was by setting `display:none;`, but this breaks the accessibility. Instead, the button is now clipped to no size and the clip is removed on hover/focus. 

The best way to test this change is to check `Attachment -> Preview theme` story and try tabbing to the attachment and a remove button.

See this recording: https://c.hlp.sc/ApuYg8ez