### PR TITLE
[DropList] Adds clearOnSelect ability

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -21,6 +21,7 @@ import ListItem, { generateListItemKey } from './DropList.ListItem'
 import { DROPLIST_MENULIST, VARIANTS } from './DropList.constants'
 
 function Combobox({
+  clearOnSelect = false,
   closeOnBlur = true,
   closeOnSelection = true,
   customEmptyList = null,
@@ -86,6 +87,11 @@ function Combobox({
       switch (type) {
         case useCombobox.stateChangeTypes.InputBlur:
           onMenuBlur()
+          break
+
+        case useCombobox.stateChangeTypes.InputKeyDownEnter:
+        case useCombobox.stateChangeTypes.ItemClick:
+          clearOnSelect && handleSelectedItemChange({ selectedItem: null })
           break
 
         default:

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -16,6 +16,7 @@ import ListItem, { generateListItemKey } from './DropList.ListItem'
 import { DROPLIST_MENULIST, VARIANTS } from './DropList.constants'
 
 function Select({
+  clearOnSelect = false,
   closeOnBlur = true,
   closeOnSelection = true,
   customEmptyList = null,
@@ -69,6 +70,12 @@ function Select({
       switch (type) {
         case useSelect.stateChangeTypes.MenuBlur:
           onMenuBlur()
+          break
+
+        case useSelect.stateChangeTypes.MenuKeyDownSpaceButton:
+        case useSelect.stateChangeTypes.MenuKeyDownEnter:
+        case useSelect.stateChangeTypes.ItemClick:
+          clearOnSelect && handleSelectedItemChange({ selectedItem: null })
           break
 
         default:

--- a/src/components/DropList/DropList.downshift.common.js
+++ b/src/components/DropList/DropList.downshift.common.js
@@ -36,6 +36,7 @@ export function stateReducerCommon({
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputKeyDownEnter}`:
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.ItemClick}`:
     case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownEnter}`:
+    case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownSpaceButton}`:
     case `${SELECT}.${useSelect.stateChangeTypes.ItemClick}`:
       if (withMultipleSelection) {
         const newState = {
@@ -118,6 +119,7 @@ export function onIsOpenChangeCommon({
   switch (type) {
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputKeyDownEnter}`:
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.ItemClick}`:
+    case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownSpaceButton}`:
     case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownEnter}`:
     case `${SELECT}.${useSelect.stateChangeTypes.ItemClick}`:
       closeOnSelection && toggleOpenedState(false)

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -33,6 +33,7 @@ import Select from './DropList.Select'
 function DropListManager({
   animateOptions = {},
   autoSetComboboxAt = 0,
+  clearOnSelect = false,
   closeOnBlur = true,
   closeOnClickOutside = true,
   closeOnSelection = true,
@@ -173,6 +174,11 @@ function DropListManager({
   }
 
   function handleSelectedItemChange({ selectedItem }) {
+    if (selectedItem == null) {
+      setSelectedItem(null)
+      return
+    }
+
     if (selectedItem.isDisabled) {
       return
     }
@@ -244,6 +250,7 @@ function DropListManager({
       render={() => (
         <Animate {...animateProps} in={isOpen}>
           <DropListVariant
+            clearOnSelect={clearOnSelect}
             closeOnBlur={closeOnBlur}
             closeOnSelection={closeOnSelection}
             customEmptyList={customEmptyList}
@@ -298,6 +305,8 @@ DropListManager.propTypes = {
   animateOptions: PropTypes.object,
   /** When the number of items is larger than this number, automatically set the variant to combobox */
   autoSetComboboxAt: PropTypes.number,
+  /** Clears selected item on select */
+  clearOnSelect: PropTypes.bool,
   /** Whether to close the DropList on blur (useful when debugging) */
   closeOnBlur: PropTypes.bool,
   /** Whether to close the DropList when clicking outside the droplist */

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -526,6 +526,30 @@ function renderCustomListItem({
   </Story>
 </Canvas>
 
+### Clear on Select
+
+Sometimes is useful to clear the selected item on select.
+
+<Canvas>
+  <Story name="Clear on select">
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        clearOnSelect
+        items={regularItems}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    </div>
+  </Story>
+</Canvas>
+
 ### Multiple selection
 
 Depending on your use case, you might want to set `closeOnSelection = false` when multiple selection is enabled.

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -543,6 +543,9 @@ Sometimes is useful to clear the selected item on select.
     >
       <DropList
         clearOnSelect
+        onSelect={selection => {
+          console.log('on select called with:', selection)
+        }}
         items={regularItems}
         toggler={<SimpleButton text="Button Toggler" />}
       />

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -796,6 +796,7 @@ describe('Selection', () => {
       expect(onSelectSpy).toHaveBeenCalledWith(itemToSelect, itemToSelect)
     })
   })
+
   test('should select an item when clicked (combobox string version)', async () => {
     const onSelectSpy = jest.fn()
     const { getByText } = render(
@@ -841,6 +842,91 @@ describe('Selection', () => {
       ).toBeTruthy()
       expect(onSelect).toHaveBeenCalledWith(itemToSelect, itemToSelect)
     })
+  })
+
+  test('should clear selection if clearOnSelect is enabled (select)', async () => {
+    const onSelectSpy = jest.fn()
+    const { getByRole, getByText } = render(
+      <DropList
+        clearOnSelect
+        onSelect={onSelectSpy}
+        items={someItems}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+
+    user.click(getByRole('button'))
+
+    const itemToSelect = someItems[3]
+
+    user.click(getByText(itemToSelect.label).parentElement)
+
+    await waitFor(() => {
+      // Item should not have the selected styles
+      expect(
+        getByText(itemToSelect.label).parentElement.classList.contains(
+          'is-selected'
+        )
+      ).toBeFalsy()
+
+      // Click it again
+      user.click(getByText(itemToSelect.label).parentElement)
+    })
+
+    // Again, item should not have the selected styles
+    expect(
+      getByText(itemToSelect.label).parentElement.classList.contains(
+        'is-selected'
+      )
+    ).toBeFalsy()
+
+    // On normal circumstances onSelect only gets called once
+    // if you select the same item, with clearOnSelect, it gets called
+    // every time (twice in this case)
+    expect(onSelectSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('should clear selection if clearOnSelect is enabled (combobox)', async () => {
+    const onSelectSpy = jest.fn()
+    const { getByRole, getByText } = render(
+      <DropList
+        variant="combobox"
+        clearOnSelect
+        onSelect={onSelectSpy}
+        items={someItems}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+
+    user.click(getByRole('button'))
+
+    const itemToSelect = someItems[3]
+
+    user.click(getByText(itemToSelect.label).parentElement)
+
+    await waitFor(() => {
+      // Item should not have the selected styles
+      expect(
+        getByText(itemToSelect.label).parentElement.classList.contains(
+          'is-selected'
+        )
+      ).toBeFalsy()
+
+      // Click it again
+      user.click(getByText(itemToSelect.label).parentElement)
+    })
+
+    // Again, item should not have the selected styles
+    expect(
+      getByText(itemToSelect.label).parentElement.classList.contains(
+        'is-selected'
+      )
+    ).toBeFalsy()
+
+    // On normal circumstances onSelect only gets called once
+    // if you select the same item, with clearOnSelect, it gets called
+    // every time (twice in this case)
+    expect(onSelectSpy).toHaveBeenCalledTimes(2)
   })
 
   test('should multi-select', async () => {


### PR DESCRIPTION
# Feature

Sometimes is useful to clear the selected item right after selecting it, for example a menu of actions that are performed on select (think of something like "attach file"), they shouldn't be shown as "selected" and you should be able to perform them again if wanted (normally a click on a selected item gets ignored if clicked again)