### PR TITLE
Adds some enhancements to DropList

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -21,6 +21,7 @@ import ListItem, { generateListItemKey } from './DropList.ListItem'
 import { VARIANTS } from './DropList.constants'
 
 function Combobox({
+  closeOnBlur = true,
   closeOnSelection = true,
   customEmptyList = null,
   'data-cy': dataCy = `DropList.${VARIANTS.COMBOBOX}`,
@@ -72,6 +73,7 @@ function Combobox({
 
     onIsOpenChange(changes) {
       onIsOpenChangeCommon({
+        closeOnBlur,
         closeOnSelection,
         toggleOpenedState,
         type: `${VARIANTS.COMBOBOX}.${changes.type}`,

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -16,6 +16,7 @@ import ListItem, { generateListItemKey } from './DropList.ListItem'
 import { VARIANTS } from './DropList.constants'
 
 function Select({
+  closeOnBlur = true,
   closeOnSelection = true,
   customEmptyList = null,
   'data-cy': dataCy = `DropList.${VARIANTS.SELECT}`,
@@ -55,6 +56,7 @@ function Select({
 
     onIsOpenChange(changes) {
       onIsOpenChangeCommon({
+        closeOnBlur,
         closeOnSelection,
         toggleOpenedState,
         type: `${VARIANTS.SELECT}.${changes.type}`,

--- a/src/components/DropList/DropList.css.js
+++ b/src/components/DropList/DropList.css.js
@@ -27,11 +27,11 @@ export const MenuListUI = styled('ul')`
   max-height: 200px;
   overflow-y: auto;
   margin: 0;
-  padding: 5px 0 0 0;
+  padding: 5px 0 5px 0;
   list-style: none;
 
   &.MenuList-Combobox {
-    padding: 0;
+    padding: 0 0 5px 0;
   }
 
   &:focus {
@@ -83,7 +83,7 @@ export const ListItemUI = styled('li')`
   cursor: pointer;
 
   &:last-child {
-    margin-bottom: 10px;
+    margin-bottom: 0;
   }
 
   &.is-selected,

--- a/src/components/DropList/DropList.downshift.common.js
+++ b/src/components/DropList/DropList.downshift.common.js
@@ -108,6 +108,7 @@ export function stateReducerCommon({
 }
 
 export function onIsOpenChangeCommon({
+  closeOnBlur,
   closeOnSelection,
   toggleOpenedState,
   type,
@@ -127,7 +128,7 @@ export function onIsOpenChangeCommon({
 
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputBlur}`:
     case `${SELECT}.${useSelect.stateChangeTypes.MenuBlur}`:
-      toggleOpenedState(false, OPEN_ACTION_ORIGIN.INPUT_BLUR)
+      closeOnBlur && toggleOpenedState(false, OPEN_ACTION_ORIGIN.INPUT_BLUR)
       break
 
     default:

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -28,6 +28,7 @@ import Select from './DropList.Select'
 function DropListManager({
   animateOptions = {},
   autoSetComboboxAt = 0,
+  closeOnBlur = true,
   closeOnClickOutside = true,
   closeOnSelection = true,
   customEmptyList = null,
@@ -225,6 +226,7 @@ function DropListManager({
       render={() => (
         <Animate {...animateProps} in={isOpen}>
           <DropListVariant
+            closeOnBlur={closeOnBlur}
             closeOnSelection={closeOnSelection}
             customEmptyList={customEmptyList}
             data-cy={dataCy}
@@ -278,6 +280,8 @@ DropListManager.propTypes = {
   animateOptions: PropTypes.object,
   /** When the number of items is larger than this number, automatically set the variant to combobox */
   autoSetComboboxAt: PropTypes.number,
+  /** Whether to close the DropList on blur (useful when debugging) */
+  closeOnBlur: PropTypes.bool,
   /** Whether to close the DropList when clicking outside the droplist */
   closeOnClickOutside: PropTypes.bool,
   /** Whether to close the DropList when an item is selected */

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -644,6 +644,7 @@ The `toggler` prop accepts any React component, so you can provide your own cust
         items={regularItems}
         toggler={
           <IconBtn
+            a11yLabel="Accessibility Wins The Day"
             onClick={() => {
               console.log('Clicked from story')
             }}

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -644,6 +644,7 @@ The `toggler` prop accepts any React component, so you can provide your own cust
         items={regularItems}
         toggler={
           <IconBtn
+            withTooltip
             a11yLabel="Accessibility Wins The Day"
             onClick={() => {
               console.log('Clicked from story')

--- a/src/components/DropList/DropList.togglers.css.js
+++ b/src/components/DropList/DropList.togglers.css.js
@@ -1,0 +1,154 @@
+import styled from 'styled-components'
+import { getColor } from '../../styles/utilities/color'
+import HSDSButton from '../Button'
+
+export const NavLinkTogglerUI = styled('button')`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  height: 55px;
+  padding: 0 18px;
+  background: transparent;
+  border: 0;
+  font-family: var(--HSDSGlobalFontFamily);
+  font-size: 14px;
+  color: ${getColor('blue.300')};
+  cursor: pointer;
+
+  &.is-active {
+    color: white;
+  }
+
+  .c-Icon {
+    margin: 3px 0 0 3px;
+  }
+`
+
+export const SplitButtonTogglerUI = styled(HSDSButton)`
+  &.SplitButton__Toggler {
+    min-width: 30px !important;
+    padding: 0;
+    pointer-events: all;
+
+    &.is-primary {
+      box-shadow: -1px 0 0 ${getColor('blue.600')};
+
+      &.is-success {
+        box-shadow: -1px 0 0 ${getColor('green.600')};
+      }
+      &.is-danger {
+        box-shadow: -1px 0 0 ${getColor('red.600')};
+      }
+      &[disabled] {
+        box-shadow: -1px 0 0 ${getColor('grey.600')};
+      }
+    }
+
+    .c-Button__content {
+      padding-top: 2px;
+      width: 16px;
+    }
+  }
+`
+
+export const SelectUI = styled('button')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 150px;
+  height: 38px;
+  padding: 0 15px;
+  margin: 0;
+  background: white;
+  border: 0;
+  box-shadow: inset 0 0 0 1px ${getColor('grey.800')};
+  box-sizing: border-box;
+  border-radius: 3px;
+  font-family: var(--HSDSGlobalFontFamily);
+  font-size: 13px;
+  color: ${getColor('charcoal.600')};
+
+  &.is-error {
+    box-shadow: inset 0 0 0 2px ${getColor('red.500')};
+    padding-right: 10px;
+  }
+
+  &.is-active,
+  &:focus {
+    outline: 0;
+    box-shadow: inset 0 0 0 2px ${getColor('blue.500')};
+  }
+`
+
+export const SelectArrowsUI = styled('div')`
+  margin-left: auto;
+  width: 7px;
+  height: 14px;
+  position: relative;
+
+  &::before,
+  &::after {
+    content: '';
+    border-left: 3.5px solid transparent;
+    border-right: 3.5px solid transparent;
+    position: absolute;
+    left: 0;
+  }
+
+  &::before {
+    border-bottom: 6px solid ${getColor('charcoal.700')};
+    top: 0;
+  }
+
+  &::after {
+    border-top: 6px solid ${getColor('charcoal.700')};
+    bottom: 0;
+  }
+`
+
+export const SelectErrorTooltipIconUI = styled('div')`
+  margin-left: 8px;
+`
+
+export const KebabUI = styled('button')`
+  width: 24px;
+  height: 24px;
+  padding: 0.5px 0px 0px 0.5px;
+  border: 0;
+  border-radius: 3px;
+  background-color: white;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:focus {
+    outline: 0;
+    box-shadow: inset 0 0 0 2px ${getColor('blue.500')};
+  }
+`
+
+export const IconButtonUI = styled('button')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 45px;
+  height: 34px;
+  padding: 5px;
+  border: 0;
+  border-radius: 3px;
+  background-color: white;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:focus {
+    outline: 0;
+    box-shadow: inset 0 0 0 2px ${getColor('blue.500')};
+  }
+
+  .is-iconName-caret-down {
+    margin-left: -3px;
+  }
+`

--- a/src/components/DropList/DropList.togglers.jsx
+++ b/src/components/DropList/DropList.togglers.jsx
@@ -240,6 +240,7 @@ export const Kebab = forwardRef(
       isActive = false,
       iconSize = '24',
       onClick = noop,
+      withTooltip = false,
       ...rest
     },
     ref
@@ -263,7 +264,18 @@ export const Kebab = forwardRef(
         type="button"
         {...rest}
       >
-        <Icon name="kebab" size={iconSize} />
+        {withTooltip ? (
+          <Tooltip
+            animationDelay={0}
+            animationDuration={0}
+            placement="top-end"
+            title={a11yLabel}
+          >
+            <Icon name="kebab" size={iconSize} />
+          </Tooltip>
+        ) : (
+          <Icon name="kebab" size={iconSize} />
+        )}
         {a11yLabel ? <VisuallyHidden>{a11yLabel}</VisuallyHidden> : null}
       </KebabUI>
     )
@@ -282,6 +294,7 @@ export const IconBtn = forwardRef(
       iconSize = '24',
       onClick = noop,
       withCaret = true,
+      withTooltip = false,
       ...rest
     },
     ref
@@ -304,7 +317,18 @@ export const IconBtn = forwardRef(
         type="button"
         {...rest}
       >
-        <Icon name={iconName} size={iconSize} />
+        {withTooltip ? (
+          <Tooltip
+            animationDelay={0}
+            animationDuration={0}
+            placement="top-end"
+            title={a11yLabel}
+          >
+            <Icon name={iconName} size={iconSize} />
+          </Tooltip>
+        ) : (
+          <Icon Name={iconName} Size={iconSize} />
+        )}
         {a11yLabel ? <VisuallyHidden>{a11yLabel}</VisuallyHidden> : null}
         {withCaret ? <Icon name="caret-down" size={caretSize} /> : null}
       </IconButtonUI>

--- a/src/components/DropList/DropList.togglers.jsx
+++ b/src/components/DropList/DropList.togglers.jsx
@@ -1,22 +1,31 @@
 import React, { forwardRef } from 'react'
-import styled from 'styled-components'
-import { getColor } from '../../styles/utilities/color'
 import { classNames } from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import ControlGroup from '../ControlGroup'
 import HSDSButton from '../Button'
 import Icon from '../Icon'
+import VisuallyHidden from '../VisuallyHidden'
 import { STATES } from '../../constants'
 import Tooltip from '../Tooltip'
+import {
+  IconButtonUI,
+  KebabUI,
+  NavLinkTogglerUI,
+  SelectArrowsUI,
+  SelectErrorTooltipIconUI,
+  SelectUI,
+  SplitButtonTogglerUI,
+} from './DropList.togglers.css'
 
 export const SimpleButton = forwardRef(
   (
     {
-      text = '',
+      className = '',
       isActive = false,
       kind = 'primary',
-      size = 'lg',
       onClick = noop,
+      size = 'lg',
+      text = '',
       ...rest
     },
     ref
@@ -27,7 +36,12 @@ export const SimpleButton = forwardRef(
         aria-haspopup="true"
         aria-expanded={isActive}
         buttonRef={ref}
-        className="DropListToggler ButtonToggler"
+        className={classNames(
+          className,
+          'DropListToggler',
+          'ButtonToggler',
+          isActive && 'is-active'
+        )}
         data-cy="DropList.ButtonToggler"
         data-testid="DropList.ButtonToggler"
         isActive={isActive}
@@ -48,11 +62,12 @@ export const SimpleButton = forwardRef(
 export const NavLink = forwardRef(
   (
     {
-      text = '',
+      className = '',
       isActive = false,
       kind = 'primary',
-      size = 'lg',
       onClick = noop,
+      size = 'lg',
+      text = '',
       ...rest
     },
     ref
@@ -64,6 +79,7 @@ export const NavLink = forwardRef(
         aria-expanded={isActive}
         ref={ref}
         className={classNames(
+          className,
           'DropListToggler',
           'NavLinkToggler',
           isActive && 'is-active'
@@ -82,38 +98,17 @@ export const NavLink = forwardRef(
   }
 )
 
-const NavLinkTogglerUI = styled('button')`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  height: 55px;
-  padding: 0 18px;
-  background: transparent;
-  border: 0;
-  font-family: var(--HSDSGlobalFontFamily);
-  font-size: 14px;
-  color: ${getColor('blue.300')};
-  cursor: pointer;
-
-  &.is-active {
-    color: white;
-  }
-
-  .c-Icon {
-    margin: 3px 0 0 3px;
-  }
-`
-
 export const SplittedButton = forwardRef(
   (
     {
-      text = '',
+      actionButtonProps = {},
+      className = '',
+      isActive = false,
       kind = 'primary',
-      size = 'lg',
       onActionClick = noop,
       onClick = noop,
-      isActive = false,
-      actionButtonProps = {},
+      size = 'lg',
+      text = '',
       togglerButtonProps = {},
       ...rest
     },
@@ -145,7 +140,12 @@ export const SplittedButton = forwardRef(
             aria-haspopup="true"
             aria-expanded={isActive}
             buttonRef={ref}
-            className="SplitButton__Toggler"
+            className={classNames(
+              className,
+              'DropListToggler',
+              'SplitButton__Toggler',
+              isActive && 'is-active'
+            )}
             data-cy="DropList.SplitButtonToggler"
             data-testid="DropList.SplitButtonToggler"
             isActive={isActive}
@@ -171,33 +171,6 @@ export const SplittedButton = forwardRef(
   }
 )
 
-const SplitButtonTogglerUI = styled(HSDSButton)`
-  &.SplitButton__Toggler {
-    min-width: 30px !important;
-    padding: 0;
-    pointer-events: all;
-
-    &.is-primary {
-      box-shadow: -1px 0 0 ${getColor('blue.600')};
-
-      &.is-success {
-        box-shadow: -1px 0 0 ${getColor('green.600')};
-      }
-      &.is-danger {
-        box-shadow: -1px 0 0 ${getColor('red.600')};
-      }
-      &[disabled] {
-        box-shadow: -1px 0 0 ${getColor('grey.600')};
-      }
-    }
-
-    .c-Button__content {
-      padding-top: 2px;
-      width: 16px;
-    }
-  }
-`
-
 const ErrorTooltipIcon = ({ error }) => {
   return (
     <Tooltip
@@ -214,20 +187,31 @@ const ErrorTooltipIcon = ({ error }) => {
 }
 
 export const SelectTag = forwardRef(
-  ({ isActive = false, text = '', onClick = noop, error, ...rest }, ref) => {
-    const className = classNames(
-      'DropListToggler SelectTagToggler',
-      error && 'is-error',
-      isActive && 'is-active'
-    )
+  (
+    {
+      className = '',
+      error,
+      isActive = false,
+      onClick = noop,
+      text = '',
+      ...rest
+    },
+    ref
+  ) => {
     return (
       <SelectUI
         aria-label="toggle menu"
         aria-haspopup="true"
         aria-expanded={isActive}
-        className={className}
+        className={classNames(
+          className,
+          'DropListToggler SelectTagToggler',
+          error && 'is-error',
+          isActive && 'is-active'
+        )}
         data-cy="DropList.SelectTagToggler"
         data-testid="DropList.SelectTagToggler"
+        isActive={isActive}
         onClick={onClick}
         ref={ref}
         type="button"
@@ -246,150 +230,83 @@ export const SelectTag = forwardRef(
   }
 )
 
-const SelectUI = styled('button')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 150px;
-  height: 38px;
-  padding: 0 15px;
-  margin: 0;
-  background: white;
-  border: 0;
-  box-shadow: inset 0 0 0 1px ${getColor('grey.800')};
-  box-sizing: border-box;
-  border-radius: 3px;
-  font-family: var(--HSDSGlobalFontFamily);
-  font-size: 13px;
-  color: ${getColor('charcoal.600')};
-
-  &.is-error {
-    box-shadow: inset 0 0 0 2px ${getColor('red.500')};
-    padding-right: 10px;
-  }
-
-  &.is-active,
-  &:focus {
-    outline: 0;
-    box-shadow: inset 0 0 0 2px ${getColor('blue.500')};
-  }
-`
-
-const SelectArrowsUI = styled('div')`
-  margin-left: auto;
-  width: 7px;
-  height: 14px;
-  position: relative;
-
-  &::before,
-  &::after {
-    content: '';
-    border-left: 3.5px solid transparent;
-    border-right: 3.5px solid transparent;
-    position: absolute;
-    left: 0;
-  }
-
-  &::before {
-    border-bottom: 6px solid ${getColor('charcoal.700')};
-    top: 0;
-  }
-
-  &::after {
-    border-top: 6px solid ${getColor('charcoal.700')};
-    bottom: 0;
-  }
-`
-
-const SelectErrorTooltipIconUI = styled('div')`
-  margin-left: 8px;
-`
-
-const KebabUI = styled('button')`
-  width: 24px;
-  height: 24px;
-  padding: 0.5px 0px 0px 0.5px;
-  border: 0;
-  border-radius: 3px;
-  background-color: white;
-
-  &:hover {
-    cursor: pointer;
-  }
-
-  &:focus {
-    outline: 0;
-    box-shadow: inset 0 0 0 2px ${getColor('blue.500')};
-  }
-`
-
 // No need to test every single toggler if they're basically the same as Button
 /* istanbul ignore next */
 export const Kebab = forwardRef(
-  ({ isActive = false, onClick = noop, ...rest }, ref) => {
+  (
+    {
+      a11yLabel = '',
+      className = '',
+      isActive = false,
+      iconSize = '24',
+      onClick = noop,
+      ...rest
+    },
+    ref
+  ) => {
     return (
       <KebabUI
         aria-label="toggle menu"
         aria-haspopup="true"
         aria-expanded={isActive}
-        className="DropListToggler KebabToggler"
+        className={classNames(
+          className,
+          'DropListToggler',
+          'KebabToggler',
+          isActive && 'is-active'
+        )}
         data-cy="DropList.KebabToggler"
         data-testid="DropList.KebabToggler"
+        isActive={isActive}
         onClick={onClick}
         ref={ref}
         type="button"
         {...rest}
       >
-        <Icon name="kebab" size="24" />
+        <Icon name="kebab" size={iconSize} />
+        {a11yLabel ? <VisuallyHidden>{a11yLabel}</VisuallyHidden> : null}
       </KebabUI>
     )
   }
 )
 
-const IconButtonUI = styled('button')`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 45px;
-  height: 34px;
-  padding: 5px;
-  border: 0;
-  border-radius: 3px;
-  background-color: white;
-
-  &:hover {
-    cursor: pointer;
-  }
-
-  &:focus {
-    outline: 0;
-    box-shadow: inset 0 0 0 2px ${getColor('blue.500')};
-  }
-
-  .is-iconName-caret-down {
-    margin-left: -3px;
-  }
-`
-
 // No need to test every single toggler if they're basically the same as Button
 /* istanbul ignore next */
 export const IconBtn = forwardRef(
-  ({ isActive = false, onClick = noop, iconName = 'assign', ...rest }, ref) => {
+  (
+    {
+      a11yLabel = '',
+      caretSize = '14',
+      isActive = false,
+      iconName = 'assign',
+      iconSize = '24',
+      onClick = noop,
+      withCaret = true,
+      ...rest
+    },
+    ref
+  ) => {
     return (
       <IconButtonUI
         aria-label="toggle menu"
         aria-haspopup="true"
         aria-expanded={isActive}
-        className="DropListToggler IconButtonToggler"
+        className={classNames(
+          'DropListToggler',
+          'IconButtonToggler',
+          isActive && 'is-active'
+        )}
         data-cy="DropList.IconButtonToggler"
         data-testid="DropList.IconButtonToggler"
+        isActive={isActive}
         onClick={onClick}
         ref={ref}
         type="button"
         {...rest}
       >
-        <Icon name={iconName} size="24" />
-        <Icon name="caret-down" size="14" />
+        <Icon name={iconName} size={iconSize} />
+        {a11yLabel ? <VisuallyHidden>{a11yLabel}</VisuallyHidden> : null}
+        {withCaret ? <Icon name="caret-down" size={caretSize} /> : null}
       </IconButtonUI>
     )
   }


### PR DESCRIPTION
# Feature

Continuing the replacement of Dropdown, found a few more things to improve:

- Cleaned up togglers file (moved all styled components into a css file)
- Adds 'is-active' class to all preset togglers
- Adds some options to `IconBtn` toggler (`withCaret`, `iconSize`, `caretSize`)
- Adds `a11yLabel` to togglers that are just icons so we can pass text that will not be rendered but readable for screen readers
- Adds the ability to enable Tooltip on icon-only togglers with the flag `withTooltip` using the `a11yLabel` text
- Adds `closeOnBlur` flag to DropList, mainly because is useful when debugging (so that the menu DOM Node can be inspectable on devtools)
- Improves the padding/margin of menu when there is only one item in the DropList