### PR TITLE
[DropList] Fix crash when a divider item type is present and you type a character

### DIFF
--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -47,8 +47,11 @@ export function isTogglerOfType(toggler, type) {
 
 export function itemToString(item) {
   if (item == null || checkIfGroupOrDividerItem(item)) return ''
+  // Items can be simple strings
   if (isString(item)) return item
+
   if (isObject(item)) {
+    // Object items should have 'label' or 'value', obtain which one is used per item
     const itemContentKeyName = getItemContentKeyName(item)
 
     return itemContentKeyName ? item[itemContentKeyName] : ''

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { isDefined, isObject } from '../../utilities/is'
+import { isDefined, isObject, isString } from '../../utilities/is'
 import { ITEM_TYPES } from './DropList.constants'
 import { SelectTag } from './DropList.togglers'
 import { ListItemUI, EmptyListUI } from './DropList.css'
@@ -47,8 +47,14 @@ export function isTogglerOfType(toggler, type) {
 
 export function itemToString(item) {
   if (item == null || checkIfGroupOrDividerItem(item)) return ''
-  if (isObject(item)) return item[getItemContentKeyName(item)]
-  return item
+  if (isString(item)) return item
+  if (isObject(item)) {
+    const itemContentKeyName = getItemContentKeyName(item)
+
+    return itemContentKeyName ? item[itemContentKeyName] : ''
+  }
+
+  return ''
 }
 
 export function parseSelectionFromProps({ withMultipleSelection, selection }) {

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -46,7 +46,7 @@ export function isTogglerOfType(toggler, type) {
 }
 
 export function itemToString(item) {
-  if (item == null) return ''
+  if (item == null || checkIfGroupOrDividerItem(item)) return ''
   if (isObject(item)) return item[getItemContentKeyName(item)]
   return item
 }


### PR DESCRIPTION
# Problem

When a character key is pressed, downshift tries to scroll to an item that starts with that letter. If an item of type "divider" is present, tries to process it and crashes.

We add a guard here to stop downshift from processing items that are groups or dividers to prevent the crash