### PR TITLE
Adjust Attachment states on hover and focus in a preview theme

### DIFF
--- a/src/components/Attachment/Attachment.css.js
+++ b/src/components/Attachment/Attachment.css.js
@@ -73,6 +73,11 @@ export const AttachmentUI = styled.a`
       ${d400Effect}
     }
 
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 2px ${getColor('blue.500')};
+    }
+
     &.has-image {
       padding: 3px;
     }
@@ -111,23 +116,44 @@ export const AttachmentUI = styled.a`
   ${bem.element('closeButton')} {
     ${cardStyles()};
     display: block;
-    clip: rect(0, 0, 0, 0);
     border-radius: 9999px !important;
     position: absolute;
     right: 0;
     top: 0;
     transform: translate(50%, -50%);
     z-index: 1;
+    opacity: 0;
+
+    transition: all 200ms linear;
+    will-change: box-shadow, color, opacity;
+
+    box-shadow: inset 0 0 0 1px ${getColor('grey.700')};
+    color: ${getColor('charcoal.300')};
+
+    & .c-Icon {
+      &,
+      &:focus,
+      &:hover {
+        opacity: 1;
+      }
+    }
   }
 
   &:hover,
   &:focus {
     ${bem.element('closeButton')} {
-      clip: unset;
+      opacity: 1;
     }
   }
 
   ${bem.element('closeButton')}:focus {
-    clip: unset;
+    opacity: 1;
+    box-shadow: 0 0 0 2px ${getColor('blue.500')};
+  }
+
+  ${bem.element('closeButton')}:hover {
+    box-shadow: inset 0 0 0 1px ${getColor('red.500')};
+
+    color: ${getColor('red.500')};
   }
 `

--- a/src/components/Attachment/Attachment.stories.mdx
+++ b/src/components/Attachment/Attachment.stories.mdx
@@ -98,3 +98,20 @@ A Provider component provides child components with props accessible as `context
     </Attachment.Provider>
   </Story>
 </Canvas>
+
+#### Preview theme with image
+
+<Canvas>
+  <Story name="Preview theme with image">
+    <div style={{ width: '86px' }}>
+      <Attachment.Provider theme="preview">
+        <Attachment
+          name={text('name', 'image.png')}
+          imageUrl={
+            'http://matthewjamestaylor.com/img/illustrations/large/how-to-convert-a-liquid-layout-to-fixed-width.jpg'
+          }
+        />
+      </Attachment.Provider>
+    </div>
+  </Story>
+</Canvas>


### PR DESCRIPTION
# Problem/Feature

This PR changes the states of Attachment and its close button when in preview mode. The changes are done according to the designs: 
- https://www.figma.com/file/48D5ND2HIf7z77gv906Xfz/QA-%E2%86%92-1.5-Image-Upload?node-id=18%3A849
- https://www.figma.com/file/3IjtCyf7M2KV525EKT9C7M/7.-UX-Patterns?node-id=3%3A717

