### PR TITLE
More DropList tweaks

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -161,6 +161,12 @@ function Combobox({
             onFocus: e => {
               onMenuFocus(e)
             },
+            onKeyDown: e => {
+              if (e.key === 'Tab') {
+                e.preventDefault()
+                toggleOpenedState(false)
+              }
+            },
           })}
           placeholder="Search"
         />

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -338,7 +338,7 @@ DropListManager.propTypes = {
   ]),
   /** Options to configure Tippy (https://atomiks.github.io/tippyjs/v6/all-props/)*/
   tippyOptions: PropTypes.object,
-  /** A component to render as the "toggler" or "trigger", a set of built-in options are provided: Button, IconButton, Kebab, SelectTag, SplitButton */
+  /** A component to render as the "toggler" or "trigger", a set of built-in options are provided: Button, IconButton, MeatButton, SelectTag, SplitButton */
   toggler: PropTypes.element,
   /** The type of DropList, standard ("select") or searchable ("combobox") */
   variant: PropTypes.oneOf(['select', 'Select', 'combobox', 'Combobox']),

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -668,9 +668,11 @@ The `toggler` prop accepts any React component, so you can provide your own cust
         items={regularItems}
         toggler={
           <MeatButton
+            a11yLabel="Nice Kebab"
             onClick={() => {
               console.log('Clicked from story')
             }}
+            withTooltip
           />
         }
       />
