### PR TITLE
[Refactor] Replaces usage of Dropdown in EditableField with DropList

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5297,6 +5297,18 @@
       "integrity": "sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==",
       "dev": true
     },
+    "@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "dev": true,
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
     "@types/cheerio": {
       "version": "0.22.28",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.28.tgz",
@@ -5392,6 +5404,12 @@
       "integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==",
       "dev": true
     },
+    "@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
+      "dev": true
+    },
     "@types/is-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.0.tgz",
@@ -5443,6 +5461,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/markdown-to-jsx": {
       "version": "6.11.3",
@@ -5609,6 +5636,15 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/scheduler": {
@@ -7676,6 +7712,33 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "cacheable-lookup": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+      "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
+      "dev": true,
+      "requires": {
+        "@types/keyv": "^3.1.1",
+        "keyv": "^4.0.0"
+      },
+      "dependencies": {
+        "json-buffer": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+          "dev": true
+        },
+        "keyv": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+          "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+          "dev": true,
+          "requires": {
+            "json-buffer": "3.0.1"
+          }
+        }
       }
     },
     "cacheable-request": {
@@ -9772,58 +9835,57 @@
       }
     },
     "del": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-      "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
       "dev": true,
       "requires": {
-        "@types/glob": "^7.1.1",
-        "globby": "^6.1.0",
-        "is-path-cwd": "^2.0.0",
-        "is-path-in-cwd": "^2.0.0",
-        "p-map": "^2.0.0",
-        "pify": "^4.0.1",
-        "rimraf": "^2.6.3"
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
       },
       "dependencies": {
-        "array-union": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
           "dev": true,
           "requires": {
-            "array-uniq": "^1.0.1"
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
           }
         },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
+            "aggregate-error": "^3.0.0"
           }
         },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
         }
       }
     },
@@ -13452,6 +13514,15 @@
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
+    "ignore-walk": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "immer": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
@@ -14205,6 +14276,12 @@
         "is-path-inside": "^3.0.2"
       }
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
     "is-ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
@@ -14296,26 +14373,6 @@
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
       "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
       "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-      "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^2.1.0"
-      },
-      "dependencies": {
-        "is-path-inside": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-          "dev": true,
-          "requires": {
-            "path-is-inside": "^1.0.2"
-          }
-        }
-      }
     },
     "is-path-inside": {
       "version": "3.0.3",
@@ -14432,13 +14489,10 @@
       "dev": true
     },
     "is-url-superb": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-3.0.0.tgz",
-      "integrity": "sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==",
-      "dev": true,
-      "requires": {
-        "url-regex": "^5.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+      "dev": true
     },
     "is-whitespace-character": {
       "version": "1.0.4",
@@ -17545,26 +17599,19 @@
       "dev": true
     },
     "mem": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.1.tgz",
+      "integrity": "sha512-Ci6bIfq/UgcxPTYa8dQQ5FY3BzKkT894bwXWXxC/zqs0XgMO2cT20CGkOqda7gZNkmK5VP4x89IGZ6K7hfbn3Q==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.0.0"
       },
       "dependencies": {
         "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
-        },
-        "p-is-promise": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
           "dev": true
         }
       }
@@ -18382,46 +18429,50 @@
       "dev": true
     },
     "np": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/np/-/np-6.2.3.tgz",
-      "integrity": "sha512-EuRlncnTPL6e/p1lqa1lbrTPPddT3KWpTvztTmOCrB2/ZvHp73xqljoUh7xSm+NTipbrcSacTDSlDZt8N6MeWg==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/np/-/np-7.5.0.tgz",
+      "integrity": "sha512-CdpgqtO6JpDKJjQ2gueY0jnbz6APWA9wFXSwPv5bXg4seSBibHqQ8JyWxYlS8YRfVbpeDtj582wcAWTlfy5qNA==",
       "dev": true,
       "requires": {
-        "@samverschueren/stream-to-observable": "^0.3.0",
-        "any-observable": "^0.5.0",
+        "@samverschueren/stream-to-observable": "^0.3.1",
+        "any-observable": "^0.5.1",
         "async-exit-hook": "^2.0.1",
-        "chalk": "^3.0.0",
-        "cosmiconfig": "^6.0.0",
-        "del": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^7.0.0",
+        "del": "^6.0.0",
         "escape-goat": "^3.0.0",
-        "escape-string-regexp": "^2.0.0",
-        "execa": "^4.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "execa": "^5.0.0",
         "github-url-from-git": "^1.5.0",
         "has-yarn": "^2.1.0",
-        "hosted-git-info": "^3.0.0",
-        "inquirer": "^7.0.0",
-        "is-installed-globally": "^0.3.1",
+        "hosted-git-info": "^3.0.7",
+        "ignore-walk": "^3.0.3",
+        "import-local": "^3.0.2",
+        "inquirer": "^7.3.3",
+        "is-installed-globally": "^0.3.2",
+        "is-interactive": "^1.0.0",
         "is-scoped": "^2.1.0",
         "issue-regex": "^3.1.0",
         "listr": "^0.14.3",
         "listr-input": "^0.2.1",
-        "log-symbols": "^3.0.0",
-        "meow": "^6.0.0",
+        "log-symbols": "^4.0.0",
+        "meow": "^8.1.0",
+        "minimatch": "^3.0.4",
         "new-github-release-url": "^1.0.0",
-        "npm-name": "^5.4.0",
-        "onetime": "^5.1.0",
-        "open": "^7.0.0",
-        "ow": "^0.15.0",
-        "p-memoize": "^3.1.0",
-        "p-timeout": "^3.1.0",
-        "pkg-dir": "^4.1.0",
-        "read-pkg-up": "^7.0.0",
-        "rxjs": "^6.5.4",
-        "semver": "^7.1.1",
-        "split": "^1.0.0",
-        "symbol-observable": "^1.2.0",
-        "terminal-link": "^2.0.0",
-        "update-notifier": "^4.0.0"
+        "npm-name": "^6.0.1",
+        "onetime": "^5.1.2",
+        "open": "^7.3.0",
+        "ow": "^0.21.0",
+        "p-memoize": "^4.0.1",
+        "p-timeout": "^4.1.0",
+        "pkg-dir": "^5.0.0",
+        "read-pkg-up": "^7.0.1",
+        "rxjs": "^6.6.3",
+        "semver": "^7.3.4",
+        "split": "^1.0.1",
+        "symbol-observable": "^3.0.0",
+        "terminal-link": "^2.1.1",
+        "update-notifier": "^5.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -18440,9 +18491,9 @@
           "dev": true
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -18464,6 +18515,30 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "cosmiconfig": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
         "escape-goat": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
@@ -18471,20 +18546,43 @@
           "dev": true
         },
         "escape-string-regexp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+        "execa": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+          "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
           "dev": true,
           "requires": {
-            "locate-path": "^5.0.0",
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
           }
+        },
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
         },
         "global-dirs": {
           "version": "2.1.0",
@@ -18510,6 +18608,12 @@
             "lru-cache": "^6.0.0"
           }
         },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
         "ini": {
           "version": "1.3.7",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
@@ -18526,86 +18630,48 @@
             "is-path-inside": "^3.0.1"
           }
         },
