### PR TITLE
Avoid setting state on unmounted Tooltip component

### DIFF
--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useState } from 'react'
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import PropTypes from 'prop-types'
 import Tippy from '@tippyjs/react/headless'
 import { isFunction } from '../../utilities/is'
@@ -66,6 +72,13 @@ const Tooltip = props => {
   const { zIndex = zIndexProp, animationDuration: animationDurationContext } =
     useContext(TooltipContext) || {}
   const [isEntered, setEntered] = useState(animationDuration === 0)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
 
   const scope = getCurrentScope ? getCurrentScope() : null
 
@@ -121,7 +134,11 @@ const Tooltip = props => {
   }
 
   const onShow = () => {
-    setTimeout(() => setEntered(true), animationDelay)
+    setTimeout(() => {
+      if (isMounted.current) {
+        setEntered(true)
+      }
+    }, animationDelay)
   }
 
   const onHide = () => {

--- a/src/components/Tooltip/Tooltip.test.js
+++ b/src/components/Tooltip/Tooltip.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import Tooltip, { TooltipContext } from './index'
 import Tippy from '@tippyjs/react/headless'
+import { act } from 'react-dom/test-utils'
 
 jest.mock('@tippyjs/react/headless', () => {
   const Tippy = ({ children }) => <div>{children}</div>
@@ -116,7 +117,7 @@ describe('Tippy', () => {
     expect(pop.zIndex).toBe(1243)
   })
 
-  test.only("Controlled component should'nt pass down trigger and showOnCreate props ", () => {
+  test("Controlled component should'nt pass down trigger and showOnCreate props ", () => {
     const props = {
       placement: 'bottom',
       triggerOn: 'click',
@@ -142,5 +143,25 @@ describe('Context', () => {
     )
     const pop = wrapper.find(Tippy).props()
     expect(pop.zIndex).toBe(1234)
+  })
+})
+
+describe('Unmounting', () => {
+  test('Should not log warning when unmounting', () => {
+    jest.useFakeTimers()
+    const consoleErrorSpy = jest.spyOn(console, 'error')
+    const props = {
+      title: 'Pop',
+    }
+    const wrapper = mount(<Tooltip {...props} />)
+    const onShow = wrapper.find(Tippy).prop('onShow')
+    onShow()
+
+    wrapper.unmount()
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
# Problem/Feature

In Tooltip component, there's `onShow` function that calls `setTimeout` with setting state inside. In most situations it works fine, but in case of ConditionField component, there's a tooltip used on `Remove` button. If you click it fast enough (before animation duration passed), then the component would be unmounted, but it would still try to set state after timeout, which results in a console warning about setting state on unmounted component, like this:
![Screenshot from 2021-06-15 11-03-44](https://user-images.githubusercontent.com/1765264/122025540-b5f84780-cdc9-11eb-840e-edf3005cd223.png)

The solution is to save flag saying that component is mounted and do not set the state when this flag is false.

No new story has been added, but it can be checked on `Condition` story. Click `Remove` button next to `Specific URL` condition. It has to be done fast, before the tooltip has a chance to be displayed - just hovering over the button and immediately clicking it would be enough.

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
