### PR TITLE
DropList fix > manipulate tippy instance manually to show and hide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.17.1",
+  "version": "3.17.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19093,8 +19093,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.escape": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19093,7 +19093,8 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
     },
     "lodash.escape": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.17.2-0",
+  "version": "3.17.2-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.17.2-0",
+  "version": "3.17.2-1",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.17.1",
+  "version": "3.17.2-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "downshift": "^6.1.1",
     "fast-deep-equal": "^2.0.1",
     "invariant": "2.2.4",
+    "lodash.debounce": "^4.0.8",
     "path-to-regexp": "2.4.0",
     "prismjs": "^1.17.1",
     "react-frame-component": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "downshift": "^6.1.1",
     "fast-deep-equal": "^2.0.1",
     "invariant": "2.2.4",
-    "lodash.debounce": "^4.0.8",
     "path-to-regexp": "2.4.0",
     "prismjs": "^1.17.1",
     "react-frame-component": "4.1.1",

--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -36,6 +36,7 @@ function Combobox({
   onListItemSelectEvent = noop,
   handleSelectedItemChange = noop,
   renderCustomListItem = null,
+  setMenuBlurred,
   toggleOpenedState = noop,
   withMultipleSelection = false,
 }) {
@@ -168,6 +169,9 @@ function Combobox({
           {...getInputProps({
             className: 'DropList__Combobox__input',
             ref: inputEl,
+            onBlur: () => {
+              setMenuBlurred(true)
+            },
             onFocus: event => {
               onMenuFocus(event)
             },

--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -36,7 +36,6 @@ function Combobox({
   onListItemSelectEvent = noop,
   handleSelectedItemChange = noop,
   renderCustomListItem = null,
-  setMenuBlurred,
   toggleOpenedState = noop,
   withMultipleSelection = false,
 }) {
@@ -87,10 +86,6 @@ function Combobox({
 
     onStateChange({ type }) {
       switch (type) {
-        case useCombobox.stateChangeTypes.InputBlur:
-          onMenuBlur()
-          break
-
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
           clearOnSelect && handleSelectedItemChange({ selectedItem: null })
@@ -166,11 +161,12 @@ function Combobox({
     >
       <InputSearchHolderUI show={items.length > 0}>
         <input
+          data-event-driver
           {...getInputProps({
             className: 'DropList__Combobox__input',
             ref: inputEl,
             onBlur: () => {
-              setMenuBlurred(true)
+              onMenuBlur()
             },
             onFocus: event => {
               onMenuFocus(event)

--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -165,8 +165,8 @@ function Combobox({
           {...getInputProps({
             className: 'DropList__Combobox__input',
             ref: inputEl,
-            onBlur: () => {
-              onMenuBlur()
+            onBlur: e => {
+              onMenuBlur(e)
             },
             onFocus: event => {
               onMenuFocus(event)

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -33,7 +33,6 @@ function Select({
   selectedItem = null,
   selectedItems,
   toggleOpenedState = noop,
-  setMenuBlurred,
   withMultipleSelection = false,
 }) {
   const {
@@ -70,10 +69,6 @@ function Select({
 
     onStateChange({ type }) {
       switch (type) {
-        case useSelect.stateChangeTypes.MenuBlur:
-          onMenuBlur()
-          break
-
         case useSelect.stateChangeTypes.MenuKeyDownSpaceButton:
         case useSelect.stateChangeTypes.MenuKeyDownEnter:
         case useSelect.stateChangeTypes.ItemClick:
@@ -167,6 +162,7 @@ function Select({
     >
       <A11yTogglerUI {...getToggleButtonProps()}>Toggler</A11yTogglerUI>
       <MenuListUI
+        data-event-driver
         className={`${DROPLIST_MENULIST} MenuList-Select`}
         {...getMenuProps({
           onKeyDown: handleMenuKeyDown,
@@ -174,7 +170,7 @@ function Select({
             onMenuFocus(e)
           },
           onBlur: () => {
-            setMenuBlurred(true)
+            onMenuBlur()
           },
         })}
       >

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -58,7 +58,6 @@ function Select({
 
     onIsOpenChange(changes) {
       onIsOpenChangeCommon({
-        closeOnBlur,
         closeOnSelection,
         toggleOpenedState,
         type: `${VARIANTS.SELECT}.${changes.type}`,
@@ -169,7 +168,25 @@ function Select({
           onFocus: e => {
             onMenuFocus(e)
           },
-          onBlur: () => {
+          onBlur: e => {
+            /**
+             * Closing on blur
+             *
+             * When clicking on the toggler, this event gets fired _before_
+             * so it sets the isOpen flag to false, and then the click event happens
+             * and sets isOpen to true, making the DropList never close on cliking
+             * the toggler.
+             *
+             * Here we wait a little bit to see if the next element gathering focus
+             * is indeed the toggler, and only close the DropList if it isn't
+             */
+            setTimeout(() => {
+              if (
+                !document.activeElement.classList.contains('DropListToggler')
+              ) {
+                closeOnBlur && toggleOpenedState(false)
+              }
+            }, 100)
             onMenuBlur()
           },
         })}

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -33,6 +33,7 @@ function Select({
   selectedItem = null,
   selectedItems,
   toggleOpenedState = noop,
+  setMenuBlurred,
   withMultipleSelection = false,
 }) {
   const {
@@ -171,6 +172,9 @@ function Select({
           onKeyDown: handleMenuKeyDown,
           onFocus: e => {
             onMenuFocus(e)
+          },
+          onBlur: () => {
+            setMenuBlurred(true)
           },
         })}
       >

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -187,7 +187,7 @@ function Select({
                 ) {
                   toggleOpenedState(false)
                 }
-              }, 100)
+              }, 50)
             }
             onMenuBlur(e)
           },

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -169,25 +169,27 @@ function Select({
             onMenuFocus(e)
           },
           onBlur: e => {
-            /**
-             * Closing on blur
-             *
-             * When clicking on the toggler, this event gets fired _before_
-             * so it sets the isOpen flag to false, and then the click event happens
-             * and sets isOpen to true, making the DropList never close on cliking
-             * the toggler.
-             *
-             * Here we wait a little bit to see if the next element gathering focus
-             * is indeed the toggler, and only close the DropList if it isn't
-             */
-            setTimeout(() => {
-              if (
-                !document.activeElement.classList.contains('DropListToggler')
-              ) {
-                closeOnBlur && toggleOpenedState(false)
-              }
-            }, 100)
-            onMenuBlur()
+            if (closeOnBlur) {
+              /**
+               * Closing on blur
+               *
+               * When clicking on the toggler, this event gets fired _before_
+               * so it sets the isOpen flag to false, and then the click event happens
+               * and sets isOpen to true, making the DropList never close on cliking
+               * the toggler.
+               *
+               * Here we wait a little bit to see if the next element gathering focus
+               * is indeed the toggler, and only close the DropList if it isn't
+               */
+              setTimeout(() => {
+                if (
+                  !document.activeElement.classList.contains('DropListToggler')
+                ) {
+                  toggleOpenedState(false)
+                }
+              }, 100)
+            }
+            onMenuBlur(e)
           },
         })}
       >

--- a/src/components/DropList/DropList.config.js
+++ b/src/components/DropList/DropList.config.js
@@ -1,0 +1,21 @@
+export function getAnimateProps(userOptions) {
+  return {
+    duration: 200,
+    easing: 'ease-in-out',
+    sequence: 'fade down',
+    ...userOptions,
+    // These shouldn't be overriden
+    animateOnMount: true,
+    mountOnEnter: false,
+    unmountOnExit: false,
+  }
+}
+
+export function getTippyProps(userOptions) {
+  return {
+    trigger: 'manual',
+    ...userOptions,
+    // These shouldn't be overriden
+    interactive: true,
+  }
+}

--- a/src/components/DropList/DropList.constants.js
+++ b/src/components/DropList/DropList.constants.js
@@ -9,9 +9,5 @@ export const ITEM_TYPES = {
   GROUP_LABEL: 'group_label',
 }
 
-export const OPEN_ACTION_ORIGIN = {
-  DROPLIST_BLUR: '__droplist_blur__',
-}
-
 export const DROPLIST_TOGGLER = 'DropListToggler'
 export const DROPLIST_MENULIST = 'DropList__MenuList MenuList'

--- a/src/components/DropList/DropList.downshift.common.js
+++ b/src/components/DropList/DropList.downshift.common.js
@@ -5,7 +5,7 @@ import {
   getEnabledItemIndex,
   getItemContentKeyName,
 } from './DropList.utils'
-import { OPEN_ACTION_ORIGIN, VARIANTS } from './DropList.constants'
+import { VARIANTS } from './DropList.constants'
 
 const { SELECT, COMBOBOX } = VARIANTS
 
@@ -132,7 +132,7 @@ export function onIsOpenChangeCommon({
 
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputBlur}`:
     case `${SELECT}.${useSelect.stateChangeTypes.MenuBlur}`:
-      closeOnBlur && toggleOpenedState(false, OPEN_ACTION_ORIGIN.DROPLIST_BLUR)
+      closeOnBlur && toggleOpenedState(false)
       break
 
     default:

--- a/src/components/DropList/DropList.downshift.common.js
+++ b/src/components/DropList/DropList.downshift.common.js
@@ -111,7 +111,6 @@ export function stateReducerCommon({
 }
 
 export function onIsOpenChangeCommon({
-  closeOnBlur,
   closeOnSelection,
   toggleOpenedState,
   type,
@@ -128,11 +127,6 @@ export function onIsOpenChangeCommon({
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputKeyDownEscape}`:
     case `${SELECT}.${useSelect.stateChangeTypes.MenuKeyDownEscape}`:
       toggleOpenedState(false)
-      break
-
-    case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputBlur}`:
-    case `${SELECT}.${useSelect.stateChangeTypes.MenuBlur}`:
-      closeOnBlur && toggleOpenedState(false)
       break
 
     default:

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -89,6 +89,7 @@ function DropListManager({
   const Toggler = decorateUserToggler(toggler)
   const DropListVariant = getDropListVariant()
   const [tippyInstance, setTippyInstance] = useState(null)
+
   useWarnings({ toggler, withMultipleSelection, menuCSS, tippyOptions })
 
   useDeepCompareEffect(() => {

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -106,6 +106,10 @@ function DropListManager({
 
   useEffect(() => {
     setOpenedState(isMenuOpen)
+    toggleTippy(tippyInstance, isMenuOpen)
+
+    // We only care when isMenuOpen changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMenuOpen])
 
   function decorateUserToggler(userToggler) {
@@ -220,16 +224,21 @@ function DropListManager({
     }
   }
 
+  function toggleTippy(instance, visible) {
+    if (instance == null) return
+
+    if (visible) {
+      instance.show()
+    } else {
+      instance.hide()
+    }
+  }
+
   function toggleOpenedState(shouldOpen, origin = '') {
     setOpenOrigin(origin)
     setOpenedState(shouldOpen)
     onOpenedStateChange(shouldOpen)
-
-    if (tippyInstance && shouldOpen) {
-      tippyInstance.show()
-    } else {
-      tippyInstance.hide()
-    }
+    toggleTippy(tippyInstance, shouldOpen)
   }
 
   return (

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -41,6 +41,7 @@ function DropListManager({
   'data-cy': dataCy,
   enableLeftRightNavigation = false,
   focusTogglerOnMenuClose = true,
+  getTippyInstance = noop,
   isMenuOpen = false,
   items = [],
   menuCSS,
@@ -87,7 +88,7 @@ function DropListManager({
   }
   const Toggler = decorateUserToggler(toggler)
   const DropListVariant = getDropListVariant()
-
+  const [tippyInstance, setTippyInstance] = useState(null)
   useWarnings({ toggler, withMultipleSelection, menuCSS, tippyOptions })
 
   useDeepCompareEffect(() => {
@@ -115,7 +116,6 @@ function DropListManager({
 
         onClick: e => {
           onClick && onClick(e)
-
           /**
            * When clicking the button the menu blur event happens first that closes
            * the DropList, here we check if the menu was closed due to the input blur and ignore the
@@ -223,11 +223,21 @@ function DropListManager({
     setOpenOrigin(origin)
     setOpenedState(shouldOpen)
     onOpenedStateChange(shouldOpen)
+
+    if (tippyInstance && shouldOpen) {
+      tippyInstance.show()
+    } else {
+      tippyInstance.hide()
+    }
   }
 
   return (
     <Tippy
       {...tippyProps}
+      onCreate={instance => {
+        setTippyInstance(instance)
+        getTippyInstance(instance)
+      }}
       showOnCreate={isOpen}
       onClickOutside={(instance, { target }) => {
         if (
@@ -325,6 +335,8 @@ DropListManager.propTypes = {
   enableLeftRightNavigation: PropTypes.bool,
   /** Automatically moves the focus back to the toggler when the DropList is closed */
   focusTogglerOnMenuClose: PropTypes.bool,
+  /** Retrieves the tippy instance */
+  getTippyInstance: PropTypes.any,
   /** Open/close the DropList externally */
   isMenuOpen: PropTypes.bool,
   /** Items to populate the list with */

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -202,7 +202,7 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
       }}
     >
       <DropList
-        isMenuOpen={boolean('Is Menu Open', false)}
+        isMenuOpen={boolean('Is Menu Open', true)}
         onListItemSelectEvent={({ event, listItemNode }) => {
           console.log('event', event)
           console.log('listItemNode', listItemNode)
@@ -466,6 +466,7 @@ function renderCustomListItem({
         toggler={<SimpleButton text="Click" />}
         renderCustomListItem={({ item, isSelected }) => (
           <div
+            isMenuOpen={boolean('is menu open', true)}
             style={{
               padding: '5px 10px',
               fontSize: '14px',

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -221,64 +221,6 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
         toggler={<SimpleButton text="This is a select" />}
       />
     </div>
-    <div
-      style={{
-        width: '400px',
-        margin: '50px 100px 200px 150px',
-        border: '1px dashed silver',
-        borderRadius: '5px',
-        padding: '20px',
-      }}
-    >
-      <DropList
-        isMenuOpen={boolean('Is Menu Open', false)}
-        onListItemSelectEvent={({ event, listItemNode }) => {
-          console.log('event', event)
-          console.log('listItemNode', listItemNode)
-        }}
-        selection={select(
-          'Selection',
-          {
-            clear: null,
-            first: regularItems[0],
-            second: regularItems[1],
-            third: regularItems[2],
-          },
-          regularItems[1]
-        )}
-        items={regularItems}
-        toggler={<SimpleButton text="This is a select" />}
-      />
-    </div>
-    <div
-      style={{
-        width: '400px',
-        margin: '50px 100px 200px 150px',
-        border: '1px dashed silver',
-        borderRadius: '5px',
-        padding: '20px',
-      }}
-    >
-      <DropList
-        isMenuOpen={boolean('Is Menu Open', false)}
-        onListItemSelectEvent={({ event, listItemNode }) => {
-          console.log('event', event)
-          console.log('listItemNode', listItemNode)
-        }}
-        selection={select(
-          'Selection',
-          {
-            clear: null,
-            first: regularItems[0],
-            second: regularItems[1],
-            third: regularItems[2],
-          },
-          regularItems[1]
-        )}
-        items={regularItems}
-        toggler={<SimpleButton text="This is a select" />}
-      />
-    </div>
   </Story>
 </Canvas>
 

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -203,6 +203,9 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
     >
       <DropList
         isMenuOpen={boolean('Is Menu Open', false)}
+        onOpenedStateChange={isOpen => {
+          console.log('onOpenedStateChange', isOpen)
+        }}
         onListItemSelectEvent={({ event, listItemNode }) => {
           console.log('event', event)
           console.log('listItemNode', listItemNode)

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -221,6 +221,64 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
         toggler={<SimpleButton text="This is a select" />}
       />
     </div>
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        isMenuOpen={boolean('Is Menu Open', false)}
+        onListItemSelectEvent={({ event, listItemNode }) => {
+          console.log('event', event)
+          console.log('listItemNode', listItemNode)
+        }}
+        selection={select(
+          'Selection',
+          {
+            clear: null,
+            first: regularItems[0],
+            second: regularItems[1],
+            third: regularItems[2],
+          },
+          regularItems[1]
+        )}
+        items={regularItems}
+        toggler={<SimpleButton text="This is a select" />}
+      />
+    </div>
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        isMenuOpen={boolean('Is Menu Open', false)}
+        onListItemSelectEvent={({ event, listItemNode }) => {
+          console.log('event', event)
+          console.log('listItemNode', listItemNode)
+        }}
+        selection={select(
+          'Selection',
+          {
+            clear: null,
+            first: regularItems[0],
+            second: regularItems[1],
+            third: regularItems[2],
+          },
+          regularItems[1]
+        )}
+        items={regularItems}
+        toggler={<SimpleButton text="This is a select" />}
+      />
+    </div>
   </Story>
 </Canvas>
 
@@ -466,7 +524,12 @@ function renderCustomListItem({
         toggler={<SimpleButton text="Click" />}
         renderCustomListItem={({ item, isSelected }) => (
           <div
-            style={{ padding: '5px 10px', fontSize: '14px', color: '#404996' }}
+            style={{
+              padding: '5px 10px',
+              fontSize: '14px',
+              color: '#404996',
+              cursor: 'pointer',
+            }}
           >
             {isSelected ? (
               <strong style={{ color: 'white', backgroundColor: '#404996' }}>

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -202,7 +202,7 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
       }}
     >
       <DropList
-        isMenuOpen={boolean('Is Menu Open', true)}
+        isMenuOpen={boolean('Is Menu Open', false)}
         onListItemSelectEvent={({ event, listItemNode }) => {
           console.log('event', event)
           console.log('listItemNode', listItemNode)

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -56,6 +56,12 @@ describe('Render', () => {
         expect(queryByText(beatle)).toBeInTheDocument()
       })
     })
+
+    user.click(toggler)
+
+    await waitFor(() => {
+      expect(queryByRole('listbox')).not.toBeInTheDocument()
+    })
   })
 
   test('should render a menu list with string items', async () => {
@@ -77,6 +83,12 @@ describe('Render', () => {
       beatles.forEach(beatle => {
         expect(queryByText(beatle)).toBeInTheDocument()
       })
+    })
+
+    user.click(toggler)
+
+    await waitFor(() => {
+      expect(queryByRole('listbox')).not.toBeInTheDocument()
     })
   })
 
@@ -463,7 +475,7 @@ describe('Menu', () => {
       expect(focusSpy).toHaveBeenCalled()
     })
 
-    user.click(queryByText('Click'))
+    user.tab()
 
     await waitFor(() => {
       expect(blurSpy).toHaveBeenCalled()
@@ -488,7 +500,7 @@ describe('Menu', () => {
       expect(focusSpy).toHaveBeenCalled()
     })
 
-    user.click(queryByText('Click'))
+    user.tab()
 
     await waitFor(() => {
       expect(blurSpy).toHaveBeenCalled()
@@ -734,7 +746,9 @@ describe('Selection', () => {
 
     user.click(toggler)
 
-    expect(toggler.getAttribute('aria-expanded')).toBe('true')
+    await waitFor(() => {
+      expect(toggler.getAttribute('aria-expanded')).toBe('true')
+    })
 
     user.click(getByText('Paul').parentElement)
 
@@ -801,17 +815,17 @@ describe('Selection', () => {
   test('should select an item when enter key pressed (object version)', async () => {
     const onSelectSpy = jest.fn()
     const onListItemSelectEventSpy = jest.fn()
-    const { container, getByText, getByRole } = render(
+    const { container, getByText } = render(
       <DropList
         onSelect={onSelectSpy}
         onListItemSelectEvent={onListItemSelectEventSpy}
         items={someItems}
         toggler={<SimpleButton text="Button Toggler" />}
+        isMenuOpen
       />
     )
     const itemToSelect = someItems[1]
 
-    user.click(getByRole('button'))
     user.type(container.querySelector('.MenuList'), '{arrowdown}')
     user.type(container.querySelector('.MenuList'), '{arrowdown}')
     user.type(container.querySelector('.MenuList'), '{enter}')
@@ -835,17 +849,17 @@ describe('Selection', () => {
   test('should select an item when space key pressed (object version)', async () => {
     const onSelectSpy = jest.fn()
     const onListItemSelectEventSpy = jest.fn()
-    const { container, getByText, getByRole } = render(
+    const { container, getByText } = render(
       <DropList
         onSelect={onSelectSpy}
         onListItemSelectEvent={onListItemSelectEventSpy}
         items={someItems}
         toggler={<SimpleButton text="Button Toggler" />}
+        isMenuOpen
       />
     )
     const itemToSelect = someItems[1]
 
-    user.click(getByRole('button'))
     user.type(container.querySelector('.MenuList'), '{arrowdown}')
     user.type(container.querySelector('.MenuList'), '{arrowdown}')
     user.type(container.querySelector('.MenuList'), '{space}')
@@ -932,18 +946,18 @@ describe('Selection', () => {
   test('should select an item when enter key pressed (combobox object version)', async () => {
     const onSelectSpy = jest.fn()
     const onListItemSelectEventSpy = jest.fn()
-    const { container, getByText, getByRole } = render(
+    const { container, getByText } = render(
       <DropList
         variant="combobox"
         onSelect={onSelectSpy}
         onListItemSelectEvent={onListItemSelectEventSpy}
         items={someItems}
         toggler={<SimpleButton text="Button Toggler" />}
+        isMenuOpen
       />
     )
     const itemToSelect = someItems[1]
 
-    user.click(getByRole('button'))
     user.type(container.querySelector('input'), '{arrowdown}')
     user.type(container.querySelector('input'), '{arrowdown}')
     user.type(container.querySelector('input'), '{enter}')
@@ -966,16 +980,15 @@ describe('Selection', () => {
 
   test('should clear selection if clearOnSelect is enabled (select)', async () => {
     const onSelectSpy = jest.fn()
-    const { getByRole, getByText } = render(
+    const { getByText } = render(
       <DropList
         clearOnSelect
         onSelect={onSelectSpy}
         items={someItems}
         toggler={<SimpleButton text="Button Toggler" />}
+        isMenuOpen
       />
     )
-
-    user.click(getByRole('button'))
 
     const itemToSelect = someItems[3]
 
@@ -1008,17 +1021,16 @@ describe('Selection', () => {
 
   test('should clear selection if clearOnSelect is enabled (combobox)', async () => {
     const onSelectSpy = jest.fn()
-    const { getByRole, getByText } = render(
+    const { getByText } = render(
       <DropList
         variant="combobox"
         clearOnSelect
         onSelect={onSelectSpy}
         items={someItems}
         toggler={<SimpleButton text="Button Toggler" />}
+        isMenuOpen
       />
     )
-
-    user.click(getByRole('button'))
 
     const itemToSelect = someItems[3]
 

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -37,13 +37,13 @@ describe('Render', () => {
   })
 
   test('should render a menu list with string items', async () => {
-    const { getByRole, queryByText, queryByRole } = render(
+    const { getByTestId, queryByText, queryByRole } = render(
       <DropList
         items={beatles}
         toggler={<SimpleButton text="Button Toggler" />}
       />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     expect(queryByRole('listbox')).not.toBeInTheDocument()
 
@@ -56,22 +56,38 @@ describe('Render', () => {
         expect(queryByText(beatle)).toBeInTheDocument()
       })
     })
+  })
+
+  test('should render a menu list with string items', async () => {
+    const { getByTestId, queryByText, queryByRole } = render(
+      <DropList
+        items={beatles}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+    const toggler = getByTestId('DropList.ButtonToggler')
+
+    expect(queryByRole('listbox')).not.toBeInTheDocument()
 
     user.click(toggler)
 
     await waitFor(() => {
-      expect(queryByRole('listbox')).not.toBeInTheDocument()
+      expect(queryByRole('listbox')).toBeInTheDocument()
+
+      beatles.forEach(beatle => {
+        expect(queryByText(beatle)).toBeInTheDocument()
+      })
     })
   })
 
   test('should render a menu list with object items that include a label', async () => {
-    const { getByRole, queryByText, queryByRole } = render(
+    const { getByTestId, queryByText, queryByRole } = render(
       <DropList
         items={someItems}
         toggler={<SimpleButton text="Button Toggler" />}
       />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     expect(queryByRole('listbox')).not.toBeInTheDocument()
 
@@ -84,25 +100,19 @@ describe('Render', () => {
         expect(queryByText(item.label)).toBeInTheDocument()
       })
     })
-
-    user.click(toggler)
-
-    await waitFor(() => {
-      expect(queryByRole('listbox')).not.toBeInTheDocument()
-    })
   })
 
   test('should render a menu list with object items that include a value and no label', async () => {
     const regularValueItems = someItems.map(item => {
       return { value: item.label }
     })
-    const { getByRole, queryByText, queryByRole } = render(
+    const { getByTestId, queryByText, queryByRole } = render(
       <DropList
         items={regularValueItems}
         toggler={<SimpleButton text="Button Toggler" />}
       />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     expect(queryByRole('listbox')).not.toBeInTheDocument()
 
@@ -115,16 +125,10 @@ describe('Render', () => {
         expect(queryByText(item.value)).toBeInTheDocument()
       })
     })
-
-    user.click(toggler)
-
-    await waitFor(() => {
-      expect(queryByRole('listbox')).not.toBeInTheDocument()
-    })
   })
 
   test('should add a classname to the list item if present in the item', async () => {
-    const { getByRole, queryByText } = render(
+    const { getByTestId, queryByText } = render(
       <DropList
         items={someItems.map((item, index) => {
           if (index === 1) {
@@ -135,7 +139,7 @@ describe('Render', () => {
         toggler={<SimpleButton text="Button Toggler" />}
       />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     user.click(toggler)
 
@@ -149,13 +153,13 @@ describe('Render', () => {
   })
 
   test('should render a menu list with dividers', async () => {
-    const { container, getByRole, queryByRole } = render(
+    const { container, getByTestId, queryByRole } = render(
       <DropList
         items={itemsWithDivider}
         toggler={<SimpleButton text="Button Toggler" />}
       />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     user.click(toggler)
 
@@ -166,13 +170,13 @@ describe('Render', () => {
   })
 
   test('should render a menu list with groups', async () => {
-    const { container, getByRole, queryByRole } = render(
+    const { container, getByTestId, queryByRole } = render(
       <DropList
         items={simpleGroupedItems}
         toggler={<SimpleButton text="Button Toggler" />}
       />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     user.click(toggler)
 
@@ -183,13 +187,13 @@ describe('Render', () => {
   })
 
   test('should render a menu list with groups and dividers', async () => {
-    const { container, getByRole, queryByRole } = render(
+    const { container, getByTestId, queryByRole } = render(
       <DropList
         items={groupAndDividerItems}
         toggler={<SimpleButton text="Button Toggler" />}
       />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     user.click(toggler)
 
@@ -201,10 +205,10 @@ describe('Render', () => {
   })
 
   test('should render an empty menu list if no items in the array', async () => {
-    const { getByRole, queryByText, queryByRole } = render(
+    const { getByTestId, queryByText, queryByRole } = render(
       <DropList items={[]} toggler={<SimpleButton text="Button Toggler" />} />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
     expect(toggler.getAttribute('aria-expanded')).toBe('false')
     expect(queryByRole('listbox')).not.toBeInTheDocument()
 
@@ -214,12 +218,6 @@ describe('Render', () => {
       expect(toggler.getAttribute('aria-expanded')).toBe('true')
       expect(queryByRole('listbox')).toBeInTheDocument()
       expect(queryByText('No items')).toBeInTheDocument()
-    })
-
-    user.click(toggler)
-
-    await waitFor(() => {
-      expect(queryByRole('listbox')).not.toBeInTheDocument()
     })
   })
 
@@ -602,13 +600,13 @@ describe('Combobox', () => {
 describe('Togglers', () => {
   test('Should run custom onclick callback', async () => {
     const onClick = jest.fn()
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <DropList
         items={[]}
         toggler={<SimpleButton onClick={onClick} text="Button Toggler" />}
       />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     user.click(toggler)
 
@@ -618,21 +616,15 @@ describe('Togglers', () => {
   })
 
   test('Should pass the open/closed state to the toggler', async () => {
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <DropList items={[]} toggler={<SimpleButton text="Button Toggler" />} />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     user.click(toggler)
 
     await waitFor(() => {
       expect(toggler.classList.contains('is-active')).toBeTruthy()
-    })
-
-    user.click(toggler)
-
-    await waitFor(() => {
-      expect(toggler.classList.contains('is-active')).toBeFalsy()
     })
   })
 
@@ -730,7 +722,7 @@ describe('Selection', () => {
   test('should select an item when clicked (string version)', async () => {
     const onSelectSpy = jest.fn()
     const onListItemSelectEventSpy = jest.fn()
-    const { getByText, getByRole } = render(
+    const { getByText, getByTestId } = render(
       <DropList
         onSelect={onSelectSpy}
         onListItemSelectEvent={onListItemSelectEventSpy}
@@ -738,7 +730,7 @@ describe('Selection', () => {
         toggler={<SimpleButton text="Button Toggler" />}
       />
     )
-    const toggler = getByRole('button')
+    const toggler = getByTestId('DropList.ButtonToggler')
 
     user.click(toggler)
 
@@ -760,14 +752,7 @@ describe('Selection', () => {
       expect(toggler.getAttribute('aria-expanded')).toBe('false')
     })
 
-    // click another one should deselect the previous and select new one
-    user.click(toggler)
-
-    await waitFor(() => {
-      expect(toggler.getAttribute('aria-expanded')).toBe('true')
-      user.click(getByText('Ringo').parentElement)
-      user.click(getByText('Ringo').parentElement)
-    })
+    user.click(getByText('Ringo').parentElement)
 
     await waitFor(() => {
       expect(

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -11,6 +11,8 @@ import {
   simpleGroupedItems,
 } from '../../utilities/specs/dropdown.specs'
 
+jest.useFakeTimers()
+
 const beatles = ['John', 'Paul', 'Ringo', 'George']
 const someItems = [
   { label: 'John' },

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -1,8 +1,21 @@
 import React, { useEffect } from 'react'
 import { isDefined, isObject, isString } from '../../utilities/is'
-import { ITEM_TYPES } from './DropList.constants'
+import { ITEM_TYPES, VARIANTS } from './DropList.constants'
 import { SelectTag } from './DropList.togglers'
 import { ListItemUI, EmptyListUI } from './DropList.css'
+import Combobox from './DropList.Combobox'
+import Select from './DropList.Select'
+
+export function getDropListVariant({
+  variant,
+  autoSetComboboxAt,
+  numberOfItems,
+}) {
+  return variant.toLowerCase() === VARIANTS.COMBOBOX ||
+    (autoSetComboboxAt > 0 && numberOfItems >= autoSetComboboxAt)
+    ? Combobox
+    : Select
+}
 
 // No need to test this helper
 /* istanbul ignore next */

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.17.2-0',
+  version: '3.17.2-1',
 }

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.17.1',
+  version: '3.17.2-0',
 }


### PR DESCRIPTION
# Problem

By removing the usage of `visible` here https://github.com/helpscout/hsds-react/pull/957, we have another problem that the tippy is not getting removed from the DOM in some instances (we are only making it invisible).

# Solution

Since `visible` is the only way react-tippy provides to [control the open/close state of the tippy](https://github.com/atomiks/tippyjs-react#visible-boolean-controlled-mode) (and we do want to control it) but continues to be buggy by scrolling the document we resort to manipulating the tippy instance instead.

While at it, I added a new prop `getTippyInstance` to retrieve the tippy instance in case you want to do stuff with it. This prop exists in Tooltip too so might aswell have it here too.