@@ -688,10 +690,12 @@ The `toggler` prop accepts any React component, so you can provide your own cust
         items={regularItems}
         toggler={
           <MeatButton
+            a11yLabel="Nice Meatballs"
             meatIcon="meatball"
             onClick={() => {
               console.log('Clicked from story')
             }}
+            withTooltip
           />
         }
       />

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -3,7 +3,7 @@ import { boolean, number, text, select } from '@storybook/addon-knobs'
 import DropList from './DropList'
 import {
   IconBtn,
-  Kebab,
+  MeatButton,
   NavLink,
   SelectTag,
   SimpleButton,
@@ -567,12 +567,12 @@ Depending on your use case, you might want to set `closeOnSelection = false` whe
 
 ### Togglers
 
-DropList provides a set of ready-to-use "triggers" or "togglers" components that should cover most if not all of our current needs: `SimpleButton`, `IconBtn`, `Kebab`, `SelectTag` and `SplittedButton`. Import them into your project from `src/components/DropList/DropList.togglers.jsx` and feed them to the `toggler` prop.
+DropList provides a set of ready-to-use "triggers" or "togglers" components that should cover most if not all of our current needs: `SimpleButton`, `IconBtn`, `MeatButton` (meatball or kebab), `SelectTag` and `SplittedButton`. Import them into your project from `src/components/DropList/DropList.togglers.jsx` and feed them to the `toggler` prop.
 
 #### SplittedButton
 
 This toggler replaces the previous `SplittedButton` component. It's not very different from the other togglers except that it's composed of 2 HSDS Buttons, the "action" and the "toggler". The props to interact / customize them are:
-DropList provides a set of ready-to-use "triggers" or "togglers" components that should cover most if not all of our current needs: `SimpleButton`, `IconBtn`, `Kebab`, `SelectTag` and `SplittedButton`. Import them into your project from `src/components/DropList/DropList.togglers.jsx` and feed them to the `toggler` prop.
+DropList provides a set of ready-to-use "triggers" or "togglers" components that should cover most if not all of our current needs: `SimpleButton`, `IconBtn`, `MeatButton`, `SelectTag` and `SplittedButton`. Import them into your project from `src/components/DropList/DropList.togglers.jsx` and feed them to the `toggler` prop.
 
 ```
 {
@@ -654,7 +654,7 @@ The `toggler` prop accepts any React component, so you can provide your own cust
       />
     </div>
   </Story>
-  <Story name="Toggler: Kebab">
+  <Story name="Toggler: MeatButton">
     <div
       style={{
         width: '400px',
@@ -667,7 +667,28 @@ The `toggler` prop accepts any React component, so you can provide your own cust
       <DropList
         items={regularItems}
         toggler={
-          <Kebab
+          <MeatButton
+            onClick={() => {
+              console.log('Clicked from story')
+            }}
+          />
+        }
+      />
+    </div>
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 0 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        items={regularItems}
+        toggler={
+          <MeatButton
+            meatIcon="meatball"
             onClick={() => {
               console.log('Clicked from story')
             }}

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -1308,6 +1308,14 @@ describe('getEnabledItemIndex', () => {
   test('Regular Items', () => {
     expect(
       getEnabledItemIndex({
+        currentHighlightedIndex: 0,
+        nextHighlightedIndex: -1,
+        items: someItems,
+        arrowKey: 'DOWN',
+      })
+    ).toBe(-1)
+    expect(
+      getEnabledItemIndex({
         currentHighlightedIndex: -1,
         nextHighlightedIndex: 0,
         items: someItems,
@@ -1354,6 +1362,14 @@ describe('getEnabledItemIndex', () => {
         arrowKey: 'UP',
       })
     ).toBe(4)
+    expect(
+      getEnabledItemIndex({
+        currentHighlightedIndex: 0,
+        nextHighlightedIndex: -1,
+        items: someItems,
+        arrowKey: 'UP',
+      })
+    ).toBe(-1)
   })
 
   test('Grouped and divider Items', () => {

--- a/src/components/DropList/DropList.togglers.css.js
+++ b/src/components/DropList/DropList.togglers.css.js
@@ -115,13 +115,13 @@ export const SelectErrorTooltipIconUI = styled('div')`
   margin-left: 8px;
 `
 
-export const KebabUI = styled('button')`
+export const MeatButtonUI = styled('button')`
   width: 24px;
   height: 24px;
   padding: 0.5px 0px 0px 0.5px;
   border: 0;
   border-radius: 3px;
-  background-color: white;
+  background-color: transparent;
 
   &:hover {
     cursor: pointer;

--- a/src/components/DropList/DropList.togglers.jsx
+++ b/src/components/DropList/DropList.togglers.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { useRef, forwardRef } from 'react'
 import { classNames } from '../../utilities/classNames'
 import { noop } from '../../utilities/other'
 import ControlGroup from '../ControlGroup'
@@ -242,6 +242,8 @@ export const MeatButton = forwardRef(
     },
     ref
   ) => {
+    const tooltipRef = useRef()
+
     return (
       <MeatButtonUI
         aria-label="toggle menu"
@@ -264,8 +266,14 @@ export const MeatButton = forwardRef(
           <Tooltip
             animationDelay={0}
             animationDuration={0}
+            getTippyInstance={instance => {
+              tooltipRef.current = instance.reference
+            }}
             placement="top-end"
             title={a11yLabel}
+            triggerTarget={
+              tooltipRef.current && tooltipRef.current.parentElement
+            }
           >
             <Icon name={meatIcon} size={iconSize} />
           </Tooltip>
@@ -296,6 +304,8 @@ export const IconBtn = forwardRef(
     },
     ref
   ) => {
+    const tooltipRef = useRef()
+
     return (
       <IconButtonUI
         aria-label="toggle menu"
@@ -318,8 +328,14 @@ export const IconBtn = forwardRef(
           <Tooltip
             animationDelay={0}
             animationDuration={0}
+            getTippyInstance={instance => {
+              tooltipRef.current = instance.reference
+            }}
             placement="top-end"
             title={a11yLabel}
+            triggerTarget={
+              tooltipRef.current && tooltipRef.current.parentElement
+            }
           >
             <Icon name={iconName} size={iconSize} />
           </Tooltip>

--- a/src/components/DropList/DropList.togglers.jsx
+++ b/src/components/DropList/DropList.togglers.jsx
@@ -9,7 +9,7 @@ import { STATES } from '../../constants'
 import Tooltip from '../Tooltip'
 import {
   IconButtonUI,
-  KebabUI,
+  MeatButtonUI,
   NavLinkTogglerUI,
   SelectArrowsUI,
   SelectErrorTooltipIconUI,
@@ -228,13 +228,14 @@ export const SelectTag = forwardRef(
 
 // No need to test every single toggler if they're basically the same as Button
 /* istanbul ignore next */
-export const Kebab = forwardRef(
+export const MeatButton = forwardRef(
   (
     {
       a11yLabel = '',
       className = '',
       isActive = false,
       iconSize = '24',
+      meatIcon = 'kebab',
       onClick = noop,
       withTooltip = false,
       ...rest
@@ -242,17 +243,17 @@ export const Kebab = forwardRef(
     ref
   ) => {
     return (
-      <KebabUI
+      <MeatButtonUI
         aria-label="toggle menu"
         aria-haspopup="true"
         aria-expanded={isActive}
         className={classNames(
           className,
-          'KebabToggler',
+          'MeatButtonToggler',
           isActive && 'is-active'
         )}
-        data-cy="DropList.KebabToggler"
-        data-testid="DropList.KebabToggler"
+        data-cy="DropList.MeatButtonToggler"
+        data-testid="DropList.MeatButtonToggler"
         isActive={isActive}
         onClick={onClick}
         ref={ref}
@@ -266,13 +267,13 @@ export const Kebab = forwardRef(
             placement="top-end"
             title={a11yLabel}
           >
-            <Icon name="kebab" size={iconSize} />
+            <Icon name={meatIcon} size={iconSize} />
           </Tooltip>
         ) : (
-          <Icon name="kebab" size={iconSize} />
+          <Icon name={meatIcon} size={iconSize} />
         )}
         {a11yLabel ? <VisuallyHidden>{a11yLabel}</VisuallyHidden> : null}
-      </KebabUI>
+      </MeatButtonUI>
     )
   }
 )
@@ -349,7 +350,7 @@ export function getTogglerPlacementProps(toggler, { placement, offset }) {
     }
   }
 
-  if (toggler.type === Kebab) {
+  if (toggler.type === MeatButton) {
     return {
       placement: placement || 'bottom-end',
       offset: offset || [0, 3],

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -199,6 +199,10 @@ export function getEnabledItemIndex({
   items,
   arrowKey,
 }) {
+  // When nextHighlightedIndex === -1 it means there are no items to be highlighted
+  // like in the case of a combobox being filtered to "no results"
+  if (nextHighlightedIndex === -1) return -1
+
   const isNextIndexItemHighlightable =
     !checkIfGroupOrDividerItem(items[nextHighlightedIndex]) &&
     !items[nextHighlightedIndex].isDisabled

--- a/src/components/Tooltip/Tooltip.css.js
+++ b/src/components/Tooltip/Tooltip.css.js
@@ -8,6 +8,10 @@ export const config = {
 
 export const TooltipTriggerUI = styled.span`
   display: ${({ display }) => (display ? display : 'inline-block')};
+
+  &:focus {
+    outline: 0;
+  }
 `
 
 export const ArrowUI = styled.span`

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -54,6 +54,7 @@ const Tooltip = props => {
     closeOnEscPress,
     display,
     'data-cy': dataCy,
+    getTippyInstance = () => {},
     innerRef,
     isOpen,
     minWidth,
@@ -141,6 +142,10 @@ const Tooltip = props => {
     }, animationDelay)
   }
 