-        "is-npm": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-          "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
         },
         "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
           "dev": true,
           "requires": {
-            "p-locate": "^4.1.0"
+            "p-locate": "^5.0.0"
           }
         },
         "log-symbols": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "color-convert": {
-              "version": "1.9.3",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-              "dev": true,
-              "requires": {
-                "color-name": "1.1.3"
-              }
-            },
-            "color-name": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-              "dev": true
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-              "dev": true
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          }
+        },
+        "meow": {
+          "version": "8.1.2",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+          "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+          "dev": true,
+          "requires": {
+            "@types/minimist": "^1.2.0",
+            "camelcase-keys": "^6.2.2",
+            "decamelize-keys": "^1.1.0",
+            "hard-rejection": "^2.1.0",
+            "minimist-options": "4.1.0",
+            "normalize-package-data": "^3.0.0",
+            "read-pkg-up": "^7.0.1",
+            "redent": "^3.0.0",
+            "trim-newlines": "^3.0.0",
+            "type-fest": "^0.18.0",
+            "yargs-parser": "^20.2.3"
           }
         },
         "mimic-fn": {
@@ -18613,6 +18679,38 @@
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
+        },
+        "normalize-package-data": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+          "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "resolve": "^1.20.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "hosted-git-info": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+              "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            }
+          }
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
         },
         "onetime": {
           "version": "5.1.2",
@@ -18623,23 +18721,29 @@
             "mimic-fn": "^2.1.0"
           }
         },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.2.0"
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
           }
         },
         "p-timeout": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-          "dev": true,
-          "requires": {
-            "p-finally": "^1.0.0"
-          }
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+          "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+          "dev": true
         },
         "path-exists": {
           "version": "4.0.0",
@@ -18647,13 +18751,19 @@
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
         "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
           "dev": true,
           "requires": {
-            "find-up": "^4.0.0"
+            "find-up": "^5.0.0"
           }
         },
         "semver": {
@@ -18665,6 +18775,21 @@
             "lru-cache": "^6.0.0"
           }
         },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -18674,42 +18799,214 @@
             "has-flag": "^4.0.0"
           }
         },
-        "update-notifier": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
-          "integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
+        "symbol-observable": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-3.0.0.tgz",
+          "integrity": "sha512-6tDOXSHiVjuCaasQSWTmHUWn4PuG7qa3+1WT031yTc/swT7+rLiw3GOrFxaH1E3lLP09dH3bVuVDf2gK5rxG3Q==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
-            "boxen": "^4.2.0",
-            "chalk": "^3.0.0",
-            "configstore": "^5.0.1",
-            "has-yarn": "^2.1.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^2.0.0",
-            "is-installed-globally": "^0.3.1",
-            "is-npm": "^4.0.0",
-            "is-yarn-global": "^0.3.0",
-            "latest-version": "^5.0.0",
-            "pupa": "^2.0.1",
-            "semver-diff": "^3.1.1",
-            "xdg-basedir": "^4.0.0"
+            "isexe": "^2.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "dev": true
         }
       }
     },
     "npm-name": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/npm-name/-/npm-name-5.5.0.tgz",
-      "integrity": "sha512-l7/uyVfEi2e3ho+ovaJZC0xlbwzXNUz3RxkxpfcnLuoGKAuYoo9YoJ/uy18PsTD8IziugGHks4t/mGmBJEZ4Qg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/npm-name/-/npm-name-6.0.1.tgz",
+      "integrity": "sha512-fhKRvUAxaYzMEUZim4mXWyfFbVS+M1CbrCLdAo3txWzrctxKka/h+KaBW0O9Cz5uOM00Nldn2JLWhuwnyW3SUw==",
       "dev": true,
       "requires": {
-        "got": "^9.6.0",
+        "got": "^10.6.0",
         "is-scoped": "^2.1.0",
-        "is-url-superb": "^3.0.0",
+        "is-url-superb": "^4.0.0",
         "lodash.zip": "^4.2.0",
+        "org-regex": "^1.0.0",
+        "p-map": "^3.0.0",
         "registry-auth-token": "^4.0.0",
         "registry-url": "^5.1.0",
         "validate-npm-package-name": "^3.0.0"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
+          "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
+          "dev": true
+        },
+        "@szmarczak/http-timer": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+          "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+          "dev": true,
+          "requires": {
+            "defer-to-connect": "^2.0.0"
+          }
+        },
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "cacheable-request": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+          "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+          "dev": true,
+          "requires": {
+            "clone-response": "^1.0.2",
+            "get-stream": "^5.1.0",
+            "http-cache-semantics": "^4.0.0",
+            "keyv": "^4.0.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^4.1.0",
+            "responselike": "^2.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
+        "decompress-response": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
+          "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "defer-to-connect": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+          "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "10.7.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
+          "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/is": "^2.0.0",
+            "@szmarczak/http-timer": "^4.0.0",
+            "@types/cacheable-request": "^6.0.1",
+            "cacheable-lookup": "^2.0.0",
+            "cacheable-request": "^7.0.1",
+            "decompress-response": "^5.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^5.0.0",
+            "lowercase-keys": "^2.0.0",
+            "mimic-response": "^2.1.0",
+            "p-cancelable": "^2.0.0",
+            "p-event": "^4.0.0",
+            "responselike": "^2.0.0",
+            "to-readable-stream": "^2.0.0",
+            "type-fest": "^0.10.0"
+          }
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "json-buffer": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+          "dev": true
+        },
+        "keyv": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+          "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+          "dev": true,
+          "requires": {
+            "json-buffer": "3.0.1"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+          "dev": true
+        },
+        "p-cancelable": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+          "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+          "dev": true
+        },
+        "p-map": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "responselike": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+          "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+          "dev": true,
+          "requires": {
+            "lowercase-keys": "^2.0.0"
+          }
+        },
+        "to-readable-stream": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+          "integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+          "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+          "dev": true
+        }
       }
     },
     "npm-run-path": {
@@ -19169,6 +19466,12 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "org-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/org-regex/-/org-regex-1.0.0.tgz",
+      "integrity": "sha512-7bqkxkEJwzJQUAlyYniqEZ3Ilzjh0yoa62c7gL6Ijxj5bEpPL+8IE1Z0PFj0ywjjXQcdrwR51g9MIcLezR0hKQ==",
+      "dev": true
+    },
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -19210,12 +19513,40 @@
       "dev": true
     },
     "ow": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.15.1.tgz",
-      "integrity": "sha512-rwiuvCnk3Ug9T4s5oKzw3QXQSiTXlTUiQgHmZ9Ozw/37YzeX8LycosVKOtO3v5+fuARGmCgz9rVhaBJeGV+2bQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.21.0.tgz",
+      "integrity": "sha512-dlsoDe39g7mhdsdrC1R/YwjT7yjVqE3svWwOlMGvN690waBkgEZBmKBdkmKvSt5/wZ6E0Jn/nIesPqMZOpPKqw==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.8.1"
+        "@sindresorhus/is": "^4.0.0",
+        "callsites": "^3.1.0",
+        "dot-prop": "^6.0.1",
+        "lodash.isequal": "^4.5.0",
+        "type-fest": "^0.20.2",
+        "vali-date": "^1.0.0"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
+          "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
+          "dev": true
+        },
+        "dot-prop": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+          "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
       }
     },
     "p-all": {
@@ -19320,19 +19651,19 @@
       "dev": true
     },
     "p-memoize": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-3.1.0.tgz",
-      "integrity": "sha512-e5tIvrsr7ydUUnxb534iQWtXxWgk/86IsH+H+nV4FHouIggBt4coXboKBt26o4lTu7JbEnGSeXdEsYR8BhAHFA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.1.tgz",
+      "integrity": "sha512-km0sP12uE0dOZ5qP+s7kGVf07QngxyG0gS8sYFvFWhqlgzOsSy+m71aUejf/0akxj5W7gE//2G74qTv6b4iMog==",
       "dev": true,
       "requires": {
-        "mem": "^4.3.0",
-        "mimic-fn": "^2.1.0"
+        "mem": "^6.0.1",
+        "mimic-fn": "^3.0.0"
       },
       "dependencies": {
         "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
           "dev": true
         }
       }
@@ -19551,12 +19882,6 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -19635,21 +19960,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
     },
     "pirates": {
       "version": "4.0.1",
@@ -24697,12 +25007,6 @@
         "@popperjs/core": "^2.8.3"
       }
     },
