### PR TITLE
[Bug] Fixes EditableFields bugs when blurring the inputs

### DIFF
--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -732,6 +732,7 @@ The `toggler` prop accepts any React component, so you can provide your own cust
         items={regularItems}
         toggler={
           <SelectTag
+            disabled={boolean('disabled', false)}
             onClick={() => {
               console.log('Clicked from story')
             }}

--- a/src/components/DropList/DropList.togglers.css.js
+++ b/src/components/DropList/DropList.togglers.css.js
@@ -78,6 +78,11 @@ export const SelectUI = styled('button')`
     outline: 0;
     box-shadow: inset 0 0 0 2px ${getColor('blue.500')};
   }
+
+  &[disabled] {
+    cursor: not-allowed;
+    color: ${getColor('charcoal.200')};
+  }
 `
 
 export const SelectArrowsUI = styled('div')`

--- a/src/components/EditableField/EditableField.Input.jsx
+++ b/src/components/EditableField/EditableField.Input.jsx
@@ -156,6 +156,9 @@ export class EditableFieldInput extends React.Component {
 
   handleInputBlur = event => {
     const { name, onInputBlur, valueOptions } = this.props
+    // Lots of async stuff happening that need this event as is
+    // so allow references to it to be maintained
+    event && event.persist && event.persist()
 
     if (valueOptions) {
       setTimeout(() => {

--- a/src/components/EditableField/EditableField.jsx
+++ b/src/components/EditableField/EditableField.jsx
@@ -285,7 +285,10 @@ export class EditableField extends React.Component {
       return
     }
 
-    const optionChanged = initialField.option !== changedField.option
+    let optionChanged =
+      hasOptions && initialField
+        ? initialField.option !== changedField.option
+        : false
 
     if (!changedField.validated || optionChanged) {
       this.setState({


### PR DESCRIPTION
## Problem

Reported: Not committing email addresses when clicking away from email field if there is already 2+ emails attached

The issue happened on multiple value EditableFields, when more than one value alreaady present, adding a new one and then blurring would break.

![Multiple Values Before](https://p-zkF42X.t2.n0.cdn.getcloudapp.com/items/Kou4d9lp/c685fd07-202c-4eee-a374-3714ed521de0.gif)

While looking into it I found a similar but cause by different reasons bug in the multiple value with options fields, again blurring was broken:

![With options before](https://p-zkF42X.t2.n0.cdn.getcloudapp.com/items/GGuWQ76o/e42610b7-3920-42cf-86e7-256964d378d3.gif?v=e62d8778006adc8c21a78bd4f01ddcbd)


## Solution

- Check if the EditableFields is a multiple option field, and put a guard if not.
- Persist the `Event` coming from blur

![Multiple Values after](https://p-zkF42X.t2.n0.cdn.getcloudapp.com/items/E0uAYX9R/f7fa91e0-6e2d-4ef5-971c-fdb84ec1b844.gif?v=15c40071a11f83682d5684f69015892d)

![With options after](https://p-zkF42X.t2.n0.cdn.getcloudapp.com/items/mXurpD18/bdf6751d-b51e-47af-9ef7-eff6db30f59b.gif?v=3c77ecb34509cbc449cf7ed6c5d35bf8)