### PR TITLE
Fixes selection and beefs up test for ActionSelect

### DIFF
--- a/src/components/ActionSelect/ActionSelect.jsx
+++ b/src/components/ActionSelect/ActionSelect.jsx
@@ -15,7 +15,7 @@ export class ActionSelect extends React.PureComponent {
   state = {
     isOpen: this.props.isOpen,
     resizeCount: 0,
-    selectedItem: null,
+    selectedItem: this.props.selectedItem || null,
   }
 
   _isMounted = false
@@ -141,7 +141,7 @@ export class ActionSelect extends React.PureComponent {
             onOpenedStateChange={this.handleOnOpenClose}
             onSelect={this.handleOnSelect}
             toggler={<SelectTag text={getSelectTagText(selectedItem, items)} />}
-            selection={this.props.selectedItem}
+            selection={selectedItem}
           />
         </div>
         <ContentResizer

--- a/src/components/ActionSelect/ActionSelect.jsx
+++ b/src/components/ActionSelect/ActionSelect.jsx
@@ -18,7 +18,7 @@ export class ActionSelect extends React.PureComponent {
     this.state = {
       isOpen: props.isOpen,
       resizeCount: 0,
-      selectedItem: props.selectedItem || null,
+      selection: props.selectedItem || null,
     }
   }
 
@@ -79,13 +79,13 @@ export class ActionSelect extends React.PureComponent {
     })
   }
 
-  handleOnSelect = selectedItem => {
-    this.props.onSelect(selectedItem.value, selectedItem)
+  handleOnSelect = selection => {
+    this.props.onSelect(selection.value, selection)
     this.autoFocusChildNode()
     this.resizeContent()
-    this.scrollIntoView(selectedItem.value)
+    this.scrollIntoView(selection.value)
     this.safeSetState({
-      selectedItem,
+      selection,
     })
   }
 
@@ -129,7 +129,7 @@ export class ActionSelect extends React.PureComponent {
       onResize,
       shouldRefocusOnClose,
     } = this.props
-    const { isOpen, resizeCount, selectedItem } = this.state
+    const { isOpen, resizeCount, selection } = this.state
 
     return (
       <ActionSelectUI
@@ -144,8 +144,8 @@ export class ActionSelect extends React.PureComponent {
             items={items}
             onOpenedStateChange={this.handleOnOpenClose}
             onSelect={this.handleOnSelect}
-            toggler={<SelectTag text={getSelectTagText(selectedItem, items)} />}
-            selection={selectedItem}
+            toggler={<SelectTag text={getSelectTagText(selection, items)} />}
+            selection={selection}
           />
         </div>
         <ContentResizer
@@ -158,7 +158,7 @@ export class ActionSelect extends React.PureComponent {
           onAnimationUpdate={onAnimationUpdate}
           onResize={onResize}
           resizeCount={resizeCount}
-          selectedKey={getUniqueKeyFromItem(selectedItem)}
+          selectedKey={getUniqueKeyFromItem(selection)}
         >
           {children}
         </ContentResizer>
@@ -217,6 +217,7 @@ ActionSelect.propTypes = {
   onOpen: PropTypes.func,
   onResize: PropTypes.func,
   onSelect: PropTypes.func,
+  selectedItem: PropTypes.object,
   shouldRefocusOnClose: PropTypes.func,
   shouldScrollIntoView: PropTypes.func,
 }

--- a/src/components/ActionSelect/ActionSelect.jsx
+++ b/src/components/ActionSelect/ActionSelect.jsx
@@ -12,10 +12,14 @@ import { ActionSelectUI } from './ActionSelect.css'
 export class ActionSelect extends React.PureComponent {
   static className = 'c-ActionSelect'
 
-  state = {
-    isOpen: this.props.isOpen,
-    resizeCount: 0,
-    selectedItem: this.props.selectedItem || null,
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      isOpen: props.isOpen,
+      resizeCount: 0,
+      selectedItem: props.selectedItem || null,
+    }
   }
 
   _isMounted = false

--- a/src/components/ActionSelect/ActionSelect.test.js
+++ b/src/components/ActionSelect/ActionSelect.test.js
@@ -17,8 +17,8 @@ const mockItems = [
   },
 ]
 
-describe('SelectDropdown', () => {
-  test('Renders a SelectDropdown with items', async () => {
+describe('DropList', () => {
+  test('Renders a DropList with items', async () => {
     const { getByRole, getAllByRole } = render(
       <ActionSelect items={mockItems} isOpen={true} />
     )
@@ -35,20 +35,38 @@ describe('SelectDropdown', () => {
     })
   })
 
-  test('Renders a SelectDropdown with a selected item', async () => {
-    const { getByRole, getAllByRole } = render(
-      <ActionSelect items={mockItems} selectedItem={mockItems[1]} />
+  test('DropList Selection', async () => {
+    const onSelectSpy = jest.fn()
+    const { getByRole, getAllByRole, getByTestId } = render(
+      <ActionSelect
+        items={mockItems}
+        selectedItem={mockItems[1]}
+        onSelect={onSelectSpy}
+      />
     )
 
     user.click(getByRole('button'))
 
     await waitFor(() => {
-      const selectedItem = getAllByRole('option').filter(item =>
-        item.classList.contains('is-selected')
+      expect(
+        getAllByRole('option')[1].classList.contains('is-selected')
+      ).toBeTruthy()
+      expect(getByTestId('DropList.SelectTagToggler').textContent).toBe(
+        'Hansel'
       )
 
-      expect(selectedItem.length).toBeTruthy()
-      expect(selectedItem[0].textContent).toBe('Hansel')
+      user.click(getAllByRole('option')[0])
+    })
+
+    await waitFor(() => {
+      expect(
+        getAllByRole('option')[1].classList.contains('is-selected')
+      ).toBeFalsy()
+      expect(
+        getAllByRole('option')[0].classList.contains('is-selected')
+      ).toBeTruthy()
+      expect(getByTestId('DropList.SelectTagToggler').textContent).toBe('Derek')
+      expect(onSelectSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/DropList/DropList.togglers.jsx
+++ b/src/components/DropList/DropList.togglers.jsx
@@ -116,7 +116,11 @@ export const SplittedButton = forwardRef(
   ) => {
     return (
       <ControlGroup
-        className="DropListToggler SplitButtonTogglerControlGroup"
+        className={classNames(
+          className,
+          'DropListToggler',
+          'SplitButtonTogglerControlGroup'
+        )}
         data-cy="DropList.SplitButtonTogglerControlGroup"
         {...rest}
       >
@@ -141,7 +145,6 @@ export const SplittedButton = forwardRef(
             aria-expanded={isActive}
             buttonRef={ref}
             className={classNames(
-              className,
               'DropListToggler',
               'SplitButton__Toggler',
               isActive && 'is-active'


### PR DESCRIPTION
# Problem

The selection from props and state in `ActionSelect` was out of sync and used in a mixed manner:
- The state value was not set on mount (so it was being ignored)
- The state was being in one place and the prop value in another (causing the sync issue)
- The corresponding test while existing it was incomplete and so giving false positive

Also in the SplitButton toggler from Droplist, moved the classname from props to be applied to the root instead of the actual toggler button as it is a little more intuitive (you can target the toggler button with its own classname 'SplitButton__Toggler`)