### PR TITLE
Adds onListItemSelectEvent prop to DropList

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -33,6 +33,7 @@ function Combobox({
   menuCSS,
   onMenuBlur = noop,
   onMenuFocus = noop,
+  onListItemSelectEvent = noop,
   handleSelectedItemChange = noop,
   renderCustomListItem = null,
   toggleOpenedState = noop,
@@ -140,6 +141,9 @@ function Combobox({
         item,
         index,
         onClick: event => {
+          event.persist()
+          onListItemSelectEvent({ listItemNode: event.target, event })
+
           if (item.isDisabled) {
             event.nativeEvent.preventDownshiftDefault = true
             return
@@ -164,13 +168,26 @@ function Combobox({
           {...getInputProps({
             className: 'DropList__Combobox__input',
             ref: inputEl,
-            onFocus: e => {
-              onMenuFocus(e)
+            onFocus: event => {
+              onMenuFocus(event)
             },
-            onKeyDown: e => {
-              if (e.key === 'Tab') {
-                e.preventDefault()
+            onKeyDown: event => {
+              if (event.key === 'Tab') {
+                event.preventDefault()
                 toggleOpenedState(false)
+              }
+              if (event.key === 'Enter') {
+                const droplistMenu =
+                  event.target.parentElement.nextElementSibling
+
+                // Since the event happens on the input and not the list item
+                // we look for the selected item and send it to onListItemSelectEvent as listItemNode
+                droplistMenu.querySelectorAll('.DropListItem').forEach(item => {
+                  if (item.classList.contains('is-highlighted')) {
+                    event.persist()
+                    onListItemSelectEvent({ listItemNode: item, event })
+                  }
+                })
               }
             },
           })}

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -28,6 +28,7 @@ function Select({
   menuCSS,
   onMenuBlur = noop,
   onMenuFocus = noop,
+  onListItemSelectEvent = noop,
   renderCustomListItem = null,
   selectedItem = null,
   selectedItems,
@@ -116,6 +117,9 @@ function Select({
         item,
         index,
         onClick: event => {
+          event.persist()
+          onListItemSelectEvent({ listItemNode: event.target, event })
+
           if (item.isDisabled) {
             event.nativeEvent.preventDownshiftDefault = true
             return
@@ -127,7 +131,7 @@ function Select({
     return <ListItem {...itemProps} />
   }
 
-  function handleSidewaysKeyNavigation(event) {
+  function handleMenuKeyDown(event) {
     if (enableLeftRightNavigation) {
       if (event.key === 'ArrowRight') {
         if (highlightedIndex !== items.length - 1) {
@@ -141,6 +145,17 @@ function Select({
         }
       }
     }
+
+    if (event.key === 'Enter' || event.key === 'Space') {
+      // Since the event happens on the Menu and not the list item
+      // we look for the selected item and send it to onListItemSelectEvent as listItemNode
+      event.target.querySelectorAll('.DropListItem').forEach(item => {
+        if (item.classList.contains('is-highlighted')) {
+          event.persist()
+          onListItemSelectEvent({ listItemNode: item, event })
+        }
+      })
+    }
   }
 
   return (
@@ -153,7 +168,7 @@ function Select({
       <MenuListUI
         className={`${DROPLIST_MENULIST} MenuList-Select`}
         {...getMenuProps({
-          onKeyDown: handleSidewaysKeyNavigation,
+          onKeyDown: handleMenuKeyDown,
           onFocus: e => {
             onMenuFocus(e)
           },

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -146,7 +146,7 @@ function Select({
       }
     }
 
-    if (event.key === 'Enter' || event.key === 'Space') {
+    if (event.key === 'Enter' || event.key === ' ') {
       // Since the event happens on the Menu and not the list item
       // we look for the selected item and send it to onListItemSelectEvent as listItemNode
       event.target.querySelectorAll('.DropListItem').forEach(item => {

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -46,6 +46,7 @@ function DropListManager({
   menuCSS,
   onMenuBlur = noop,
   onMenuFocus = noop,
+  onListItemSelectEvent = noop,
   onOpenedStateChange = noop,
   onSelect = noop,
   renderCustomListItem = null,
@@ -262,6 +263,7 @@ function DropListManager({
             menuCSS={menuCSS}
             onMenuBlur={onMenuBlur}
             onMenuFocus={onMenuFocus}
+            onListItemSelectEvent={onListItemSelectEvent}
             renderCustomListItem={renderCustomListItem}
             selectedItem={selectedItem}
             selectedItems={selectedItems}
@@ -333,6 +335,8 @@ DropListManager.propTypes = {
   onMenuBlur: PropTypes.func,
   /** Callback that fires when the menu gets focus */
   onMenuFocus: PropTypes.func,
+  /** Downshift does not provide the event on select, this callback fires when selecting an item (clicking, keydown enter (and space on Select variant)), gives you the DOM selected item as listItemNode and the original event */
+  onListItemSelectEvent: PropTypes.func,
   /** Callback that fires whenever the DropList opens and closes */
   onOpenedStateChange: PropTypes.func,
   /** Callback that fires whenever the selection in the DropList changes, signature: `onSelect(selection, clickedItem)` */

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -98,6 +98,29 @@ function onSelect(selection, clickedItem) {}
 
 <br />
 
+#### onListItemSelectEvent
+
+In downshift item selection other than click is not handled directly on the list item nodes, in Select the events are handled on the Menu and in Combobox they are handled from the input. Because of this there is no access to any list item "event" on selection.
+
+Most of the time you don't care _how_ the item was selected, but if you need to, you can use this callback where you'll find the `event` and get the `event.type`.
+
+For this we have added `onListItemSelectEvent` which fires on any selection event (click, keydown). This callback gives you access to the actual List Item DOM node that was selected, and the original event.
+
+The original click event will give you the actual list item, so `listItemNode === e.target`
+
+Notice that on keyboard events `e.target` will be either the Menu (Select variant) or the Input (Combobox variant)
+
+```js
+/**
+ *
+ * @param {object} event Original event
+ * @param {DOMNode} listItemNode The item that was selected
+ */
+function onListItemSelectEvent({ event, listItemNode }) {}
+```
+
+<br />
+
 ## Example
 
 <Canvas>
@@ -180,6 +203,10 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
     >
       <DropList
         isMenuOpen={boolean('Is Menu Open', false)}
+        onListItemSelectEvent={({ event, listItemNode }) => {
+          console.log('event', event)
+          console.log('listItemNode', listItemNode)
+        }}
         selection={select(
           'Selection',
           {

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -729,9 +729,11 @@ describe('Togglers', () => {
 describe('Selection', () => {
   test('should select an item when clicked (string version)', async () => {
     const onSelectSpy = jest.fn()
+    const onListItemSelectEventSpy = jest.fn()
     const { getByText, getByRole } = render(
       <DropList
         onSelect={onSelectSpy}
+        onListItemSelectEvent={onListItemSelectEventSpy}
         items={beatles}
         toggler={<SimpleButton text="Button Toggler" />}
       />
@@ -749,6 +751,12 @@ describe('Selection', () => {
         getByText('Paul').parentElement.classList.contains('is-selected')
       ).toBeTruthy()
       expect(onSelectSpy).toHaveBeenCalledWith('Paul', 'Paul')
+      expect(onListItemSelectEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'click' }),
+          listItemNode: getByText('Paul').parentElement,
+        })
+      )
       expect(toggler.getAttribute('aria-expanded')).toBe('false')
     })
 
@@ -775,10 +783,12 @@ describe('Selection', () => {
 
   test('should select an item when clicked (object version)', async () => {
     const onSelectSpy = jest.fn()
+    const onListItemSelectEventSpy = jest.fn()
     const { getByText } = render(
       <DropList
         isMenuOpen
         onSelect={onSelectSpy}
+        onListItemSelectEvent={onListItemSelectEventSpy}
         items={someItems}
         toggler={<SimpleButton text="Button Toggler" />}
       />
@@ -794,15 +804,23 @@ describe('Selection', () => {
         )
       ).toBeTruthy()
       expect(onSelectSpy).toHaveBeenCalledWith(itemToSelect, itemToSelect)
+      expect(onListItemSelectEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'click' }),
+          listItemNode: getByText(itemToSelect.label).parentElement,
+        })
+      )
     })
   })
 
   test('should select an item when clicked (combobox string version)', async () => {
     const onSelectSpy = jest.fn()
+    const onListItemSelectEventSpy = jest.fn()
     const { getByText } = render(
       <DropList
         isMenuOpen
         onSelect={onSelectSpy}
+        onListItemSelectEvent={onListItemSelectEventSpy}
         items={beatles}
         toggler={<SimpleButton text="Button Toggler" />}
         variant="combobox"
@@ -816,15 +834,23 @@ describe('Selection', () => {
         getByText('Paul').parentElement.classList.contains('is-selected')
       ).toBeTruthy()
       expect(onSelectSpy).toHaveBeenCalledWith('Paul', 'Paul')
+      expect(onListItemSelectEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'click' }),
+          listItemNode: getByText('Paul').parentElement,
+        })
+      )
     })
   })
 
   test('should select an item when clicked (combobox object version)', async () => {
     const onSelect = jest.fn()
+    const onListItemSelectEventSpy = jest.fn()
     const { getByText } = render(
       <DropList
         isMenuOpen
         onSelect={onSelect}
+        onListItemSelectEvent={onListItemSelectEventSpy}
         items={someItems}
         toggler={<SimpleButton text="Button Toggler" />}
         variant="combobox"
@@ -841,6 +867,12 @@ describe('Selection', () => {
         )
       ).toBeTruthy()
       expect(onSelect).toHaveBeenCalledWith(itemToSelect, itemToSelect)
+      expect(onListItemSelectEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'click' }),
+          listItemNode: getByText(itemToSelect.label).parentElement,
+        })
+      )
     })
   })
 

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -813,6 +813,74 @@ describe('Selection', () => {
     })
   })
 
+  test('should select an item when enter key pressed (object version)', async () => {
+    const onSelectSpy = jest.fn()
+    const onListItemSelectEventSpy = jest.fn()
+    const { container, getByText, getByRole } = render(
+      <DropList
+        onSelect={onSelectSpy}
+        onListItemSelectEvent={onListItemSelectEventSpy}
+        items={someItems}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+    const itemToSelect = someItems[1]
+
+    user.click(getByRole('button'))
+    user.type(container.querySelector('.MenuList'), '{arrowdown}')
+    user.type(container.querySelector('.MenuList'), '{arrowdown}')
+    user.type(container.querySelector('.MenuList'), '{enter}')
+
+    await waitFor(() => {
+      expect(
+        getByText(itemToSelect.label).parentElement.classList.contains(
+          'is-selected'
+        )
+      ).toBeTruthy()
+      expect(onSelectSpy).toHaveBeenCalledWith(itemToSelect, itemToSelect)
+      expect(onListItemSelectEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'keydown' }),
+          listItemNode: getByText(itemToSelect.label).parentElement,
+        })
+      )
+    })
+  })
+
+  test('should select an item when space key pressed (object version)', async () => {
+    const onSelectSpy = jest.fn()
+    const onListItemSelectEventSpy = jest.fn()
+    const { container, getByText, getByRole } = render(
+      <DropList
+        onSelect={onSelectSpy}
+        onListItemSelectEvent={onListItemSelectEventSpy}
+        items={someItems}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+    const itemToSelect = someItems[1]
+
+    user.click(getByRole('button'))
+    user.type(container.querySelector('.MenuList'), '{arrowdown}')
+    user.type(container.querySelector('.MenuList'), '{arrowdown}')
+    user.type(container.querySelector('.MenuList'), '{space}')
+
+    await waitFor(() => {
+      expect(
+        getByText(itemToSelect.label).parentElement.classList.contains(
+          'is-selected'
+        )
+      ).toBeTruthy()
+      expect(onSelectSpy).toHaveBeenCalledWith(itemToSelect, itemToSelect)
+      expect(onListItemSelectEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'keydown' }),
+          listItemNode: getByText(itemToSelect.label).parentElement,
+        })
+      )
+    })
+  })
+
   test('should select an item when clicked (combobox string version)', async () => {
     const onSelectSpy = jest.fn()
     const onListItemSelectEventSpy = jest.fn()
@@ -870,6 +938,41 @@ describe('Selection', () => {
       expect(onListItemSelectEventSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           event: expect.objectContaining({ type: 'click' }),
+          listItemNode: getByText(itemToSelect.label).parentElement,
+        })
+      )
+    })
+  })
+
+  test('should select an item when enter key pressed (combobox object version)', async () => {
+    const onSelectSpy = jest.fn()
+    const onListItemSelectEventSpy = jest.fn()
+    const { container, getByText, getByRole } = render(
+      <DropList
+        variant="combobox"
+        onSelect={onSelectSpy}
+        onListItemSelectEvent={onListItemSelectEventSpy}
+        items={someItems}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+    const itemToSelect = someItems[1]
+
+    user.click(getByRole('button'))
+    user.type(container.querySelector('input'), '{arrowdown}')
+    user.type(container.querySelector('input'), '{arrowdown}')
+    user.type(container.querySelector('input'), '{enter}')
+
+    await waitFor(() => {
+      expect(
+        getByText(itemToSelect.label).parentElement.classList.contains(
+          'is-selected'
+        )
+      ).toBeTruthy()
+      expect(onSelectSpy).toHaveBeenCalledWith(itemToSelect, itemToSelect)
+      expect(onListItemSelectEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({ type: 'keydown' }),
           listItemNode: getByText(itemToSelect.label).parentElement,
         })
       )


### PR DESCRIPTION
# Feature

> Copied from the addition I made to the docs for this feature:

### onListItemSelectEvent

In downshift item selection other than click is not handled directly on the list item nodes, in Select the events are handled on the Menu and in Combobox they are handled from the input. Because of this there is no access to any list item "event" on selection.

Most of the time you don't care _how_ the item was selected, but if you need to, you can use this callback where you'll find the `event` and get the `event.type`.

For this we have added `onListItemSelectEvent` which fires on any selection event (click, keydown). This callback gives you access to the actual List Item DOM node that was selected, and the original event.

The original click event will give you the actual list item, so `listItemNode === e.target`

Notice that on keyboard events `e.target` will be either the Menu (Select variant) or the Input (Combobox variant) and that is where `listItemNode` comes handy,

```js
/**
 *
 * @param {object} event Original event
 * @param {DOMNode} listItemNode The item that was selected
 */
function onListItemSelectEvent({ event, listItemNode }) {}
```