### PR TITLE
Fixes Droplist scrolling the document

### DIFF
--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -80,7 +80,9 @@ function DropListManager({
     unmountOnExit: false,
   }
   const tippyProps = {
+    trigger: 'click',
     ...tippyOptions,
+    // These shouldn't be overriden
     interactive: true,
   }
   const Toggler = decorateUserToggler(toggler)
@@ -226,7 +228,7 @@ function DropListManager({
   return (
     <Tippy
       {...tippyProps}
-      visible={isOpen}
+      showOnCreate={isOpen}
       onClickOutside={(instance, { target }) => {
         if (
           target.dataset.ignoreToggling &&


### PR DESCRIPTION
# Problem

@Charca reported: 
Whenever I open a dropdown, it scrolls me back to the top of the page. Any ideas why this might be happening? My usage of this component is quite simple:
```
<DropList
  items={messageOptions}
  toggler={
    <MessageOptionsButtonUI
      onClick={handleButtonClick}
      a11yLabel="Message options"
    />
  }
/>
```

https://c.hlp.sc/yAur5nZG

The issue is fixed by using `showOnCreate` instead of `visible` on the `<Tippy />` component. Don't ask me why though 😅 