### PR TITLE
[Fix] DropList tweaks

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -18,7 +18,7 @@ import {
   MenuListUI,
 } from './DropList.css'
 import ListItem, { generateListItemKey } from './DropList.ListItem'
-import { VARIANTS } from './DropList.constants'
+import { DROPLIST_MENULIST, VARIANTS } from './DropList.constants'
 
 function Combobox({
   closeOnBlur = true,
@@ -165,7 +165,10 @@ function Combobox({
           placeholder="Search"
         />
       </InputSearchHolderUI>
-      <MenuListUI className="MenuList MenuList-Combobox" {...getMenuProps()}>
+      <MenuListUI
+        className={`${DROPLIST_MENULIST} MenuList-Combobox`}
+        {...getMenuProps()}
+      >
         {renderListContents({
           customEmptyList,
           emptyList: items.length === 0,

--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -156,6 +156,7 @@ function Combobox({
       <InputSearchHolderUI show={items.length > 0}>
         <input
           {...getInputProps({
+            className: 'DropList__Combobox__input',
             ref: inputEl,
             onFocus: e => {
               onMenuFocus(e)

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -13,7 +13,7 @@ import {
 } from './DropList.downshift.common'
 import { A11yTogglerUI, DropListWrapperUI, MenuListUI } from './DropList.css'
 import ListItem, { generateListItemKey } from './DropList.ListItem'
-import { VARIANTS } from './DropList.constants'
+import { DROPLIST_MENULIST, VARIANTS } from './DropList.constants'
 
 function Select({
   closeOnBlur = true,
@@ -144,7 +144,7 @@ function Select({
     >
       <A11yTogglerUI {...getToggleButtonProps()}>Toggler</A11yTogglerUI>
       <MenuListUI
-        className="DropList__MenuList"
+        className={`${DROPLIST_MENULIST} MenuList-Select`}
         {...getMenuProps({
           onKeyDown: handleSidewaysKeyNavigation,
           onFocus: e => {

--- a/src/components/DropList/DropList.constants.js
+++ b/src/components/DropList/DropList.constants.js
@@ -10,7 +10,8 @@ export const ITEM_TYPES = {
 }
 
 export const OPEN_ACTION_ORIGIN = {
-  INPUT_BLUR: '__input_blur__',
+  DROPLIST_BLUR: '__droplist_blur__',
 }
 
 export const DROPLIST_TOGGLER = 'DropListToggler'
+export const DROPLIST_MENULIST = 'DropList__MenuList MenuList'

--- a/src/components/DropList/DropList.constants.js
+++ b/src/components/DropList/DropList.constants.js
@@ -12,3 +12,5 @@ export const ITEM_TYPES = {
 export const OPEN_ACTION_ORIGIN = {
   INPUT_BLUR: '__input_blur__',
 }
+
+export const DROPLIST_TOGGLER = 'DropListToggler'

--- a/src/components/DropList/DropList.downshift.common.js
+++ b/src/components/DropList/DropList.downshift.common.js
@@ -74,15 +74,18 @@ export function stateReducerCommon({
 
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputKeyDownArrowUp}`:
     case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownArrowUp}`: {
+      const { highlightedIndex: currentHighlightedIndex } = state
       const { highlightedIndex: nextHighlightedIndex } = changes
+      const highlightedIndex = getEnabledItemIndex({
+        currentHighlightedIndex,
+        nextHighlightedIndex,
+        items,
+        arrowKey: 'UP',
+      })
 
       return {
         ...changes,
-        highlightedIndex: getEnabledItemIndex({
-          nextHighlightedIndex,
-          items,
-          arrowKey: 'UP',
-        }),
+        highlightedIndex,
       }
     }
 
@@ -94,8 +97,8 @@ export function stateReducerCommon({
       return {
         ...changes,
         highlightedIndex: getEnabledItemIndex({
-          nextHighlightedIndex,
           currentHighlightedIndex,
+          nextHighlightedIndex,
           items,
           arrowKey: 'DOWN',
         }),

--- a/src/components/DropList/DropList.downshift.common.js
+++ b/src/components/DropList/DropList.downshift.common.js
@@ -130,7 +130,7 @@ export function onIsOpenChangeCommon({
 
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputBlur}`:
     case `${SELECT}.${useSelect.stateChangeTypes.MenuBlur}`:
-      closeOnBlur && toggleOpenedState(false, OPEN_ACTION_ORIGIN.INPUT_BLUR)
+      closeOnBlur && toggleOpenedState(false, OPEN_ACTION_ORIGIN.DROPLIST_BLUR)
       break
 
     default:

--- a/src/components/DropList/DropList.downshift.common.js
+++ b/src/components/DropList/DropList.downshift.common.js
@@ -76,23 +76,22 @@ export function stateReducerCommon({
     case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownArrowUp}`: {
       const { highlightedIndex: currentHighlightedIndex } = state
       const { highlightedIndex: nextHighlightedIndex } = changes
-      const highlightedIndex = getEnabledItemIndex({
-        currentHighlightedIndex,
-        nextHighlightedIndex,
-        items,
-        arrowKey: 'UP',
-      })
 
       return {
         ...changes,
-        highlightedIndex,
+        highlightedIndex: getEnabledItemIndex({
+          currentHighlightedIndex,
+          nextHighlightedIndex,
+          items,
+          arrowKey: 'UP',
+        }),
       }
     }
 
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputKeyDownArrowDown}`:
     case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownArrowDown}`: {
-      const { highlightedIndex: currentHighlightedIndex } = state
       const { highlightedIndex: nextHighlightedIndex } = changes
+      const { highlightedIndex: currentHighlightedIndex } = state
 
       return {
         ...changes,

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -1,10 +1,15 @@
 import React, { useContext, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import useDeepCompareEffect from 'use-deep-compare-effect'
+import classNames from 'classnames'
 import Tippy from '@tippyjs/react/headless'
 import { noop } from '../../utilities/other'
 import { GlobalContext } from '../HSDS/Provider'
-import { OPEN_ACTION_ORIGIN, VARIANTS } from './DropList.constants'
+import {
+  DROPLIST_TOGGLER,
+  OPEN_ACTION_ORIGIN,
+  VARIANTS,
+} from './DropList.constants'
 import {
   findItemInArray,
   flattenListItems,
@@ -99,8 +104,20 @@ function DropListManager({
 
   function decorateUserToggler(userToggler) {
     if (React.isValidElement(userToggler)) {
-      const { onClick } = userToggler.props
+      const { onClick, onKeyDown, className } = userToggler.props
       const togglerProps = {
+        className: classNames(DROPLIST_TOGGLER, className),
+        isActive: isOpen,
+
+        onKeyDown: e => {
+          onKeyDown && onKeyDown(e)
+
+          if (e.key === 'Enter') {
+            e.preventDefault && e.preventDefault()
+            toggleOpenedState(!isOpen)
+          }
+        },
+
         onClick: e => {
           onClick && onClick(e)
 
@@ -115,7 +132,6 @@ function DropListManager({
 
           setOpenOrigin('')
         },
-        isActive: isOpen,
       }
 
       if (userToggler.type === SelectTag) {

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -104,33 +104,35 @@ function DropListManager({
 
   function decorateUserToggler(userToggler) {
     if (React.isValidElement(userToggler)) {
-      const { onClick, onKeyDown, className } = userToggler.props
+      const { onClick, onFocus, className } = userToggler.props
       const togglerProps = {
         className: classNames(DROPLIST_TOGGLER, className),
         isActive: isOpen,
-
-        onKeyDown: e => {
-          onKeyDown && onKeyDown(e)
-
-          if (e.key === 'Enter') {
-            e.preventDefault && e.preventDefault()
-            toggleOpenedState(!isOpen)
-          }
-        },
 
         onClick: e => {
           onClick && onClick(e)
 
           /**
-           * On combobox when clicking the button a blur event happens first that closes
+           * When clicking the button the menu blur event happens first that closes
            * the DropList, here we check if the menu was closed due to the input blur and ignore the
            * click action to toggle the open state, we also always reset the "origin" to resume normal behaviour
            */
-          if (openOrigin !== OPEN_ACTION_ORIGIN.INPUT_BLUR) {
-            toggleOpenedState(!isOpen)
+          if (openOrigin !== OPEN_ACTION_ORIGIN.DROPLIST_BLUR) {
+            toggleOpenedState(!isOpen, '')
+          } else {
+            setOpenOrigin('')
           }
+        },
 
-          setOpenOrigin('')
+        onFocus: e => {
+          onFocus && onFocus(e)
+
+          /**
+           * Reset the "origin" to resume normal behaviour
+           */
+          if (!isOpen) {
+            setOpenOrigin('')
+          }
         },
       }
 
@@ -208,10 +210,10 @@ function DropListManager({
     }
   }
 
-  function toggleOpenedState(isOpen, origin = '') {
-    setOpenedState(isOpen)
+  function toggleOpenedState(shouldOpen, origin = '') {
     setOpenOrigin(origin)
-    onOpenedStateChange(isOpen)
+    setOpenedState(shouldOpen)
+    onOpenedStateChange(shouldOpen)
   }
 
   return (

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -1332,18 +1332,28 @@ describe('getEnabledItemIndex', () => {
     ).toBe(0)
     expect(
       getEnabledItemIndex({
-        nextHighlightedIndex: 1,
-        items: someItems,
-        arrowKey: 'UP',
-      })
-    ).toBe(1)
-    expect(
-      getEnabledItemIndex({
+        currentHighlightedIndex: 0,
         nextHighlightedIndex: 0,
         items: someItems,
         arrowKey: 'UP',
       })
     ).toBe(6)
+    expect(
+      getEnabledItemIndex({
+        currentHighlightedIndex: 1,
+        nextHighlightedIndex: 0,
+        items: someItems,
+        arrowKey: 'UP',
+      })
+    ).toBe(0)
+    expect(
+      getEnabledItemIndex({
+        currentHighlightedIndex: 5,
+        nextHighlightedIndex: 4,
+        items: someItems,
+        arrowKey: 'UP',
+      })
+    ).toBe(4)
   })
 
   test('Grouped and divider Items', () => {
@@ -1364,43 +1374,46 @@ describe('getEnabledItemIndex', () => {
         items,
         arrowKey: 'DOWN',
       })
-    ).toBe(3)
+    ).toBe(4)
     expect(
       getEnabledItemIndex({
-        currentHighlightedIndex: 6,
-        nextHighlightedIndex: 7,
+        currentHighlightedIndex: 5,
+        nextHighlightedIndex: 6,
         items,
         arrowKey: 'DOWN',
       })
-    ).toBe(9)
+    ).toBe(8)
     expect(
       getEnabledItemIndex({
-        currentHighlightedIndex: 13,
-        nextHighlightedIndex: 13,
+        currentHighlightedIndex: 9,
+        nextHighlightedIndex: 10,
         items,
         arrowKey: 'DOWN',
       })
     ).toBe(1)
     expect(
       getEnabledItemIndex({
-        nextHighlightedIndex: 8,
+        currentHighlightedIndex: 5,
+        nextHighlightedIndex: 4,
         items,
         arrowKey: 'UP',
       })
-    ).toBe(6)
+    ).toBe(4)
     expect(
       getEnabledItemIndex({
-        nextHighlightedIndex: 7,
+        currentHighlightedIndex: 4,
+        nextHighlightedIndex: 3,
         items,
         arrowKey: 'UP',
       })
-    ).toBe(6)
+    ).toBe(2)
     expect(
       getEnabledItemIndex({
+        currentHighlightedIndex: 1,
         nextHighlightedIndex: 0,
         items,
         arrowKey: 'UP',
       })
-    ).toBe(13)
+    ).toBe(9)
   })
 })

--- a/src/components/DropList/DropList.togglers.jsx
+++ b/src/components/DropList/DropList.togglers.jsx
@@ -38,7 +38,6 @@ export const SimpleButton = forwardRef(
         buttonRef={ref}
         className={classNames(
           className,
-          'DropListToggler',
           'ButtonToggler',
           isActive && 'is-active'
         )}
@@ -80,7 +79,6 @@ export const NavLink = forwardRef(
         ref={ref}
         className={classNames(
           className,
-          'DropListToggler',
           'NavLinkToggler',
           isActive && 'is-active'
         )}
@@ -116,11 +114,7 @@ export const SplittedButton = forwardRef(
   ) => {
     return (
       <ControlGroup
-        className={classNames(
-          className,
-          'DropListToggler',
-          'SplitButtonTogglerControlGroup'
-        )}
+        className={classNames(className, 'SplitButtonTogglerControlGroup')}
         data-cy="DropList.SplitButtonTogglerControlGroup"
         {...rest}
       >
@@ -145,7 +139,6 @@ export const SplittedButton = forwardRef(
             aria-expanded={isActive}
             buttonRef={ref}
             className={classNames(
-              'DropListToggler',
               'SplitButton__Toggler',
               isActive && 'is-active'
             )}
@@ -208,7 +201,7 @@ export const SelectTag = forwardRef(
         aria-expanded={isActive}
         className={classNames(
           className,
-          'DropListToggler SelectTagToggler',
+          'SelectTagToggler',
           error && 'is-error',
           isActive && 'is-active'
         )}
@@ -255,7 +248,6 @@ export const Kebab = forwardRef(
         aria-expanded={isActive}
         className={classNames(
           className,
-          'DropListToggler',
           'KebabToggler',
           isActive && 'is-active'
         )}
@@ -292,6 +284,7 @@ export const IconBtn = forwardRef(
     {
       a11yLabel = '',
       caretSize = '14',
+      className = '',
       isActive = false,
       iconName = 'assign',
       iconSize = '24',
@@ -308,7 +301,7 @@ export const IconBtn = forwardRef(
         aria-haspopup="true"
         aria-expanded={isActive}
         className={classNames(
-          'DropListToggler',
+          className,
           'IconButtonToggler',
           isActive && 'is-active'
         )}

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -201,64 +201,36 @@ export function getEnabledItemIndex({
 }) {
   let enabledItemIndex = 0
 
-  if (arrowKey === 'UP') {
-    for (let index = items.length - 1; index >= 0; index--) {
-      const isIndexItemHighlightable =
-        !checkIfGroupOrDividerItem(items[index]) && !items[index].isDisabled
-      const isNextIndexItemHighlightable =
-        items[nextHighlightedIndex] &&
-        !checkIfGroupOrDividerItem(items[nextHighlightedIndex]) &&
-        !items[nextHighlightedIndex].isDisabled
+  const isNextIndexItemHighlightable =
+    !checkIfGroupOrDividerItem(items[nextHighlightedIndex]) &&
+    !items[nextHighlightedIndex].isDisabled
 
-      if (
-        isIndexItemHighlightable &&
-        (index <= nextHighlightedIndex ||
-          currentHighlightedIndex === nextHighlightedIndex)
-      ) {
-        enabledItemIndex = index
-        break
-      } else if (isIndexItemHighlightable && nextHighlightedIndex === 0) {
-        if (isNextIndexItemHighlightable) {
-          enabledItemIndex = nextHighlightedIndex
-          break
-        }
+  if (
+    isNextIndexItemHighlightable &&
+    currentHighlightedIndex !== nextHighlightedIndex
+  ) {
+    enabledItemIndex = nextHighlightedIndex
+  } else {
+    let newNextHighlightedIndex
 
-        enabledItemIndex = index
-        break
-      }
-    }
-  }
-
-  if (arrowKey === 'DOWN') {
-    if (currentHighlightedIndex === nextHighlightedIndex) {
-      return getEnabledItemIndex({
-        currentHighlightedIndex,
-        nextHighlightedIndex: 0,
-        items,
-        arrowKey,
-      })
+    if (arrowKey === 'UP') {
+      newNextHighlightedIndex =
+        nextHighlightedIndex - 1 >= 0
+          ? nextHighlightedIndex - 1
+          : items.length - 1
+    } else {
+      newNextHighlightedIndex =
+        nextHighlightedIndex + 1 <= items.length - 1
+          ? nextHighlightedIndex + 1
+          : 0
     }
 
-    for (let index = 0; index < items.length; index++) {
-      const isGroupOrDividerItem = checkIfGroupOrDividerItem(items[index])
-      const isHighlightableItem =
-        !isGroupOrDividerItem && !items[index].isDisabled
-
-      if (isHighlightableItem && index >= nextHighlightedIndex) {
-        enabledItemIndex = index
-        break
-      } else {
-        if (!isHighlightableItem && nextHighlightedIndex === items.length - 1) {
-          // Go to the top but restart the process in case index 0 should be skipped
-          return getEnabledItemIndex({
-            currentHighlightedIndex,
-            nextHighlightedIndex: 0,
-            items,
-            arrowKey,
-          })
-        }
-      }
-    }
+    return getEnabledItemIndex({
+      currentHighlightedIndex,
+      nextHighlightedIndex: newNextHighlightedIndex,
+      items,
+      arrowKey,
+    })
   }
 
   return enabledItemIndex

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -199,8 +199,6 @@ export function getEnabledItemIndex({
   items,
   arrowKey,
 }) {
-  let enabledItemIndex = 0
-
   const isNextIndexItemHighlightable =
     !checkIfGroupOrDividerItem(items[nextHighlightedIndex]) &&
     !items[nextHighlightedIndex].isDisabled
@@ -209,29 +207,31 @@ export function getEnabledItemIndex({
     isNextIndexItemHighlightable &&
     currentHighlightedIndex !== nextHighlightedIndex
   ) {
-    enabledItemIndex = nextHighlightedIndex
-  } else {
-    let newNextHighlightedIndex
-
-    if (arrowKey === 'UP') {
-      newNextHighlightedIndex =
-        nextHighlightedIndex - 1 >= 0
-          ? nextHighlightedIndex - 1
-          : items.length - 1
-    } else {
-      newNextHighlightedIndex =
-        nextHighlightedIndex + 1 <= items.length - 1
-          ? nextHighlightedIndex + 1
-          : 0
-    }
-
-    return getEnabledItemIndex({
-      currentHighlightedIndex,
-      nextHighlightedIndex: newNextHighlightedIndex,
-      items,
-      arrowKey,
-    })
+    return nextHighlightedIndex
   }
 
-  return enabledItemIndex
+  let newNextHighlightedIndex
+  const firstIndex = 0
+  const lastIndex = items.length - 1
+
+  if (arrowKey === 'UP') {
+    const isNextIndexAfterFirst = nextHighlightedIndex - 1 >= firstIndex
+
+    newNextHighlightedIndex = isNextIndexAfterFirst
+      ? nextHighlightedIndex - 1
+      : lastIndex
+  } else {
+    const isNextIndexBeforeLast = nextHighlightedIndex + 1 <= lastIndex
+
+    newNextHighlightedIndex = isNextIndexBeforeLast
+      ? nextHighlightedIndex + 1
+      : firstIndex
+  }
+
+  return getEnabledItemIndex({
+    currentHighlightedIndex,
+    nextHighlightedIndex: newNextHighlightedIndex,
+    items,
+    arrowKey,
+  })
 }

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -203,13 +203,26 @@ export function getEnabledItemIndex({
 
   if (arrowKey === 'UP') {
     for (let index = items.length - 1; index >= 0; index--) {
-      const isGroupOrDividerItem = checkIfGroupOrDividerItem(items[index])
+      const isIndexItemHighlightable =
+        !checkIfGroupOrDividerItem(items[index]) && !items[index].isDisabled
+      const isNextIndexItemHighlightable =
+        items[nextHighlightedIndex] &&
+        !checkIfGroupOrDividerItem(items[nextHighlightedIndex]) &&
+        !items[nextHighlightedIndex].isDisabled
 
       if (
-        !isGroupOrDividerItem &&
-        !items[index].isDisabled &&
-        (nextHighlightedIndex === 0 || index <= nextHighlightedIndex)
+        isIndexItemHighlightable &&
+        (index <= nextHighlightedIndex ||
+          currentHighlightedIndex === nextHighlightedIndex)
       ) {
+        enabledItemIndex = index
+        break
+      } else if (isIndexItemHighlightable && nextHighlightedIndex === 0) {
+        if (isNextIndexItemHighlightable) {
+          enabledItemIndex = nextHighlightedIndex
+          break
+        }
+
         enabledItemIndex = index
         break
       }
@@ -228,14 +241,22 @@ export function getEnabledItemIndex({
 
     for (let index = 0; index < items.length; index++) {
       const isGroupOrDividerItem = checkIfGroupOrDividerItem(items[index])
+      const isHighlightableItem =
+        !isGroupOrDividerItem && !items[index].isDisabled
 
-      if (
-        !isGroupOrDividerItem &&
-        !items[index].isDisabled &&
-        index >= nextHighlightedIndex
-      ) {
+      if (isHighlightableItem && index >= nextHighlightedIndex) {
         enabledItemIndex = index
         break
+      } else {
+        if (!isHighlightableItem && nextHighlightedIndex === items.length - 1) {
+          // Go to the top but restart the process in case index 0 should be skipped
+          return getEnabledItemIndex({
+            currentHighlightedIndex,
+            nextHighlightedIndex: 0,
+            items,
+            arrowKey,
+          })
+        }
       }
     }
   }

--- a/src/components/EditableField/EditableField.Input.jsx
+++ b/src/components/EditableField/EditableField.Input.jsx
@@ -50,7 +50,6 @@ const Toggler = forwardRef(
         aria-label="toggle menu"
         aria-haspopup="true"
         aria-expanded={isActive}
-        className={INPUT_CLASSNAMES.optionsTrigger}
         data-cy="EditableFieldOptionsTrigger"
         disabled={disabled}
         onClick={onClick}
@@ -249,6 +248,7 @@ export class EditableFieldInput extends React.Component {
           onOpenedStateChange={this.handleOpenCloseDropList}
           toggler={
             <Toggler
+              className={INPUT_CLASSNAMES.optionsTrigger}
               disabled={disabled}
               fieldValue={fieldValue}
               onFocus={this.handleOptionFocus}

--- a/src/components/EmojiPicker/EmojiPicker.Toggler.jsx
+++ b/src/components/EmojiPicker/EmojiPicker.Toggler.jsx
@@ -10,7 +10,6 @@ export const IconToggler = forwardRef(
         aria-label="toggle menu"
         aria-haspopup="true"
         aria-expanded={isActive}
-        className="c-EmojiPickerToggler"
         data-cy="EmojiPickerToggler"
         data-testid="EmojiPickerToggler"
         isActive={isActive}

--- a/src/components/EmojiPicker/EmojiPicker.jsx
+++ b/src/components/EmojiPicker/EmojiPicker.jsx
@@ -16,7 +16,9 @@ export function EmojiPicker({
   items = emojiSet,
   onTogglerClick = noop,
   tippyOptions = { placement: 'top-start' },
-  toggler = <IconToggler onClick={onTogglerClick} />,
+  toggler = (
+    <IconToggler className="c-EmojiPickerToggler" onClick={onTogglerClick} />
+  ),
   ...rest
 }) {
   return (

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -32,6 +32,7 @@ const portalOptions = {
   zIndex: modalBaseZIndex,
   preventEscActionElements: [
     'DropList__MenuList',
+    'DropList__Combobox__input',
     'FieldInput__input',
     'EditableTextarea__Textarea',
   ],

--- a/src/components/Modal/Modal.stories.mdx
+++ b/src/components/Modal/Modal.stories.mdx
@@ -1,8 +1,11 @@
 import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs/blocks'
 import { select, text, boolean, number, array } from '@storybook/addon-knobs'
 import SpeechBubble from '@helpscout/hsds-illos/speech-bubble'
-import Modal from './'
 import { PHONE_OPTIONS } from '../EditableField/EditableField.storiesHelpers'
+import { regularItems } from '../../utilities/specs/dropdown.specs'
+import Modal from './'
+import DropList from '../DropList'
+import { SimpleButton } from '../DropList/DropList.togglers'
 import EditableTextarea from '../EditableTextarea'
 import EditableField from '../EditableField'
 
@@ -175,6 +178,19 @@ There are components like `DropList`, `EditableField` and `EditableTextarea` tha
     >
       <Modal.Body version={2}>
         <div>
+          <DropList
+            variant="combobox"
+            items={regularItems}
+            toggler={<SimpleButton text="DropList combobox" />}
+          />
+          <br />
+          <br />
+          <DropList
+            items={regularItems}
+            toggler={<SimpleButton text="DropList select" />}
+          />
+          <br />
+          <br />
           <EditableTextarea />
           <EditableField
             label="Phone"

--- a/src/utilities/specs/dropdown.specs.js
+++ b/src/utilities/specs/dropdown.specs.js
@@ -2,8 +2,8 @@ import { createSpec, faker } from '@helpscout/helix'
 
 export const ItemSpec = createSpec({
   id: faker.datatype.uuid(),
-  label: faker.company.companyName(),
-  value: faker.name.firstName(),
+  value: faker.company.companyName(),
+  label: faker.name.firstName(),
   // onClick: () => (value, props) => console.log('Clicked!', value),
 })
 
@@ -52,7 +52,16 @@ export const simpleGroupedItems = [
 
 export const groupAndDividerItems = [
   {
-    items: ItemSpec.generate(3),
+    items: [
+      {
+        label: '0001',
+        value: '0001',
+      },
+      {
+        label: '0002',
+        value: '0002',
+      },
+    ],
     label: 'Group 1',
     value: 'thing',
     type: 'group',
@@ -60,12 +69,33 @@ export const groupAndDividerItems = [
   {
     type: 'divider',
   },
-  ...ItemSpec.generate(2),
+  {
+    label: '0004',
+    value: '0004',
+  },
+  {
+    label: '0005',
+    value: '0005',
+  },
   {
     type: 'divider',
   },
   {
-    items: ItemSpec.generate(5),
+    items: [
+      {
+        label: '0008',
+        value: '0008',
+      },
+      {
+        label: '0009',
+        value: '0009',
+      },
+      {
+        label: '0010 is disabled',
+        value: '0010',
+        isDisabled: true,
+      },
+    ],
     label: 'Group 2',
     type: 'group',
     value: 'thing2',


### PR DESCRIPTION
# Problem/Feature

1. When a DropList lives inside a Modal, pressing ESC should only close the DropList  and not the Modal, this was already handled for the Select variant, here we add the Combobox variant to the list
2. Reported by @plbabin:
> So if I tab to the trigger press enter then tab again, the dropdown closed. That’s fine, but then I need to press enter twice to get it to open once again
so the sequence I did:
tab (trigger is focused ) + enter (opened)+ tab (closed, trigger is focused) + enter (nothing happened) + enter (opened) 

That was happening due to some complex event sequences, here we add a keyDown handler besides the onClick handler to deal with them separately.
3. DropList  togglers now will get the `DropListToggler` classname applied to them automatically and merge the user toggler classname from props.
4. In some scenarios using up/down arrows was still haveing some issues, sometimes skipping an item or making it "un-highlightable" with the keyboard, here we simplify the logic of `getEnabledItemIndex` significantly to fix these issues.

Try it in the stories, specially the most complex one that includes groups, dividers and disabled items: http://localhost:8900/iframe.html?id=components-dropdowns-droplist--items-groups-and-dividers&args=&viewMode=story, going up and down should highlight items skipping disabled items, group labels and dividers.

