### PR TITLE
[Feature] AvatarList: Adds vertical stack option + Tooltip

### DIFF
--- a/src/components/Avatar/Avatar.css.js
+++ b/src/components/Avatar/Avatar.css.js
@@ -25,8 +25,8 @@ export const config = {
       fontSize: 13,
     },
     smmd: {
-      size: 35,
-      fontSize: 12,
+      size: 38,
+      fontSize: 15,
     },
     sm: {
       size: 30,
@@ -162,7 +162,7 @@ export const InitialsUI = styled('div')`
   user-select: none;
 
   &.is-light {
-    color: ${getColor('text.muted')};
+    color: ${getColor('charcoal.400')};
   }
 `
 
@@ -333,7 +333,7 @@ export const AvatarUI = styled('div')`
   ${props => getColorStyles(props)}
 
   &.is-light {
-    color: ${getColor('grey.400')};
+    color: ${getColor('grey.500')};
   }
 
   ${getSizeStyles()};
@@ -383,7 +383,7 @@ export const AvatarButtonUI = styled('button')`
   background: transparent;
 
   ${props => getColorStyles(props)} &.is-light {
-    color: ${getColor('grey.400')};
+    color: ${getColor('grey.500')};
   }
 
   ${getSizeStyles()};

--- a/src/components/Avatar/Avatar.css.js
+++ b/src/components/Avatar/Avatar.css.js
@@ -25,7 +25,7 @@ export const config = {
       fontSize: 13,
     },
     smmd: {
-      size: 38,
+      size: 35,
       fontSize: 15,
     },
     sm: {

--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
-import StatusDot from '../StatusDot'
-import Icon from '../Icon'
-import { getEasingTiming } from '../../utilities/easing'
 import classNames from 'classnames'
+import { getEasingTiming } from '../../utilities/easing'
 import { nameToInitials } from '../../utilities/strings'
 import { noop } from '../../utilities/other'
+import Icon from '../Icon'
+import StatusDot from '../StatusDot'
+import Tooltip from '../Tooltip'
 import AvatarCrop from './Avatar.Crop'
 import AvatarImage from './Avatar.Image'
 import { getImageSrc } from './Avatar.utils'
@@ -285,6 +286,7 @@ export class Avatar extends React.PureComponent {
       withShadow,
       fallbackImage,
       onActionClick,
+      tooltipProps,
       ...rest
     } = this.props
 
@@ -301,18 +303,16 @@ export class Avatar extends React.PureComponent {
       this.getShapeClassNames(),
       className
     )
-
     const Component = actionable ? AvatarButtonUI : AvatarUI
-
     const extraProps = actionable ? { onClick: onActionClick } : {}
-
-    return (
+    const withTooltip = Boolean(tooltipProps)
+    const AvatarComponent = (
       <Component
         {...getValidProps(rest)}
         data-cy="Avatar"
         className={componentClassName}
         style={this.getStyles()}
-        title={name}
+        title={!withTooltip ? name : null}
         {...extraProps}
       >
         {this.renderCrop()}
@@ -322,16 +322,26 @@ export class Avatar extends React.PureComponent {
         {actionable && this.renderFocusBorder()}
       </Component>
     )
+
+    return !withTooltip ? (
+      AvatarComponent
+    ) : (
+      <Tooltip withTriggerWrapper={false} {...tooltipProps}>
+        {AvatarComponent}
+      </Tooltip>
+    )
   }
 }
 
 const AvatarConsumer = props => {
   const contextValue = React.useContext(AvatarListContext)
+
   if (contextValue) {
     const newProps = { ...props, ...contextValue }
     newProps.className = classNames(props.className, contextValue.className)
     return <Avatar {...newProps} />
   }
+
   return <Avatar {...props} />
 }
 
@@ -359,6 +369,10 @@ Avatar.defaultProps = {
 }
 
 const avatarPropTypes = {
+  active: PropTypes.bool,
+  animation: PropTypes.bool,
+  animationDuration: PropTypes.number,
+  animationEasing: PropTypes.string,
   /** Activate the action overlay that will appear on hover */
   actionable: PropTypes.bool,
   /** Name of the [Icon](../Icon) to render into the action overlay */
@@ -371,6 +385,9 @@ const avatarPropTypes = {
   className: PropTypes.string,
   /** Used to display an additional avatar count. */
   count: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** Data attr for Cypress tests. */
+  'data-cy': PropTypes.string,
+  fallbackImage: PropTypes.string,
   /** URL of the image to display. */
   image: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   /** Custom initials to display. */
@@ -397,20 +414,15 @@ const avatarPropTypes = {
   showStatusBorderColor: PropTypes.bool,
   /** Size of the avatar. */
   size: PropTypes.oneOf(['xl', 'lg', 'md', 'smmd', 'sm', 'xs', 'xxs']),
-  /** Text for the image `alt` and `title` attributes. */
-  title: PropTypes.string,
   /** Renders a `StatusDot` with the status type. */
   status: PropTypes.string,
   /** Name of the `Icon` to render into the `StatusDot`. */
   statusIcon: PropTypes.string,
-  active: PropTypes.bool,
-  animation: PropTypes.bool,
-  animationDuration: PropTypes.number,
-  animationEasing: PropTypes.string,
-  fallbackImage: PropTypes.string,
+  /** Text for the image `alt` and `title` attributes. */
+  title: PropTypes.string,
+  /** Wrap the avatar with a Tooltip, accepts all Tooltip props */
+  tooltipProps: PropTypes.object,
   withShadow: PropTypes.bool,
-  /** Data attr for Cypress tests. */
-  'data-cy': PropTypes.string,
 }
 
 Avatar.propTypes = avatarPropTypes

--- a/src/components/Avatar/Avatar.test.js
+++ b/src/components/Avatar/Avatar.test.js
@@ -587,6 +587,22 @@ describe('Action', () => {
     expect(avatar.querySelector(`${ui.focusBorder}`)).toBeInTheDocument()
   })
 
+  test('Renders a with a Tooltip', () => {
+    const { container } = render(
+      <Avatar
+        name="Buddy the Elf"
+        image="buddy.jpg"
+        shape="rounded"
+        tooltipProps={{
+          title: 'Ringo',
+          placement: 'bottom',
+        }}
+      />
+    )
+
+    expect(container.querySelector('.TooltipTrigger')).toBeInTheDocument()
+  })
+
   test('Renders an animate svg', () => {
     const { getByTitle } = render(
       <Avatar

--- a/src/components/AvatarList/AvatarList.css.js
+++ b/src/components/AvatarList/AvatarList.css.js
@@ -19,7 +19,8 @@ export const AvatarListUI = styled('div')`
   display: inline-flex;
   position: relative;
 
-  &.is-withLayerStack {
+  &.horizontally-stacked {
+    flex-direction: row;
     align-items: center;
     justify-content: center;
     margin: auto;
@@ -27,7 +28,6 @@ export const AvatarListUI = styled('div')`
     min-height: 64px;
     width: 100%;
     min-width: 0;
-
     padding-left: ${config.borderWidth * 3}px;
 
     ${ItemUI} {
@@ -36,6 +36,33 @@ export const AvatarListUI = styled('div')`
 
       &:first-child {
         margin-left: 0;
+      }
+    }
+  }
+
+  &.vertically-stacked {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    max-width: 64px;
+    margin: auto;
+    padding-top: ${config.borderWidth * 3}px;
+
+    ${ItemUI} {
+      margin-top: -9px;
+      padding-top: 0;
+
+      &:first-child {
+        margin-top: 0;
+      }
+
+      .c-Avatar__cropBorder {
+        top: -1px;
+        bottom: -1px;
+        left: -1px;
+        right: -1px;
+        border-width: 1px;
       }
     }
   }

--- a/src/components/AvatarList/AvatarList.jsx
+++ b/src/components/AvatarList/AvatarList.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { PropTypes } from 'prop-types'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
-import Avatar from '../Avatar'
 import Animate from '../Animate'
+import Avatar from '../Avatar'
 import { ItemUI, AvatarListUI, AvatarListWrapperUI } from './AvatarList.css'
 import classNames from 'classnames'
 import { getComponentKey } from '../../utilities/component'
@@ -22,13 +22,18 @@ const wrapAvatar = (props, avatar, index) => {
 
   let zIndex = max - index
 
-  if (stack && count > 2 && isOdd(`${count}`)) {
-    if (isOdd(index)) {
-      zIndex = zIndex + 1
+  if (stack === 'horizontal') {
+    if (count > 2 && isOdd(count)) {
+      if (isOdd(index)) {
+        zIndex = zIndex + 1
+      }
+
+      if (index === getMiddleIndex(count)) {
+        zIndex = zIndex + 2
+      }
     }
-    if (index === getMiddleIndex(`${count}`)) {
-      zIndex = zIndex + 2
-    }
+  } else if (stack === 'vertical') {
+    zIndex = index + 1
   }
 
   return (
@@ -50,7 +55,7 @@ const getCurrentCount = ({ count, max }) => (count < max ? count : max)
 export const getAvatarSize = ({ size: sizeProp, stack, ...rest }) => {
   const currentCount = getCurrentCount(rest)
 
-  if (!stack) return sizeProp
+  if (stack !== 'horizontal') return sizeProp
 
   let size = 'md'
 
@@ -65,7 +70,16 @@ export const getAvatarSize = ({ size: sizeProp, stack, ...rest }) => {
 }
 
 export const AvatarList = props => {
-  const { children, max, className, center, stack, grid, ...rest } = props
+  const {
+    children,
+    max,
+    className,
+    center,
+    stack,
+    grid,
+    extraTooltipProps,
+    ...rest
+  } = props
   const avatars = React.Children.toArray(children)
   const avatarList =
     max && avatars.length > max ? avatars.slice(0, max - 1) : avatars
@@ -84,10 +98,16 @@ export const AvatarList = props => {
 
   if (shouldShowExtra) {
     const extraLabel = `+${extraAvatarCount}`
+
     avatarComponents.push(
       wrapAvatar(
         propsWithCount,
-        <Avatar count={extraLabel} light name={extraLabel} />,
+        <Avatar
+          count={extraLabel}
+          light
+          name={extraLabel}
+          tooltipProps={extraTooltipProps}
+        />,
         avatarList.length
       )
     )
@@ -96,6 +116,8 @@ export const AvatarList = props => {
   const componentClassName = classNames(
     'c-AvatarList',
     stack && 'is-withLayerStack',
+    stack === 'horizontal' && 'horizontally-stacked',
+    stack === 'vertical' && 'vertically-stacked',
     grid && 'is-grid',
     className
   )
@@ -124,7 +146,6 @@ AvatarList.defaultProps = {
   center: false,
   showStatusBorderColor: false,
   size: 'sm',
-  stack: false,
 }
 
 AvatarList.propTypes = {
@@ -138,12 +159,14 @@ AvatarList.propTypes = {
   animationSequence: PropTypes.string,
   /** Custom className to pass to `Avatars`. */
   avatarsClassName: PropTypes.string,
-  /** Center Avatars */
-  center: PropTypes.bool,
   /** Color for the Avatar border. */
   borderColor: PropTypes.string,
+  /** Center Avatars */
+  center: PropTypes.bool,
   /** Custom class names to be added to the component. */
   className: PropTypes.string,
+  /** To add a Tooltip to the "extra" avatar, accepts all Tooltip props */
+  extraTooltipProps: PropTypes.object,
   /** Display as grid (previously AvatarGrid) */
   grid: PropTypes.bool,
   /** Number of avatars to display before truncating. */
@@ -157,7 +180,7 @@ AvatarList.propTypes = {
   /** Size of the avatars. */
   size: PropTypes.string,
   /** Display as stack (previously AvatarStack) */
-  stack: PropTypes.bool,
+  stack: PropTypes.oneOf(['horizontal', 'vertical']),
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,
 }

--- a/src/components/AvatarList/AvatarList.jsx
+++ b/src/components/AvatarList/AvatarList.jsx
@@ -85,13 +85,9 @@ export const AvatarList = props => {
     max && avatars.length > max ? avatars.slice(0, max - 1) : avatars
   const extraAvatarCount = avatars.length - avatarList.length
   const shouldShowExtra = extraAvatarCount > 0
-
   const propsWithCount = { ...props, count: avatars.length }
-
   const size = getAvatarSize(propsWithCount)
-
   const contextValue = { size }
-
   const avatarComponents = avatarList.map((avatar, index) => {
     return wrapAvatar(propsWithCount, avatar, index)
   })

--- a/src/components/AvatarList/AvatarList.stories.mdx
+++ b/src/components/AvatarList/AvatarList.stories.mdx
@@ -62,13 +62,13 @@ An AvatarList component displays an array of `Avatars`. This component has a max
 
 ### Stories
 
-#### use as AvatarStack replacement
+#### Stacked
 
 <Canvas>
-  <Story name="use as AvatarStack replacement">
+  <Story name="Horizontal Stack">
     <div style={{ background: '#eee', padding: 10 }}>
-      <AvatarList max={number('max', 14)} center stack size="md">
-        {AvatarSpec.generate(20).map(avatar => {
+      <AvatarList max={number('max', 14)} center stack="horizontal" size="md">
+        {AvatarSpec.generate(19).map(avatar => {
           const { name, image, status } = avatar
           return (
             <Avatar
@@ -77,6 +77,42 @@ An AvatarList component displays an array of `Avatars`. This component has a max
               name={name}
               status={status}
               withShadow={boolean('withShadow', true)}
+            />
+          )
+        })}
+      </AvatarList>
+    </div>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Vertical Stack">
+    <div
+      style={{
+        background: '#f9fafa',
+        padding: 10,
+        margin: 'auto',
+        width: '100px',
+      }}
+    >
+      <AvatarList
+        max={number('max', 6)}
+        center
+        stack="vertical"
+        size="smmd"
+        extraTooltipProps={{
+          title: ['John', 'Paul', 'Ringo'].join('\n'),
+          placement: 'bottom',
+        }}
+      >
+        {AvatarSpec.generate(8).map(avatar => {
+          const { name, image, status } = avatar
+          return (
+            <Avatar
+              borderColor="#f9fafa"
+              image={image}
+              key={name}
+              name={name}
             />
           )
         })}

--- a/src/components/AvatarList/AvatarList.test.js
+++ b/src/components/AvatarList/AvatarList.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import AvatarList, { getAvatarSize } from './AvatarList'
-import { Animate, Avatar } from '../index'
+import { Animate, Avatar, Tooltip } from '../index'
 
 describe('ClassName', () => {
   test('Has default className', () => {
@@ -19,9 +19,16 @@ describe('ClassName', () => {
     expect(el.length).toBeTruthy()
   })
 
-  test('Adds stack class when appropriate', () => {
-    const wrapper = mount(<AvatarList stack />)
-    const el = wrapper.find('.is-withLayerStack')
+  test('Adds horizontal stack class when appropriate', () => {
+    const wrapper = mount(<AvatarList stack="horizontal" />)
+    const el = wrapper.find('.horizontally-stacked')
+
+    expect(el.length).toBeTruthy()
+  })
+
+  test('Adds vertical stack class when appropriate', () => {
+    const wrapper = mount(<AvatarList stack="vertical" />)
+    const el = wrapper.find('.vertically-stacked')
 
     expect(el.length).toBeTruthy()
   })
@@ -42,10 +49,10 @@ describe('ClassName', () => {
 })
 
 describe('AvatarList', () => {
-  test('get correct avatar size ', () => {
-    expect(getAvatarSize({ stack: true, count: 3, max: 2 })).toBe('lg')
-    expect(getAvatarSize({ stack: true, count: 3, max: 3 })).toBe('md')
-    expect(getAvatarSize({ stack: true, count: 1, max: 2 })).toBe('xl')
+  test('get correct avatar size when horizontally stacked', () => {
+    expect(getAvatarSize({ stack: 'horizontal', count: 3, max: 2 })).toBe('lg')
+    expect(getAvatarSize({ stack: 'horizontal', count: 3, max: 3 })).toBe('md')
+    expect(getAvatarSize({ stack: 'horizontal', count: 1, max: 2 })).toBe('xl')
   })
 })
 
@@ -96,5 +103,27 @@ describe('Limit', () => {
 
     expect(avatar.length).toBe(4)
     expect(additionalCounter.text()).not.toBe('+2')
+  })
+
+  test('should add a tooltip to the extra avatar', () => {
+    const max = 2
+    const wrapper = mount(
+      <AvatarList
+        stack="vertical"
+        max={max}
+        extraTooltipProps={{
+          title: ['John', 'Paul', 'Ringo'].join('\n'),
+          placement: 'bottom',
+        }}
+      >
+        <Avatar />
+        <Avatar />
+        <Avatar />
+        <Avatar />
+      </AvatarList>
+    )
+    const tooltip = wrapper.find(Tooltip)
+
+    expect(tooltip.length).toBe(1)
   })
 })


### PR DESCRIPTION
![CleanShot 2021-08-25 at 16 37 07](https://user-images.githubusercontent.com/1414086/130810934-9f8e0b9b-570f-4f7d-82af-7e78101a0376.gif)

## Avatar ssmd size

The spec has these Avatars being 38px, but the closest we have is 35px for "smmd". This PR updates to 38px for consistency but we need design to OK this, if not either make them all 35px or add yet another size to the list:

```js
// all sizes
{
    xl: {
      size: 64,
      fontSize: 13,
    },
    lg: {
      size: 52,
      fontSize: 13,
    },
    md: {
      size: 46,
      fontSize: 13,
    },
    smmd: {
      size: 38, // <-- This was 35
      fontSize: 15,
    },
    sm: {
      size: 30,
      fontSize: 10,
    },
    xs: {
      size: 28,
      fontSize: 10,
    },
    xxs: {
      size: 26,
      fontSize: 10,
    },
  },
```

## Vertical stack

AvatarList has an option to stack, using the `stack` prop, this prop used to be a boolean but I searched in our projects and is not being used at all, so I changed it to be either 'horizontal' or 'vertical'. Horizontal behaves just like it used to if `stack === true`.

## Tooltip on the "extra" Avatar

When we limit the number of avatars displayed with `max`, we show an "extra" avatar that shows the count of the hidden avatars. Here we add a prop: `extraTooltipProps`, pass this and this Extra Avatar will be wrapped with a Tooltip, use all valid Tooltip props, example:

```jsx
<AvatarList
  max={3}
  center
  stack="vertical"
  size="smmd"
  extraTooltipProps={{
    title: ['John', 'Paul', 'Ringo'].join('\n'),
    placement: 'bottom',
  }}
>
  <Avatar borderColor="#f9fafa" image={image} name={name} />
  <Avatar borderColor="#f9fafa" image={image} name={name} />
  <Avatar borderColor="#f9fafa" image={image} name={name} />
  <Avatar borderColor="#f9fafa" image={image} name={name} />
</AvatarList>
```

### Tooltip on Avatar

The above is possible by the addition of `tooltipProps` on the Avatar:

```jsx
  <Avatar
	borderColor="#f9fafa"
	image={image}
 	name={name}
	tooltipProps={{
    	title: ['John', 'Paul', 'Ringo'].join('\n'),
	    placement: 'bottom',
    }}
  />
```