### PR TITLE
Controlled Tooltip

### DIFF
--- a/src/components/CheckMarkCard/CheckMarkCard.css.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.css.js
@@ -158,7 +158,7 @@ export const AvatarUI = styled(Avatar)`
 
 export const SubtitleUI = styled('div')`
   font-size: 13px;
-  color: ${getColor('charcoal.200')};
+  color: ${getColor('charcoal.400')};
 `
 
 export const HeadingUI = styled('div')`

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -143,14 +143,22 @@ const Tooltip = props => {
     plugins.push(hideOnEsc)
   }
 
-  const tippyProps = {
+  const defaultTippyProps = {
     onHide,
     onShow,
     placement,
     plugins,
     render,
-    trigger: triggerOn === 'hover' ? 'mouseenter' : triggerOn,
-    showOnCreate: isOpen,
+  }
+
+  // only set those props if the component is not in a controlled way
+  if (!props.hasOwnProperty('visible')) {
+    defaultTippyProps.showOnCreate = isOpen
+    defaultTippyProps.trigger = triggerOn === 'hover' ? 'mouseenter' : triggerOn
+  }
+
+  const tippyProps = {
+    ...defaultTippyProps,
     ...rest,
     ...extraProps,
   }
@@ -163,7 +171,7 @@ const Tooltip = props => {
     ) : null
   }
 
-  let trigger
+  let triggerComponent
 
   if (
     !withTriggerWrapper &&
@@ -176,9 +184,9 @@ const Tooltip = props => {
       'data-cy': component.props['data-cy'] || dataCy,
       tabIndex: component.props['tabIndex'] || 0,
     }
-    trigger = React.cloneElement(component, triggerProps)
+    triggerComponent = React.cloneElement(component, triggerProps)
   } else {
-    trigger = (
+    triggerComponent = (
       <TooltipTriggerUI
         tabIndex="0"
         display={display}
@@ -190,7 +198,7 @@ const Tooltip = props => {
     )
   }
 
-  return <Tippy {...tippyProps}>{trigger}</Tippy>
+  return <Tippy {...tippyProps}>{triggerComponent}</Tippy>
 }
 
 Tooltip.defaultProps = {
@@ -215,6 +223,8 @@ Tooltip.propTypes = {
   className: PropTypes.string,
   /** Whether to allow closing the tooltip on pressing ESC */
   closeOnEscPress: PropTypes.bool,
+  /** Data attr for Cypress tests. */
+  'data-cy': PropTypes.string,
   /** Apply custom css rule `display` */
   display: PropTypes.string,
   /** Determine if the tooltip is open via a prop */
@@ -231,8 +241,8 @@ Tooltip.propTypes = {
   title: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   /** Determines how to engage the component. */
   triggerOn: PropTypes.string,
-  /** Data attr for Cypress tests. */
-  'data-cy': PropTypes.string,
+  /** Set the tooltip to be controlled externally */
+  visible: PropTypes.bool,
   /** Wrap the trigger with a span */
   withTriggerWrapper: PropTypes.bool,
 }

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -1,6 +1,10 @@
 import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs/blocks'
 import Tooltip from './'
-import { Default, CustomContent } from './Tooltip.storiesHelpers'
+import {
+  Default,
+  CustomContent,
+  ControlledTooltip,
+} from './Tooltip.storiesHelpers'
 
 <Meta
   title="Components/Overlay/Tooltip"
@@ -64,5 +68,13 @@ In some cases, we want to remove that span, the `withTriggerWrapper` will allow 
 <Canvas>
   <Story name="with custom content">
     <CustomContent />
+  </Story>
+</Canvas>
+
+#### Controlled tooltip
+
+<Canvas>
+  <Story name="controlled tooltip">
+    <ControlledTooltip />
   </Story>
 </Canvas>

--- a/src/components/Tooltip/Tooltip.storiesHelpers.js
+++ b/src/components/Tooltip/Tooltip.storiesHelpers.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { boolean, number, select, text } from '@storybook/addon-knobs'
 import Tooltip, { TooltipContext } from '.'
 import Text from '../Text'
@@ -112,6 +112,26 @@ export const CustomContent = () => {
     <TooltipContext.Provider value={{ zIndex: 256 }}>
       <div style={{ padding: '20%', textAlign: 'center' }}>
         <Tooltip {...props}>Tooltip Trigger</Tooltip>
+      </div>
+    </TooltipContext.Provider>
+  )
+}
+
+export const ControlledTooltip = () => {
+  const [visible, setVisible] = useState(false)
+  const toggle = () => setVisible(!visible)
+
+  return (
+    <TooltipContext.Provider value={{ zIndex: 256 }}>
+      <div style={{ padding: '20%', textAlign: 'center' }}>
+        <p>
+          <Tooltip visible={visible} title="Hello">
+            Tooltip Trigger
+          </Tooltip>
+        </p>
+        <p>
+          <Button onClick={toggle}>toggle tooltip</Button>
+        </p>
       </div>
     </TooltipContext.Provider>
   )

--- a/src/components/Tooltip/Tooltip.test.js
+++ b/src/components/Tooltip/Tooltip.test.js
@@ -115,6 +115,19 @@ describe('Tippy', () => {
     const pop = wrapper.find(Tippy).props()
     expect(pop.zIndex).toBe(1243)
   })
+
+  test.only("Controlled component should'nt pass down trigger and showOnCreate props ", () => {
+    const props = {
+      placement: 'bottom',
+      triggerOn: 'click',
+      title: 'Pop',
+      visible: true,
+    }
+    const wrapper = mount(<Tooltip {...props} />)
+    const pop = wrapper.find(Tippy).props()
+    expect(pop.showOnCreate).toBeFalsy()
+    expect(pop.trigger).toBeFalsy()
+  })
 })
 
 describe('Context', () => {


### PR DESCRIPTION
This update adds the `visible` props to the tooltip in case we need to entirely control the tooltip from the outside (that's the case with the Editor).

When this prop exists (just declared on the props object is enough) it will make sure to remove the `showOnCreated` and `trigger` list of props that will be passed down to Tippy.

### Checkmark
Also, at the same time, we fixed a small color issue with the CheckmarkCard component.  We increase the color contrast for the subtitle.