### PR TITLE
Replaces usage of SelectDropdown with DropList

### DIFF
--- a/src/components/ActionSelect/ActionSelect.css.js
+++ b/src/components/ActionSelect/ActionSelect.css.js
@@ -1,23 +1,30 @@
 import styled from 'styled-components'
-import InputBackdropV2 from '../Input/Input.BackdropV2'
-
 import { getColor } from '../../styles/utilities/color'
 
 export const config = {
   backgroundColor: getColor('grey.200'),
-  borderColor: getColor('grey.600'),
+  borderColor: getColor('grey.800'),
   borderRadius: '3px',
   padding: '20px',
   transition: 'height 160ms ease',
 }
 
 export const ActionSelectUI = styled('div')`
+  .c-ActionSelectDropdownWrapper {
+    width: 100%;
+    position: relative;
+  }
+
+  .DropList__Select,
+  div[id*='tippy'],
+  .SelectTagToggler {
+    width: 100%;
+  }
+
   &.is-withContent {
-    .c-ActionSelectDropdownWrapper {
-      .${InputBackdropV2.className} {
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-      }
+    .SelectTagToggler {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
     }
   }
 `

--- a/src/components/ActionSelect/ActionSelect.stories.mdx
+++ b/src/components/ActionSelect/ActionSelect.stories.mdx
@@ -1,0 +1,11 @@
+import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs/blocks'
+import { Example } from './ActionSelect.hsappstories'
+import ActionSelect from './'
+
+<Meta title="Components/Dropdowns/ActionSelect" component={ActionSelect} />
+
+<Canvas>
+  <Story name="default">
+    <Example />
+  </Story>
+</Canvas>

--- a/src/components/ActionSelect/ActionSelect.test.js
+++ b/src/components/ActionSelect/ActionSelect.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import user from '@testing-library/user-event'
 import ActionSelect from './ActionSelect'
 
@@ -18,82 +18,60 @@ const mockItems = [
 ]
 
 describe('SelectDropdown', () => {
-  test('Renders a SelectDropdown with items', () => {
-    const { getAllByRole } = render(
+  test('Renders a SelectDropdown with items', async () => {
+    const { getByRole, getAllByRole } = render(
       <ActionSelect items={mockItems} isOpen={true} />
     )
 
-    const items = getAllByRole('option')
+    const toggler = getByRole('button')
 
-    expect(items).toHaveLength(3)
-    expect(items[0].textContent).toBe('Derek')
+    user.click(toggler)
+
+    await waitFor(() => {
+      const items = getAllByRole('option')
+
+      expect(items).toHaveLength(3)
+      expect(items[0].textContent).toBe('Derek')
+    })
   })
 
-  test('Renders a SelectDropdown with a selected item', () => {
+  test('Renders a SelectDropdown with a selected item', async () => {
     const { getByRole, getAllByRole } = render(
       <ActionSelect items={mockItems} selectedItem={mockItems[1]} />
     )
 
     user.click(getByRole('button'))
 
-    const selectedItem = getAllByRole('option').filter(item =>
-      item.classList.contains('is-active')
-    )
+    await waitFor(() => {
+      const selectedItem = getAllByRole('option').filter(item =>
+        item.classList.contains('is-selected')
+      )
 
-    expect(selectedItem.length).toBeTruthy()
-    expect(selectedItem[0].textContent).toBe('Hansel')
-  })
-})
-
-describe('Focus', () => {
-  test('Can refocuses trigger on close, by default', () => {
-    const spy = jest.fn()
-    const { container, getByRole } = render(
-      <ActionSelect items={mockItems} onFocus={spy} />
-    )
-
-    user.click(getByRole('button'))
-    user.type(container, '{esc}')
-
-    expect(spy).toHaveBeenCalledTimes(1)
-  })
-
-  test('Can not trigger on close, with custom shouldRefocusOnClose', () => {
-    const spy = jest.fn()
-    const shouldRefocusOnClose = () => false
-
-    const { container } = render(
-      <ActionSelect
-        items={mockItems}
-        isOpen={true}
-        onFocus={spy}
-        shouldRefocusOnClose={shouldRefocusOnClose}
-      />
-    )
-
-    user.type(container, '{esc}')
-
-    expect(spy).not.toHaveBeenCalled()
+      expect(selectedItem.length).toBeTruthy()
+      expect(selectedItem[0].textContent).toBe('Hansel')
+    })
   })
 })
 
 describe('Open/Close', () => {
-  test('onOpen callback works', () => {
-    const spy = jest.fn()
-    const { getByRole } = render(<ActionSelect onOpen={spy} />)
+  test('onOpen/onClose callbacks works', async () => {
+    const openSpy = jest.fn()
+    const closeSpy = jest.fn()
+    const { getByRole } = render(
+      <ActionSelect onOpen={openSpy} onClose={closeSpy} />
+    )
 
     user.click(getByRole('button'))
 
-    expect(spy).toHaveBeenCalled()
-  })
-
-  test('onClose callback works', () => {
-    const spy = jest.fn()
-    const { getByRole } = render(<ActionSelect onClose={spy} isOpen />)
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalled()
+    })
 
     user.click(getByRole('button'))
 
-    expect(spy).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(closeSpy).toHaveBeenCalled()
+    })
   })
 })
 

--- a/src/components/DropList/DropList.togglers.jsx
+++ b/src/components/DropList/DropList.togglers.jsx
@@ -217,7 +217,8 @@ export const SelectTag = forwardRef(
   ({ isActive = false, text = '', onClick = noop, error, ...rest }, ref) => {
     const className = classNames(
       'DropListToggler SelectTagToggler',
-      error && 'is-error'
+      error && 'is-error',
+      isActive && 'is-active'
     )
     return (
       <SelectUI
@@ -267,6 +268,7 @@ const SelectUI = styled('button')`
     padding-right: 10px;
   }
 
+  &.is-active,
   &:focus {
     outline: 0;
     box-shadow: inset 0 0 0 2px ${getColor('blue.500')};


### PR DESCRIPTION
The Dropdown obliteration continues with the last component using it inside HSDS: ActionSelect.

Straightforward refactoring that doesn't change the original interface of `ActionSelect` to avoid having to change any usages inside of HSApp or else.


[📹 Original](https://p-zkF42X.t2.n0.cdn.getcloudapp.com/items/5zuYWwoG/6eb616af-c190-4054-9279-13a2a6ec8097.mp4)

[📹 Refactored](https://p-zkF42X.t2.n0.cdn.getcloudapp.com/items/lluNm2A6/5df20a1e-e193-483e-823e-bd45291956bd.mp4)

