### PR TITLE
HSDS-189 Update helix to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,13 +1774,13 @@
       }
     },
     "@helpscout/helix": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@helpscout/helix/-/helix-0.1.2.tgz",
-      "integrity": "sha512-/2K9VtAwNh/6wXRmDzxLOJdkBo0FnxhfKSIBiEnxcI9NBww7H1hraweI7U5QS7xgWFa9Co/rLr0u/yuuqg2ufA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@helpscout/helix/-/helix-0.2.0.tgz",
+      "integrity": "sha512-zDMkDkSxS6ybokUg1uuhvI6TdtWXTixOUbZe+LQiwrtUmxEx1azJwUij5L6E3e8KgFDh3XQ67Eyd94ZLoYSsIg==",
       "dev": true,
       "requires": {
-        "faker": "4.1.0",
-        "lodash": "^4.17.11"
+        "faker": "5.5.3",
+        "lodash": "^4.17.21"
       }
     },
     "@helpscout/hsds-illos": {
@@ -11741,9 +11741,9 @@
       "dev": true
     },
     "faker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
       "dev": true
     },
     "fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@helpscout/colorway": "0.9.5",
-    "@helpscout/helix": "^0.1.0",
+    "@helpscout/helix": "0.2.0",
     "@helpscout/prestart": "^0.0.9",
     "@storybook/addon-a11y": "6.2.9",
     "@storybook/addon-actions": "6.2.9",


### PR DESCRIPTION
Helix was updated to the latest version of all packages (https://github.com/helpscout/helix/pull/31). The package was also updated to use a plain babel transpile instead of having both commonjs and es module

This update bring the latest from helix to HSDS. All tests are still passing, and the avatar 404ing is also fixed.