### PR TITLE
Allow ActionSelect component to be disabled and to provide ID

### DIFF
--- a/src/components/ActionSelect/ActionSelect.jsx
+++ b/src/components/ActionSelect/ActionSelect.jsx
@@ -128,6 +128,8 @@ export class ActionSelect extends React.PureComponent {
       onAnimationUpdate,
       onResize,
       shouldRefocusOnClose,
+      disabled,
+      id,
     } = this.props
     const { isOpen, resizeCount, selection } = this.state
 
@@ -144,7 +146,13 @@ export class ActionSelect extends React.PureComponent {
             items={items}
             onOpenedStateChange={this.handleOnOpenClose}
             onSelect={this.handleOnSelect}
-            toggler={<SelectTag text={getSelectTagText(selection, items)} />}
+            toggler={
+              <SelectTag
+                text={getSelectTagText(selection, items)}
+                disabled={disabled}
+                id={id}
+              />
+            }
             selection={selection}
           />
         </div>
@@ -220,6 +228,10 @@ ActionSelect.propTypes = {
   selectedItem: PropTypes.object,
   shouldRefocusOnClose: PropTypes.func,
   shouldScrollIntoView: PropTypes.func,
+  /** Indicates that ActionSelect is disabled */
+  disabled: PropTypes.bool,
+  /** Id of the trigger element */
+  id: PropTypes.string,
 }
 
 export default ActionSelect

--- a/src/components/ActionSelect/ActionSelect.test.js
+++ b/src/components/ActionSelect/ActionSelect.test.js
@@ -35,6 +35,26 @@ describe('DropList', () => {
     })
   })
 
+  test('Makes droplist toggler enabled by default', async () => {
+    const { getByRole } = render(<ActionSelect items={mockItems} />)
+
+    await waitFor(() => expect(getByRole('button')).not.toBeDisabled())
+  })
+
+  test('Makes droplist toggler disabled', async () => {
+    const { getByRole } = render(<ActionSelect items={mockItems} disabled />)
+
+    await waitFor(() => expect(getByRole('button')).toBeDisabled())
+  })
+
+  test('Provides ID to the toggler', async () => {
+    const { getByRole } = render(<ActionSelect items={mockItems} id="123" />)
+
+    await waitFor(() =>
+      expect(getByRole('button')).toHaveAttribute('id', '123')
+    )
+  })
+
   test('DropList Selection', async () => {
     const onSelectSpy = jest.fn()
     const { getByRole, getAllByRole, getByTestId } = render(


### PR DESCRIPTION
# Problem/Feature
This PR adds possibility to disable ActionSelect DropList component, by passing new `disabled` prop to the toggler.
Additionally, ID can be provided to the toggler as well. This would help with accessibility so that it's possible to associate label with the DropList component.

Those changes are necessary for the new Messages app and should not affect any other usage

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
