### PR TITLE
Fix the weird avatar import issue

### DIFF
--- a/src/components/CheckMarkCard/CheckMarkCard.css.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.css.js
@@ -1,11 +1,11 @@
+import styled from 'styled-components'
 import { d400, d400Effect } from '../../styles/mixins/depth.css'
 
-import Avatar from '../Avatar/Avatar'
+import Avatar from '../Avatar'
 import ChoiceGroup from '../ChoiceGroup'
 
 import { getColor } from '../../styles/utilities/color'
 import { rgba } from '../../utilities/color'
-import styled from 'styled-components'
 
 export const MarkUI = styled('div')`
   position: absolute;
@@ -152,7 +152,7 @@ export const CheckMarkCardUI = styled('label')`
   }
 `
 
-export const AvatarUI = styled(Avatar)`
+export const AvatarWrapperUI = styled.div`
   margin-bottom: 14px;
 `
 
@@ -174,7 +174,7 @@ export const HeadingUI = styled('div')`
   white-space: nowrap;
 `
 
-export const CheckmarkCardGridUI = styled(ChoiceGroup)`
+export const CheckMarkCardGridUI = styled(ChoiceGroup)`
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: ${({ choiceHeight }) => `${choiceHeight}`};

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
+import Avatar from '../Avatar'
 import Checkbox from '../Checkbox'
 import Icon from '../Icon'
 import Tooltip from '../Tooltip'
@@ -11,9 +12,9 @@ import { createUniqueIDFactory } from '../../utilities/id'
 import { noop } from '../../utilities/other'
 
 import {
-  AvatarUI,
+  AvatarWrapperUI,
   CheckMarkCardContentUI,
-  CheckmarkCardGridUI,
+  CheckMarkCardGridUI,
   CheckMarkCardUI,
   HeadingUI,
   MarkUI,
@@ -156,7 +157,11 @@ const CheckMarkCard = props => {
     >
       <CheckMarkCardContentUI>
         <Mark cardChecked={cardChecked} {...markProps} />
-        {shouldShowAvatar && <AvatarUI size="xl" image={avatar} name={label} />}
+        {shouldShowAvatar && (
+          <AvatarWrapperUI>
+            <Avatar size="xl" image={avatar} name={label} />
+          </AvatarWrapperUI>
+        )}
         {shouldDisplayHeading && <HeadingUI>{heading || label}</HeadingUI>}
         {subtitle && <SubtitleUI>{subtitle}</SubtitleUI>}
         {children}
@@ -250,6 +255,6 @@ CheckMarkCard.propTypes = {
   ]),
 }
 
-CheckMarkCard.Grid = CheckmarkCardGridUI
+CheckMarkCard.Grid = CheckMarkCardGridUI
 
 export default CheckMarkCard

--- a/src/components/CheckMarkCard/CheckMarkCard.test.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import { getColor } from '../../styles/utilities/color'
 import CheckMarkCard from '../CheckMarkCard'
 import Checkbox from '../Checkbox'
 import Icon from '../Icon'


### PR DESCRIPTION
# Problem

Some weird issue came up within hs-app with circular import crashing the webpack loader. After investigation, we found out that extending the Avatar component within `CheckMarkCard.css` was the culprit. For some reason, extending the consumer was creating import issues. Maybe it's a difference between styled-component version between hs-app and HSDS, it is still unknown. 

To fix the issue, we import the Avatar directly within the  `CheckMarkCard` component and wrap it with a simple div to apply the needed margin

- [ ] A link to the Figma design in your story (list regularly updated [here](https://docs.google.com/spreadsheets/d/19-5gNbYuKjOb-kk7VTQZ0i_VWVd_8lubx-uhrlPUu1E/edit#gid=0))
- [ ] A link to the Story(ies) in the description
- [ ] Is there a Jira ticket associated?
- [ ] If useful, add screenshots or videos
- [ ] If useful (and unclear), add a little explanation of why a certain path was taken
- [ ] Instructions on how to test
- [ ] Found any restrictions/limitations? Let us know!

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