+  const onCreate = instance => {
+    getTippyInstance && getTippyInstance(instance)
+  }
+
   const onHide = () => {
     setEntered(false)
   }
@@ -161,6 +166,7 @@ const Tooltip = props => {
   }
 
   const defaultTippyProps = {
+    onCreate,
     onHide,
     onShow,
     placement,
@@ -244,6 +250,7 @@ Tooltip.propTypes = {
   'data-cy': PropTypes.string,
   /** Apply custom css rule `display` */
   display: PropTypes.string,
+  getTippyInstance: PropTypes.any,
   /** Determine if the tooltip is open via a prop */
   isOpen: PropTypes.bool,
   /** Max width for the component. */


### PR DESCRIPTION
# Problem/Feature

- In Chrome, when using a combobox, tabbing out of the input would take the focus all the way to the window chrome for some reason, so we prevent the default event on tabbing and do the action manually.
- Moving up/down on combobox when all items were filtered out (no results state) would throw an error and break everything
- "KebabButton" has been turned into "MeatButton" to allow having a "kebab" or a "meatball" button which are essentially the same.
- IconBtn and MeatBtn with tooltip enabled has been improved (to avoid tabbing into the actual tooltip trigger)
- A new Tooltip prop has been added `getTippyInstance` returns the Tippy instance