### PR TITLE
Update message card padding according to the newest designs

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -8,7 +8,7 @@ import Button from '../Button'
 import Heading from '../Heading'
 import Image from '../Image'
 
-export const MAX_IMAGE_SIZE = 278
+export const MAX_IMAGE_SIZE = 258
 
 const fontFamily = makeFontFamily('Barlow')
 
@@ -283,10 +283,10 @@ export const ImageContainerUI = styled('div')`
   justify-content: center;
   width: 100%;
   margin-top: 20px;
-  padding: 0 10px;
+  padding: 0 20px;
   max-height: ${MAX_IMAGE_SIZE}px;
 
   &:last-child {
-    margin-bottom: -15px;
+    margin-bottom: -5px;
   }
 `

--- a/src/components/MessageCard/MessageCard.stories.mdx
+++ b/src/components/MessageCard/MessageCard.stories.mdx
@@ -59,6 +59,24 @@ This component renders a Message Card Notification with (optional) Title, Subtit
   </Story>
 </Canvas>
 
+# With image and action
+
+<Canvas>
+  <Story name="With image and action">
+    <MessageCard
+      subtitle={text('Subtitle', 'The J&G Team is here')}
+      title={text('Title', 'Need help?')}
+      image={{
+        height: '230',
+        width: '800',
+        url:
+          'http://matthewjamestaylor.com/img/illustrations/large/how-to-convert-a-liquid-layout-to-fixed-width.jpg',
+      }}
+      action={() => <MessageCard.Button>Click here</MessageCard.Button>}
+    />
+  </Story>
+</Canvas>
+
 #### Reference
 
 - **Designer**: Buzz

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -208,8 +208,8 @@ describe('image', () => {
     )
     const image = wrapper.find(ImageUI)
 
-    expect(image.prop('height')).toEqual('104.25px')
-    expect(image.prop('width')).toEqual('278px')
+    expect(image.prop('height')).toEqual('96.75px')
+    expect(image.prop('width')).toEqual('258px')
   })
 
   test('Scales size of image when larger than fits and height is bigger', () => {
@@ -224,8 +224,8 @@ describe('image', () => {
     )
     const image = wrapper.find(ImageUI)
 
-    expect(image.prop('height')).toEqual('278px')
-    expect(image.prop('width')).toEqual('104.25px')
+    expect(image.prop('height')).toEqual('258px')
+    expect(image.prop('width')).toEqual('96.75px')
   })
 
   test('Sets default size of image when not provided', () => {


### PR DESCRIPTION
# Problem/Feature

After a review of HSAPP task, we need to make some adjustment to the MessageCard visual, as we've missed some cases.

This PR for now includes increasing padding around the image to align with other elements. See details here: https://github.com/helpscout/hs-app/pull/9906
