### PR TITLE
Update state-based input focus styling

### DIFF
--- a/src/components/Input/Input.BackdropV2.css.js
+++ b/src/components/Input/Input.BackdropV2.css.js
@@ -152,7 +152,7 @@ function makeStateFocusStyles() {
         'state',
         state,
         'borderColor'
-      )}, 0 0 0 5px ${getColor('state', state, 'backgroundColor')};
+      )}, 0 0 0 6px ${getColor('state', state, 'backgroundColor')};
     }
   `
   )

--- a/src/components/Input/Input.BackdropV2.css.js
+++ b/src/components/Input/Input.BackdropV2.css.js
@@ -139,7 +139,24 @@ export const FocusUI = styled('div')`
   &.is-stateful.is-focused {
     box-shadow: 0 0 0 ${config.focusOutlineWidth}px ${config.focusOutlineColor};
   }
+
+  ${makeStateFocusStyles()}
 `
+
+function makeStateFocusStyles() {
+  return forEach(
+    STATES,
+    state => `
+    &.is-${state} {
+      box-shadow: 0 0 0 2px ${getColor(
+        'state',
+        state,
+        'borderColor'
+      )}, 0 0 0 5px ${getColor('state', state, 'backgroundColor')};
+    }
+  `
+  )
+}
 
 function makeStateStyles() {
   return forEach(

--- a/src/components/Input/Input.stories.mdx
+++ b/src/components/Input/Input.stories.mdx
@@ -75,17 +75,29 @@ An Input component is an enhanced version of the default HTML `<input>`. Input c
   <Story name="States">
     <div>
       <Input
+        label="Some label"
         autoComplete="off"
         state="error"
         placeholder="Error"
         errorMessage="Something went wrong"
       />
       <br />
-      <Input autoComplete="off" state="success" placeholder="Success" />
-      <br />
-      <Input autoComplete="off" state="warning" placeholder="Warning" />
+      <Input
+        label="Some label"
+        autoComplete="off"
+        state="success"
+        placeholder="Success"
+      />
       <br />
       <Input
+        label="Some label"
+        autoComplete="off"
+        state="warning"
+        placeholder="Warning"
+      />
+      <br />
+      <Input
+        label="Some label"
         autoComplete="off"
         state="warning"
         placeholder="State styles will remove on focus"


### PR DESCRIPTION

![Screen Recording 2021-05-10 at 01 09 10 PM](https://user-images.githubusercontent.com/203992/117697950-1aa00100-b191-11eb-8013-7d93dc333285.gif)


This update improves the focus styles for any input with a danger, success or warning state. It adds a second lighter border around the input.