### PR TITLE
Updated babel's preset-env loose mode to reduce component bundle size

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -48,7 +48,7 @@ module.exports = api => {
             safari: '12',
             node: '12.16.3',
           },
-          loose: false,
+          loose: true,
           shippedProposals: true,
         },
       ],


### PR DESCRIPTION
# Problem/Feature

While working on some performance improvements on the Beacon embed-side, we discovered that version v3.12.0 of hsds-react increased our overall bundle size by about 10% for no apparent reason. After some investigation, we found out that changing the `@babel/preset-env` `loose` setting to false, caused built assets to include a bit more code than before, adding some extra functions and variables during build time.

I don't think this `loose` setting has any impact on functionality, so this should be a pretty low-risk change. Also, I didn't change the setting in the Babel config used by Storybook because it didn't seem to have an effect, and leaving it as `true` gets rid of some warnings caused by Storybook plugins.