-    "tlds": {
-      "version": "1.221.1",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.221.1.tgz",
-      "integrity": "sha512-N1Afn/SLeOQRpxMwHBuNFJ3GvGrdtY4XPXKPFcx8he0U9Jg9ZkvTKE1k3jQDtCmlFn44UxjVtouF6PT4rEGd3Q==",
-      "dev": true
-    },
     "tmp": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
@@ -25466,24 +25770,6 @@
         "prepend-http": "^2.0.0"
       }
     },
-    "url-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
-      "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
-      "dev": true,
-      "requires": {
-        "ip-regex": "^4.1.0",
-        "tlds": "^1.203.0"
-      },
-      "dependencies": {
-        "ip-regex": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-          "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-          "dev": true
-        }
-      }
-    },
     "url-to-options": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
@@ -25632,6 +25918,12 @@
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
+    },
+    "vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "jest-watch-typeahead": "^0.3.0",
     "jscodeshift": "^0.7.0",
     "meow": "^6.0.1",
-    "np": "6.2.3",
+    "np": "^7.5.0",
     "nyc": "^15.0.0",
     "prettier": "2.0.5",
     "pretty-quick": "^2.0.1",

--- a/src/components/ConditionField/ConditionField.test.js
+++ b/src/components/ConditionField/ConditionField.test.js
@@ -81,6 +81,12 @@ describe('Tooltip', () => {
 
 describe('With selectable conjunction', () => {
   test('should display selectable conjunction button with AND/OR options', async () => {
+    const dropdownTrigger = () =>
+      screen.queryByRole('button', {
+        name: 'toggle menu',
+      })
+
+    const conjunctionMenu = () => screen.getByRole('listbox')
     render(
       <ConditionField.Group canChangeConjunction>
         <ConditionField />
@@ -102,6 +108,11 @@ describe('With selectable conjunction', () => {
   })
 
   test('should display OR selected when no conjunction provided', async () => {
+    const dropdownTrigger = () =>
+      screen.queryByRole('button', {
+        name: 'toggle menu',
+      })
+
     render(
       <ConditionField.Group canChangeConjunction>
         <ConditionField />
@@ -116,6 +127,12 @@ describe('With selectable conjunction', () => {
   })
 
   test('should mark provided item as selected', async () => {
+    const dropdownTrigger = () =>
+      screen.queryByRole('button', {
+        name: 'toggle menu',
+      })
+
+    const conjunctionMenu = () => screen.getByRole('listbox')
     render(
       <ConditionField.Group canChangeConjunction conjunction={'and'}>
         <ConditionField />
@@ -134,6 +151,12 @@ describe('With selectable conjunction', () => {
   })
 
   test('should make a callback when conjunction changed', async () => {
+    const dropdownTrigger = () =>
+      screen.queryByRole('button', {
+        name: 'toggle menu',
+      })
+
+    const conjunctionMenu = () => screen.getByRole('listbox')
     const mock = jest.fn()
     render(
       <ConditionField.Group canChangeConjunction onConjunctionChange={mock}>
@@ -174,6 +197,11 @@ describe('With selectable conjunction', () => {
   })
 
   test('should disable button to add, but not switch', () => {
+    const dropdownTrigger = () =>
+      screen.queryByRole('button', {
+        name: 'toggle menu',
+      })
+
     render(
       <ConditionField.Group canChangeConjunction isAddEnabled={false}>
         <ConditionField />
@@ -186,6 +214,11 @@ describe('With selectable conjunction', () => {
   })
 
   test('should not display dropdown when flag is set to false', () => {
+    const dropdownTrigger = () =>
+      screen.queryByRole('button', {
+        name: 'toggle menu',
+      })
+
     render(
       <ConditionField.Group canChangeConjunction={false}>
         <ConditionField />
@@ -196,13 +229,6 @@ describe('With selectable conjunction', () => {
     expect(dropdownTrigger()).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'or' })).toBeInTheDocument()
   })
-
-  const dropdownTrigger = () =>
-    screen.queryByRole('button', {
-      name: 'toggle menu',
-    })
-
-  const conjunctionMenu = () => screen.getByRole('listbox')
 
   function getOrConjunctions(container) {
     return container.querySelectorAll('.c-ConditionOperator.is-or')

--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -29,6 +29,8 @@ function Combobox({
   isOpen = false,
   items = [],
   menuCSS,
+  onMenuBlur = noop,
+  onMenuFocus = noop,
   handleSelectedItemChange = noop,
   renderCustomListItem = null,
   toggleOpenedState = noop,
@@ -77,6 +79,17 @@ function Combobox({
     },
 
     onSelectedItemChange: handleSelectedItemChange,
+
+    onStateChange({ type }) {
+      switch (type) {
+        case useCombobox.stateChangeTypes.InputBlur:
+          onMenuBlur()
+          break
+
+        default:
+          break
+      }
+    },
 
     stateReducer(state, actionAndChanges) {
       const { changes, type } = actionAndChanges
@@ -139,7 +152,15 @@ function Combobox({
       {...getComboboxProps()}
     >
       <InputSearchHolderUI show={items.length > 0}>
-        <input {...getInputProps({ ref: inputEl })} placeholder="Search" />
+        <input
+          {...getInputProps({
+            ref: inputEl,
+            onFocus: e => {
+              onMenuFocus(e)
+            },
+          })}
+          placeholder="Search"
+        />
       </InputSearchHolderUI>
       <MenuListUI className="MenuList MenuList-Combobox" {...getMenuProps()}>
         {renderListContents({

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -25,6 +25,7 @@ function Select({
   items = [],
   menuCSS,
   onMenuBlur = noop,
+  onMenuFocus = noop,
   renderCustomListItem = null,
   selectedItem = null,
   selectedItems,
@@ -141,8 +142,12 @@ function Select({
     >
       <A11yTogglerUI {...getToggleButtonProps()}>Toggler</A11yTogglerUI>
       <MenuListUI
+        className="DropList__MenuList"
         {...getMenuProps({
           onKeyDown: handleSidewaysKeyNavigation,
+          onFocus: e => {
+            onMenuFocus(e)
+          },
         })}
       >
         {renderListContents({

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -38,6 +38,7 @@ function DropListManager({
   items = [],
   menuCSS,
   onMenuBlur = noop,
+  onMenuFocus = noop,
   onOpenedStateChange = noop,
   onSelect = noop,
   renderCustomListItem = null,
@@ -232,6 +233,7 @@ function DropListManager({
             items={parsedItems}
             menuCSS={menuCSS}
             onMenuBlur={onMenuBlur}
+            onMenuFocus={onMenuFocus}
             renderCustomListItem={renderCustomListItem}
             selectedItem={selectedItem}
             selectedItems={selectedItems}
@@ -293,6 +295,8 @@ DropListManager.propTypes = {
   menuCSS: PropTypes.any,
   /** Callback that fires when the menu loses focus */
   onMenuBlur: PropTypes.func,
+  /** Callback that fires when the menu gets focus */
+  onMenuFocus: PropTypes.func,
   /** Callback that fires whenever the DropList opens and closes */
   onOpenedStateChange: PropTypes.func,
   /** Callback that fires whenever the selection in the DropList changes */

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -419,6 +419,57 @@ describe('Menu', () => {
       expect(queryByPlaceholderText('Search')).not.toBeInTheDocument()
     })
   })
+
+  test('should fire onMenuFocus and onMenuBlur (Combobox)', async () => {
+    const blurSpy = jest.fn()
+    const focusSpy = jest.fn()
+    const { queryByText } = render(
+      <DropList
+        onMenuBlur={blurSpy}
+        onMenuFocus={focusSpy}
+        items={someItems}
+        toggler={<SimpleButton text="Click" />}
+        variant="combobox"
+      />
+    )
+
+    user.click(queryByText('Click'))
+
+    await waitFor(() => {
+      expect(focusSpy).toHaveBeenCalled()
+    })
+
+    user.click(queryByText('Click'))
+
+    await waitFor(() => {
+      expect(blurSpy).toHaveBeenCalled()
+    })
+  })
+
+  test('should fire onMenuFocus and onMenuBlur (Select)', async () => {
+    const blurSpy = jest.fn()
+    const focusSpy = jest.fn()
+    const { queryByText } = render(
+      <DropList
+        onMenuBlur={blurSpy}
+        onMenuFocus={focusSpy}
+        items={someItems}
+        toggler={<SimpleButton text="Click" />}
+      />
+    )
+
+    user.click(queryByText('Click'))
+
+    await waitFor(() => {
+      expect(focusSpy).toHaveBeenCalled()
+    })
+
+    user.click(queryByText('Click'))
+
+    await waitFor(() => {
+      expect(blurSpy).toHaveBeenCalled()
+    })
+  })
 })
 
 describe('Combobox', () => {
@@ -897,6 +948,159 @@ describe('Selection', () => {
   })
 
   describe('disabled items', () => {
+    const items = someItems.map((item, index) => ({
+      ...item,
+      isDisabled: index % 2 === 0,
+    }))
+
+    test('should set an item as disabled and do not allow to select it (select)', async () => {
+      const onSelect = jest.fn()
+      const { getByText } = render(
+        <DropList
+          onSelect={onSelect}
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+        />
+      )
+
+      expect(getByText(someItems[2].label).parentElement).toHaveClass(
+        'is-disabled'
+      )
+      expect(getByText(someItems[1].label).parentElement).not.toHaveClass(
+        'is-disabled'
+      )
+
+      user.click(getByText(someItems[2].label))
+
+      await waitFor(() => {
+        expect(onSelect).not.toHaveBeenCalled()
+      })
+    })
+
+    test('should set an item as disabled and do not allow to select it (combobox)', async () => {
+      const onSelect = jest.fn()
+      const { getByText } = render(
+        <DropList
+          onSelect={onSelect}
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+          variant="combobox"
+        />
+      )
+
+      expect(getByText(someItems[2].label).parentElement).toHaveClass(
+        'is-disabled'
+      )
+
+      user.click(getByText(someItems[2].label))
+
+      await waitFor(() => {
+        expect(onSelect).not.toHaveBeenCalled()
+      })
+    })
+
+    test('should set an item as disabled and do not allow to select it with custom list', async () => {
+      const onSelect = jest.fn()
+      const { getByText } = render(
+        <DropList
+          onSelect={onSelect}
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+          renderCustomListItem={({ item, isDisabled }) => (
+            <div className={isDisabled ? 'is-disabled' : ''}>{item.label}</div>
+          )}
+        />
+      )
+
+      const exampleItem = getByText(someItems[2].label)
+
+      expect(exampleItem.parentElement).toHaveClass('is-disabled')
+
+      user.click(exampleItem)
+
+      await waitFor(() => {
+        expect(onSelect).not.toHaveBeenCalled()
+        expect(exampleItem).toHaveClass('is-disabled')
+      })
+    })
+
+    test('should skip disabled items when navigating down', async () => {
+      const { getByPlaceholderText, getByText } = render(
+        <DropList
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+          variant="combobox"
+        />
+      )
+
+      user.type(getByPlaceholderText('Search'), '{arrowdown}')
+
+      await waitFor(() => {
+        expect(getByText(someItems[0].label).parentElement).not.toHaveClass(
+          'is-highlighted'
+        )
+        expect(getByText(someItems[1].label).parentElement).toHaveClass(
+          'is-highlighted'
+        )
+      })
+
+      user.type(getByPlaceholderText('Search'), '{arrowdown}')
+
+      await waitFor(() => {
+        expect(getByText(someItems[1].label).parentElement).not.toHaveClass(
+          'is-highlighted'
+        )
+        expect(getByText(someItems[2].label).parentElement).not.toHaveClass(
+          'is-highlighted'
+        )
+        expect(getByText(someItems[3].label).parentElement).toHaveClass(
+          'is-highlighted'
+        )
+      })
+    })
+
+    test('should skip disabled items when navigating up', async () => {
+      const { getByPlaceholderText, getByText } = render(
+        <DropList
+          items={items}
+          toggler={<SimpleButton text="Button Toggler" />}
+          isMenuOpen
+          variant="combobox"
+        />
+      )
+
+      user.type(getByPlaceholderText('Search'), '{arrowup}')
+
+      await waitFor(() => {
+        expect(getByText(someItems[0].label).parentElement).not.toHaveClass(
+          'is-highlighted'
+        )
+        expect(
+          getByText(someItems[someItems.length - 2].label).parentElement
+        ).toHaveClass('is-highlighted')
+      })
+
+      user.type(getByPlaceholderText('Search'), '{arrowup}')
+
+      await waitFor(() => {
+        expect(
+          getByText(someItems[someItems.length - 2].label).parentElement
+        ).not.toHaveClass('is-highlighted')
+        expect(
+          getByText(someItems[someItems.length - 3].label).parentElement
+        ).not.toHaveClass('is-highlighted')
+        expect(
+          getByText(someItems[someItems.length - 4].label).parentElement
+        ).toHaveClass('is-highlighted')
+      })
+    })
+  })
+
+  describe('Disabled items', () => {
     const items = someItems.map((item, index) => ({
       ...item,
       isDisabled: index % 2 === 0,

--- a/src/components/EditableField/EditableField.Input.jsx
+++ b/src/components/EditableField/EditableField.Input.jsx
@@ -80,17 +80,11 @@ const Toggler = forwardRef(
 export class EditableFieldInput extends React.Component {
   static className = INPUT_CLASSNAMES.component
 
-  fieldInputContentRef
-  optionsDropdownRef
   inputRef
   inputWrapperRef = React.createRef()
 
-  setFieldInputContentNode = node => {
-    this.fieldInputContentRef = node
-  }
-
-  setOptionsDropdownNode = node => {
-    this.optionsDropdownRef = node
+  state = {
+    isDropListOpen: false,
   }
 
   setInputNode = node => {
@@ -103,10 +97,8 @@ export class EditableFieldInput extends React.Component {
     this.setInputTitle()
 
     if (isActive) {
-      if (document.activeElement !== this.optionsDropdownRef) {
-        const inputNode = this.inputRef
-        inputNode && inputNode.focus()
-      }
+      const inputNode = this.inputRef
+      inputNode && inputNode.focus()
     }
   }
 
@@ -122,8 +114,6 @@ export class EditableFieldInput extends React.Component {
     if (this.props.disabled !== nextProps.disabled) {
       return true
     }
-
-    // Below is tested
 
     if (!equal(this.props.validationInfo, nextProps.validationInfo)) {
       return true
@@ -165,12 +155,17 @@ export class EditableFieldInput extends React.Component {
   }
 
   handleInputBlur = event => {
-    const { name, onInputBlur } = this.props
-    const optionsNode = this.optionsDropdownRef
+    const { name, onInputBlur, valueOptions } = this.props
 
-    if (optionsNode && optionsNode.classList.contains('is-open')) return
-
-    onInputBlur({ name, event })
+    if (valueOptions) {
+      setTimeout(() => {
+        if (!this.state.isDropListOpen) {
+          onInputBlur({ name, event })
+        }
+      }, 100)
+    } else {
+      onInputBlur({ name, event })
+    }
   }
 
   handleOptionFocus = event => {
@@ -229,17 +224,14 @@ export class EditableFieldInput extends React.Component {
     onKeyUp({ event, name })
   }
 
-  handleOptionsBlur = event => {
-    const { name, onOptionBlur } = this.props
-
-    onOptionBlur({ name, event })
-  }
-
   handleDropdownSelect = selection => {
     const { name, onOptionSelection } = this.props
 
     onOptionSelection({ name, selection })
-    this.optionsDropdownRef && this.optionsDropdownRef.focus()
+  }
+
+  handleOpenCloseDropList = isOpen => {
+    this.setState({ isDropListOpen: isOpen })
   }
 
   renderOptions = () => {
@@ -251,12 +243,12 @@ export class EditableFieldInput extends React.Component {
           className={INPUT_CLASSNAMES.dropdown}
           items={valueOptions}
           onSelect={this.handleDropdownSelect}
+          onOpenedStateChange={this.handleOpenCloseDropList}
           toggler={
             <Toggler
               disabled={disabled}
               fieldValue={fieldValue}
               onFocus={this.handleOptionFocus}
-              onBlur={this.handleOptionsBlur}
             />
           }
           tippyOptions={{
@@ -320,7 +312,6 @@ export class EditableFieldInput extends React.Component {
             name === validationInfo.name &&
             STATES_CLASSNAMES.withValidation
         )}
-        ref={this.setFieldInputContentNode}
       >
         {valueOptions ? this.renderOptions() : null}
 

--- a/src/components/EditableField/EditableField.Input.jsx
+++ b/src/components/EditableField/EditableField.Input.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import {
   EditableFieldInputUI,
@@ -10,7 +10,7 @@ import {
   FocusIndicatorUI,
   ValidationIconUI,
 } from './EditableField.css'
-import Dropdown from '../Dropdown'
+import DropList from '../DropList'
 import Icon from '../Icon'
 import Tooltip from '../Tooltip'
 import Truncate from '../Truncate'
@@ -31,6 +31,51 @@ import { classNames } from '../../utilities/classNames'
 import { key } from '../../constants/Keys'
 import { noop } from '../../utilities/other'
 import equal from 'fast-deep-equal'
+
+const Toggler = forwardRef(
+  (
+    {
+      disabled = false,
+      isActive = false,
+      onBlur = noop,
+      onClick = noop,
+      onFocus = noop,
+      fieldValue,
+      ...rest
+    },
+    ref
+  ) => {
+    return (
+      <TriggerUI
+        aria-label="toggle menu"
+        aria-haspopup="true"
+        aria-expanded={isActive}
+        className={INPUT_CLASSNAMES.optionsTrigger}
+        data-cy="EditableFieldOptionsTrigger"
+        disabled={disabled}
+        onClick={onClick}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        ref={ref}
+        type="button"
+        {...rest}
+      >
+        <OptionsDropdownUI
+          className={classNames(
+            INPUT_CLASSNAMES.optionsDropdown,
+            isActive && 'menu-open'
+          )}
+        >
+          <Truncate className={INPUT_CLASSNAMES.selectedOption}>
+            {fieldValue.option}
+          </Truncate>
+          <Icon name={ACTION_ICONS.valueOption} />
+        </OptionsDropdownUI>
+        <FocusIndicatorUI className={INPUT_CLASSNAMES.focusIndicator} />
+      </TriggerUI>
+    )
+  }
+)
 
 export class EditableFieldInput extends React.Component {
   static className = INPUT_CLASSNAMES.component
@@ -201,32 +246,24 @@ export class EditableFieldInput extends React.Component {
     const { disabled, fieldValue, valueOptions } = this.props
 
     return (
-      <OptionsWrapperUI
-        className={INPUT_CLASSNAMES.optionsWrapper}
-        onKeyDown={this.handleKeyDown}
-      >
-        <Dropdown
+      <OptionsWrapperUI className={INPUT_CLASSNAMES.optionsWrapper}>
+        <DropList
           className={INPUT_CLASSNAMES.dropdown}
           items={valueOptions}
-          disabled={disabled}
-          shouldRefocusOnClose={() => false}
-          minWidth={75}
-          maxWidth={200}
-          onBlur={this.handleOptionsBlur}
-          onFocus={this.handleOptionFocus}
           onSelect={this.handleDropdownSelect}
-          triggerRef={this.setOptionsDropdownNode}
-          renderTrigger={
-            <TriggerUI className={INPUT_CLASSNAMES.optionsTrigger}>
-              <OptionsDropdownUI className={INPUT_CLASSNAMES.optionsDropdown}>
-                <Truncate className={INPUT_CLASSNAMES.selectedOption}>
-                  {fieldValue.option}
-                </Truncate>
-                <Icon name={ACTION_ICONS.valueOption} />
-              </OptionsDropdownUI>
-              <FocusIndicatorUI className={INPUT_CLASSNAMES.focusIndicator} />
-            </TriggerUI>
+          toggler={
+            <Toggler
+              disabled={disabled}
+              fieldValue={fieldValue}
+              onFocus={this.handleOptionFocus}
+              onBlur={this.handleOptionsBlur}
+            />
           }
+          tippyOptions={{
+            appendTo: reference =>
+              reference.closest('.EditableField__field.has-options'),
+            offset: [0, 10],
+          }}
         />
       </OptionsWrapperUI>
     )

--- a/src/components/EditableField/EditableField.css.js
+++ b/src/components/EditableField/EditableField.css.js
@@ -374,6 +374,7 @@ export const TriggerUI = styled('button')`
   text-align: left;
   height: ${input.height.medium};
   line-height: ${field.height.medium};
+  cursor: pointer;
 
   .is-active &:focus {
     outline: 0;

--- a/src/components/EditableField/EditableField.css.js
+++ b/src/components/EditableField/EditableField.css.js
@@ -15,6 +15,8 @@ import {
   TRUNCATED_CLASSNAMES,
 } from './EditableField.utils'
 
+import { DropListWrapperUI } from '../DropList/DropList.css'
+
 const {
   field,
   fieldLabel,
@@ -41,7 +43,6 @@ export const LabelTextUI = styled('span')`
 `
 
 export const FieldUI = styled('div')`
-  
   position: relative;
   height: ${field.height};
   margin-bottom: 2px;
@@ -94,6 +95,12 @@ export const FieldUI = styled('div')`
     visibility: hidden;
     width: auto;
     height: auto;
+  }
+
+  ${DropListWrapperUI} {
+    width: auto;
+    max-width: 200px;
+    min-width: 75;
   }
 `
 
@@ -345,12 +352,6 @@ export const OptionsWrapperUI = styled('div')`
     height: ${field.height.large};
   }
 
-  .${STATES_CLASSNAMES.fieldDisabled}
-    &
-    ${`.${INPUT_CLASSNAMES.dropdown}`}:hover {
-    cursor: initial;
-  }
-
   .${STATES_CLASSNAMES.isEmpty} & {
     width: 0;
     margin-right: 0;
@@ -360,16 +361,29 @@ export const OptionsWrapperUI = styled('div')`
     width: 60px;
     margin-right: 20px;
   }
-
-  .${OTHERCOMPONENTS_CLASSNAMES.dropdownTrigger},
-    ${`.${OTHERCOMPONENTS_CLASSNAMES.dropdownTrigger}`}:hover {
-    cursor: text;
-  }
 `
 
-export const TriggerUI = styled('div')`
+export const TriggerUI = styled('button')`
   position: relative;
   width: 100%;
+  min-width: 70px;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  height: ${input.height.medium};
+  line-height: ${field.height.medium};
+
+  .is-active &:focus {
+    outline: 0;
+
+    .${INPUT_CLASSNAMES.focusIndicator} {
+      transform: scaleX(1);
+      background-color: ${COLOURS.focusIndicator.active};
+      height: ${focusIndicator.active};
+    }
+  }
 `
 
 export const OptionsDropdownUI = styled('div')`
@@ -406,20 +420,10 @@ export const OptionsDropdownUI = styled('div')`
     }
   }
 
-  .is-active ${`.${OTHERCOMPONENTS_CLASSNAMES.dropdownTrigger}`}:focus & {
-    outline: none;
-
-    & + .${INPUT_CLASSNAMES.focusIndicator} {
-      transform: scaleX(1);
-      background-color: ${COLOURS.focusIndicator.active};
-      height: ${focusIndicator.active};
-    }
-  }
-
-  &:focus {
-    & + .${INPUT_CLASSNAMES.focusIndicator} {
-      transform: scaleX(1);
-    }
+  &.menu-open + .${INPUT_CLASSNAMES.focusIndicator} {
+    transform: scaleX(1);
+    background-color: ${COLOURS.focusIndicator.active};
+    height: ${focusIndicator.active};
   }
 
   & .${OTHERCOMPONENTS_CLASSNAMES.icon} {
@@ -534,6 +538,7 @@ export const MaskOptionUI = styled('span')`
   .${STATES_CLASSNAMES.fieldDisabled} & {
     color: ${COLOURS.mask.disabled};
     pointer-events: all;
+    cursor: default;
   }
 
   &:focus {

--- a/src/components/EditableField/EditableField.jsx
+++ b/src/components/EditableField/EditableField.jsx
@@ -211,17 +211,9 @@ export class EditableField extends React.Component {
 
   handleInputBlur = payload => {
     const { name, event } = payload
-    const { activeField, multipleValuesEnabled } = this.state
+    const { activeField, multipleValuesEnabled, valueOptions } = this.state
     const { validate, onCommit, onDiscard, onInputBlur } = this.props
-
-    if (equal(this.state.initialFieldValue, this.state.fieldValue)) {
-      this.setState({ activeField: EMPTY_VALUE }, () => {
-        onInputBlur({ name, value: this.state.fieldValue, event })
-      })
-
-      return
-    }
-
+    const hasOptions = valueOptions != null
     const changedField =
       this.state.fieldValue.length === 1
         ? this.state.fieldValue[0]
@@ -231,15 +223,11 @@ export class EditableField extends React.Component {
         ? this.state.initialFieldValue[0]
         : find(this.state.initialFieldValue, val => val.id === event.target.id)
 
-    if (equal(initialField, changedField)) {
-      this.setState({ activeField: EMPTY_VALUE }, () => {
-        onInputBlur({ name, value: this.state.fieldValue, event })
-      })
-
-      return
-    }
-
-    if (this.state.disabledItem.indexOf(changedField.id) !== -1) {
+    if (
+      equal(this.state.initialFieldValue, this.state.fieldValue) ||
+      equal(initialField, changedField) ||
+      this.state.disabledItem.indexOf(changedField.id) !== -1
+    ) {
       this.setState({ activeField: EMPTY_VALUE }, () => {
         onInputBlur({ name, value: this.state.fieldValue, event })
       })
@@ -250,7 +238,6 @@ export class EditableField extends React.Component {
     const removedEmptyFields = this.state.fieldValue.filter(field =>
       Boolean(field.value)
     )
-    const hasOptions = this.state.valueOptions != null
 
     // In multivalue fields, remove the empty one when there're at least 2 fields
     const shouldDiscardEmpty =
@@ -298,7 +285,9 @@ export class EditableField extends React.Component {
       return
     }
 
-    if (!changedField.validated) {
+    const optionChanged = initialField.option !== changedField.option
+
+    if (!changedField.validated || optionChanged) {
       this.setState({
         disabledItem: this.state.disabledItem.concat(changedField.id),
       })
@@ -459,24 +448,16 @@ export class EditableField extends React.Component {
             )
           }
         })
-        .catch(
-          // tested
-
-          () => {
-            // tested
-
-            this.setState(
-              {
-                // tested
-
-                disabledItem: this.state.disabledItem.filter(
-                  item => item !== name
-                ),
-              },
-              () => this.handleFieldEscapePress({ event, name })
-            )
-          }
-        )
+        .catch(() => {
+          this.setState(
+            {
+              disabledItem: this.state.disabledItem.filter(
+                item => item !== name
+              ),
+            },
+            () => this.handleFieldEscapePress({ event, name })
+          )
+        })
 
       return
     }
@@ -636,12 +617,9 @@ export class EditableField extends React.Component {
                 )
               } else {
                 updatedFieldValue = fieldValue.map(field => {
-                  // tested
-
                   if (field.id === name) {
                     return { ...field, validated: true }
                   }
-                  // tested
 
                   return field
                 })
@@ -669,24 +647,16 @@ export class EditableField extends React.Component {
                 )
               }
             })
-            .catch(
-              // tested
-
-              () => {
-                // tested
-
-                this.setState(
-                  {
-                    // tested
-
-                    disabledItem: this.state.disabledItem.filter(
-                      item => item !== name
-                    ),
-                  },
-                  () => this.handleFieldEscapePress({ event, name })
-                )
-              }
-            )
+            .catch(() => {
+              this.setState(
+                {
+                  disabledItem: this.state.disabledItem.filter(
+                    item => item !== name
+                  ),
+                },
+                () => this.handleFieldEscapePress({ event, name })
+              )
+            })
         }
       }
     })
@@ -762,19 +732,6 @@ export class EditableField extends React.Component {
     )
   }
 
-  handleOptionBlur = ({ name, event }) => {
-    const { onOptionBlur } = this.props
-
-    this.setState(
-      {
-        activeField: EMPTY_VALUE,
-      },
-      () => {
-        onOptionBlur({ name, value: this.state.fieldValue, event })
-      }
-    )
-  }
-
   handleOptionSelection = ({ name, selection }) => {
     const { onChange, onOptionChange, onCommit } = this.props
     const { fieldValue } = this.state
@@ -835,7 +792,6 @@ export class EditableField extends React.Component {
       fieldValue[fieldValue.length - 1].value !== EMPTY_VALUE
 
     if (isNotSingleEmptyValue) {
-      // it is tested
       const { name } = this.props
       const newValueObject = createNewValueFieldObject(
         EMPTY_VALUE,
@@ -990,7 +946,6 @@ export class EditableField extends React.Component {
                 onInputFocus={this.handleInputFocus}
                 onInputBlur={this.handleInputBlur}
                 onOptionFocus={this.handleOptionFocus}
-                onOptionBlur={this.handleOptionBlur}
                 onOptionSelection={this.handleOptionSelection}
                 onChange={this.handleInputChange}
                 onKeyDown={this.handleInputKeyDown}

--- a/src/components/EditableField/EditableField.jsx
+++ b/src/components/EditableField/EditableField.jsx
@@ -247,11 +247,14 @@ export class EditableField extends React.Component {
       return
     }
 
-    // In multivalue fields, remove the empty one when there're at least 2 fields
     const removedEmptyFields = this.state.fieldValue.filter(field =>
       Boolean(field.value)
     )
+    const hasOptions = this.state.valueOptions != null
+
+    // In multivalue fields, remove the empty one when there're at least 2 fields
     const shouldDiscardEmpty =
+      !hasOptions &&
       multipleValuesEnabled &&
       removedEmptyFields.length < this.state.fieldValue.length
 
@@ -294,8 +297,6 @@ export class EditableField extends React.Component {
 
       return
     }
-
-    // tested
 
     if (!changedField.validated) {
       this.setState({
@@ -780,12 +781,13 @@ export class EditableField extends React.Component {
     let newFieldValue = []
     let changed = false
     let hasBeenValidated = ''
+    const label = typeof selection === 'string' ? selection : selection.label
 
     for (const value of fieldValue) {
       const temp = { ...value }
 
-      if (temp.id === name && temp.option !== selection) {
-        temp.option = selection
+      if (temp.id === name && temp.option !== label) {
+        temp.option = label
         changed = true
       }
 
@@ -956,7 +958,9 @@ export class EditableField extends React.Component {
         {fieldValue.map((val, index) => {
           const isActive = activeField === val.id
           const isDisabled =
-            val.disabled || this.state.disabledItem.indexOf(val.id) !== -1
+            disabled ||
+            val.disabled ||
+            this.state.disabledItem.indexOf(val.id) !== -1
           const valInfo = find(
             this.state.validationInfo,
             valItem => valItem.name === val.id

--- a/src/components/EditableField/EditableField.jsx
+++ b/src/components/EditableField/EditableField.jsx
@@ -914,9 +914,7 @@ export class EditableField extends React.Component {
         {fieldValue.map((val, index) => {
           const isActive = activeField === val.id
           const isDisabled =
-            disabled ||
-            val.disabled ||
-            this.state.disabledItem.indexOf(val.id) !== -1
+            disabled || val.disabled || this.state.disabledItem.includes(val.id)
           const valInfo = find(
             this.state.validationInfo,
             valItem => valItem.name === val.id

--- a/src/components/EditableField/EditableFieldComposite.jsx
+++ b/src/components/EditableField/EditableFieldComposite.jsx
@@ -110,14 +110,10 @@ export class EditableFieldComposite extends React.PureComponent {
         )
 
         Fields.forEach(field => {
-          // It is tested (composite test: "component did update" line:326)
-
           if (field && field.classList.contains(STATES_CLASSNAMES.isActive)) {
             hasActiveFields = true
           }
         })
-
-        // It is tested (composite test: "component did update" line:326)
 
         if (!hasActiveFields) {
           // Let's remove the transition from all but the first focus indicator
@@ -235,8 +231,6 @@ export class EditableFieldComposite extends React.PureComponent {
 
     const inputs = this.groupRef.querySelectorAll('input')
 
-    // It is tested
-
     if (inputs) {
       for (let index = 0; index < inputs.length; index++) {
         const element = inputs[index]
@@ -263,9 +257,7 @@ export class EditableFieldComposite extends React.PureComponent {
 
       input && input.focus()
       this.maskRef.removeAttribute('tabindex')
-    }
-    // It is tested
-    else if (isEscape) {
+    } else if (isEscape) {
       this.maskRef.removeAttribute('tabindex')
     }
   }

--- a/src/components/EditableField/__tests__/EditableField.test.js
+++ b/src/components/EditableField/__tests__/EditableField.test.js
@@ -1065,24 +1065,6 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalled()
   })
 
-  test('Blur option', () => {
-    const spy = jest.fn()
-
-    const { container } = render(
-      <EditableField
-        name="company"
-        value={{ option: 'Work', value: '123456789', id: '1' }}
-        valueOptions={['Home', 'Work', 'Other']}
-        onOptionBlur={spy}
-      />
-    )
-
-    container.querySelector(`.${INPUT_CLASSNAMES.optionsTrigger}`).focus()
-    container.querySelector(`.${INPUT_CLASSNAMES.optionsTrigger}`).blur()
-
-    expect(spy).toHaveBeenCalled()
-  })
-
   test('Changing option', () => {
     const onOptionChangeSpy = jest.fn()
     const onChangeSpy = jest.fn()

--- a/src/components/EditableField/__tests__/EditableField.test.js
+++ b/src/components/EditableField/__tests__/EditableField.test.js
@@ -498,7 +498,9 @@ describe('Options', () => {
         valueOptions={['Home', 'Work', 'Other']}
       />
     )
-    const button = container.querySelector('.c-DropdownTrigger')
+    const button = container.querySelector(
+      `.${INPUT_CLASSNAMES.optionsTrigger}`
+    )
 
     expect(queryByRole('listbox')).toBe(null)
 
@@ -601,7 +603,9 @@ describe('Options', () => {
       />
     )
 
-    const button = container.querySelector('.c-DropdownTrigger')
+    const button = container.querySelector(
+      `.${INPUT_CLASSNAMES.optionsTrigger}`
+    )
 
     user.click(button)
     user.click(getAllByRole('option')[0])
@@ -739,7 +743,7 @@ describe('Static Value', () => {
       container.querySelector(`.${MASK_CLASSNAMES.option}`).textContent
     ).toBe('Work')
 
-    user.click(container.querySelector('.c-DropdownTrigger'))
+    user.click(container.querySelector(`.${INPUT_CLASSNAMES.optionsTrigger}`))
     user.click(getAllByRole('option')[0])
 
     expect(
@@ -913,7 +917,9 @@ describe('disabled', () => {
     )
 
     expect(
-      container.querySelector('.c-DropdownTrigger').getAttribute('disabled')
+      container
+        .querySelector(`.${INPUT_CLASSNAMES.optionsTrigger}`)
+        .getAttribute('disabled')
     ).toBeDefined()
   })
 })
@@ -1054,7 +1060,7 @@ describe('Events', () => {
       />
     )
 
-    container.querySelector('.c-DropdownTrigger').focus()
+    container.querySelector(`.${INPUT_CLASSNAMES.optionsTrigger}`).focus()
 
     expect(spy).toHaveBeenCalled()
   })
@@ -1071,8 +1077,8 @@ describe('Events', () => {
       />
     )
 
-    container.querySelector('.c-DropdownTrigger').focus()
-    container.querySelector('.c-DropdownTrigger').blur()
+    container.querySelector(`.${INPUT_CLASSNAMES.optionsTrigger}`).focus()
+    container.querySelector(`.${INPUT_CLASSNAMES.optionsTrigger}`).blur()
 
     expect(spy).toHaveBeenCalled()
   })
@@ -1093,7 +1099,7 @@ describe('Events', () => {
       />
     )
 
-    user.click(container.querySelector('.c-DropdownTrigger'))
+    user.click(container.querySelector(`.${INPUT_CLASSNAMES.optionsTrigger}`))
     user.click(getAllByRole('option')[0])
 
     expect(onOptionChangeSpy).toHaveBeenCalled()

--- a/src/components/EditableField/__tests__/EditableFieldComposite.test.js
+++ b/src/components/EditableField/__tests__/EditableFieldComposite.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import user from '@testing-library/user-event'
 import { mount } from 'enzyme'
 import { EditableFieldComposite } from '../'
@@ -9,6 +9,8 @@ import {
   EDITABLEFIELD_CLASSNAMES,
   STATES_CLASSNAMES,
 } from '../EditableField.utils'
+
+jest.useFakeTimers()
 
 describe('Children', () => {
   test('Renders as many EditableFields as passed', () => {
@@ -73,7 +75,7 @@ describe('Children', () => {
     expect(spy).toHaveBeenCalled()
   })
 
-  test('onInputBlur still gets executed if passed on an EditableField', () => {
+  test('onInputBlur still gets executed if passed on an EditableField', async () => {
     const spy = jest.fn()
 
     const { container } = render(
@@ -84,11 +86,12 @@ describe('Children', () => {
     )
 
     const input = container.querySelector('input')
-
     input.focus()
-    input.blur()
+    user.tab()
 
-    expect(spy).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalled()
+    })
   })
 
   test('onChange still gets executed if passed on an EditableField', () => {
@@ -321,8 +324,6 @@ describe('Active Fields', () => {
   })
 
   test('component did update', () => {
-    jest.useFakeTimers()
-
     const wrapper = mount(
       <EditableFieldComposite>
         <EditableField name="city" />

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -30,6 +30,11 @@ const modalBaseZIndex = 1040
 const portalOptions = {
   id: 'Modal',
   zIndex: modalBaseZIndex,
+  preventEscActionElements: [
+    'DropList__MenuList',
+    'FieldInput__input',
+    'EditableTextarea__Textarea',
+  ],
 }
 const modalV2Animation = {
   delay: 0,

--- a/src/components/Modal/Modal.stories.mdx
+++ b/src/components/Modal/Modal.stories.mdx
@@ -2,6 +2,9 @@ import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs/blocks'
 import { select, text, boolean, number, array } from '@storybook/addon-knobs'
 import SpeechBubble from '@helpscout/hsds-illos/speech-bubble'
 import Modal from './'
+import { PHONE_OPTIONS } from '../EditableField/EditableField.storiesHelpers'
+import EditableTextarea from '../EditableTextarea'
+import EditableField from '../EditableField'
 
 <Meta
   title="Components/Overlay/Modal"
@@ -158,34 +161,49 @@ There are two versions of the Modal component, version 2 is the new standard (ve
   </Story>
 </Canvas>
 
-#### Version 1 (legacy)
+#### ESC handling
+
+There are components like `DropList`, `EditableField` and `EditableTextarea` that have their own ESC handler, we don't want the Modal to be closed on those cases:
 
 <Canvas>
-  <Story name="Version 1 (legacy)">
+  <Story name="ESC Handling">
     <Modal
-      trigger={
-        <button onClick={e => e.preventDefault()}>Open dis modal</button>
-      }
+      isOpen={false}
+      trigger={<button>open modal</button>}
+      title="Modal Title"
+      version={2}
     >
-      <Modal.Body>
-        <Heading>Title</Heading>
-        <p>
-          Lorem Lorem sit esse sit minim irure minim voluptate voluptate nostrud
-          aliqua. Do tempor qui ad sit amet labore magna proident adipisicing
-          nostrud. Adipisicing laborum veniam velit culpa deserunt proident
-          ipsum occaecat. Ex duis nulla tempor cillum mollit anim. Est qui
-          consectetur qui fugiat. Commodo tempor aute adipisicing dolore est.
-          Laboris do sint et reprehenderit consectetur amet cillum quis tempor
-          nulla qui ea.
-        </p>
-        <p>
-          Duis tempor deserunt qui Lorem sint exercitation voluptate duis Lorem.
-          Sunt et elit nulla consectetur labore. Proident dolore ullamco
-          excepteur enim aliqua incididunt culpa magna cupidatat magna non sit.
-          Occaecat laborum dolor nisi Lorem ex id occaecat incididunt cupidatat
-          ipsum amet nostrud.
-        </p>
+      <Modal.Body version={2}>
+        <div>
+          <EditableTextarea />
+          <EditableField
+            label="Phone"
+            name="Phone"
+            placeholder="Add phone"
+            type="tel"
+            valueOptions={PHONE_OPTIONS}
+            defaultOption={PHONE_OPTIONS[2]}
+            value={{ option: 'Work', value: '123456789' }}
+          />
+          <EditableField
+            label="Company"
+            name="company"
+            placeholder="Add a company name"
+            type="text"
+          />
+          <EditableField
+            label="Team"
+            name="team"
+            placeholder="Add a sports team name"
+            type="text"
+            value="Atlas"
+          />
+        </div>
       </Modal.Body>
+      <Modal.ActionFooter
+        primaryButtonText={'Primary'}
+        secondaryButtonText={'Secondary'}
+      />
     </Modal>
   </Story>
 </Canvas>

--- a/src/components/PortalWrapper/PortalWrapper.jsx
+++ b/src/components/PortalWrapper/PortalWrapper.jsx
@@ -28,6 +28,16 @@ const defaultOptions = {
 const managerNamespace = 'HSDSPortalWrapperGlobalManager'
 const uniqueIndex = createUniqueIndexFactory(1000)
 
+function shouldPreventClosing({ preventEscActionElements, classList }) {
+  for (let index = 0; index < preventEscActionElements.length; index++) {
+    if (classList.contains(preventEscActionElements[index])) {
+      return true
+    }
+  }
+
+  return false
+}
+
 const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
   const extendedOptions = {
     ...defaultOptions,
@@ -40,6 +50,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
     static defaultProps = {
       closeOnEscape: true,
       isOpen: false,
+      preventEscActionElements: extendedOptions.preventEscActionElements || [],
     }
     static contextTypes = {
       router: noop,
@@ -192,7 +203,16 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
     }
 
     handleOnEsc = event => {
-      if (this.state.isOpen) {
+      const { preventEscActionElements } = this.props
+      const { target } = event
+
+      if (
+        this.state.isOpen &&
+        !shouldPreventClosing({
+          classList: target.classList,
+          preventEscActionElements,
+        })
+      ) {
         event && event.stopPropagation()
         this.handleOnClose()
       }
@@ -307,7 +327,11 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
     renderEventListener() {
       const { closeOnEscape } = this.props
       return closeOnEscape ? (
-        <KeypressListener keyCode={Keys.ESCAPE} handler={this.handleOnEsc} />
+        <KeypressListener
+          keyCode={Keys.ESCAPE}
+          handler={this.handleOnEsc}
+          type="keydown"
+        />
       ) : null
     }
 
@@ -336,6 +360,7 @@ PortalWrapper.propTypes = Object.assign(Portal.propTypes, {
   isOpen: PropTypes.bool,
   trigger: PropTypes.any,
   isOpenProps: PropTypes.bool,
+  preventEscActionElements: PropTypes.arrayOf(PropTypes.string),
   wrapperClassName: PropTypes.string,
 })
 

--- a/src/components/PortalWrapper/PortalWrapper.jsx
+++ b/src/components/PortalWrapper/PortalWrapper.jsx
@@ -28,10 +28,12 @@ const defaultOptions = {
 const managerNamespace = 'HSDSPortalWrapperGlobalManager'
 const uniqueIndex = createUniqueIndexFactory(1000)
 
-function shouldPreventClosing({ preventEscActionElements, classList }) {
-  for (let index = 0; index < preventEscActionElements.length; index++) {
-    if (classList.contains(preventEscActionElements[index])) {
-      return true
+function shouldPreventClosing({ preventEscActionElements, target }) {
+  if (target) {
+    for (let index = 0; index < preventEscActionElements.length; index++) {
+      if (target.classList.contains(preventEscActionElements[index])) {
+        return true
+      }
     }
   }
 
@@ -209,7 +211,7 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
       if (
         this.state.isOpen &&
         !shouldPreventClosing({
-          classList: target.classList,
+          target,
           preventEscActionElements,
         })
       ) {


### PR DESCRIPTION
In this PR we refactor EditableField (the options variant) to use DropList instead of Dropdown.

This does not change external behaviours so there's no need to update wherever is used (this variant of EditableField is only used on one place in HSApp by the way).

[Story](https://deploy-preview-921--hsds-react.netlify.app/?path=/story/components-forms-editablefield--with-options)

I also fixed a couple of EditableFields minor issues that I noticed:
- Propagate the disabled option all the way
- On multiple value fields with options, adding a new one and opening the options dropdown with the input empty would remove the newly added field.

While doing the refactor I noticed DropList has `onMenuBlur` but not focus, so I added `onMenuFocus` which I ended up not needing for the refactor but kept it for consistency.


## ESC handling

https://helpscout.atlassian.net/browse/HSDS-181

When an editable field resided inside a modal, activating the field and then hitting ESC would deactivate the field and also close the modal. In that particular case, we don't want to close the modal, only deactivate the field.

But this would happen also with: a DropList being opened and hitting ESC (which will normally just close the DropList), editable textarea...

I tried to stop the propagation of the event so that it wouldn't reach the modal listener but due to the way it was handled with `keyup` instead of `keydown`, it wouldn't catch it. And when I changed it to `keydown` the modal event happens first, so again no way to stop the bubbling.

I ended up adding an option to PortalWrapper (the handler of this event on the modal) to avoid closing the modal if the target originating the event is coming from an opened component.

I added a story on the Modal to test this

