### PR TITLE
[Fix] EditableTextArea: updates validation icon position

### DIFF
--- a/src/components/EditableField/EditableField.css.js
+++ b/src/components/EditableField/EditableField.css.js
@@ -460,7 +460,7 @@ export const ValidationIconUI = styled('div')`
   position: absolute;
   width: 24px;
   height: 24px;
-  top: 0;
+  bottom: -1px;
   right: 0;
   z-index: 10;
   pointer-events: all;

--- a/src/components/EditableTextarea/EditableTextarea.storiesHelpers.js
+++ b/src/components/EditableTextarea/EditableTextarea.storiesHelpers.js
@@ -8,7 +8,7 @@ import EditableTextarea from '.'
 export const ValidationApp = () => (
   <ContainerUI>
     <NoteUI>
-      <p>Type:</p>
+      <p>Type anywhere in the textarea (for multiple lines testing):</p>
       <ul>
         <li>
           <strong>"off"</strong> to get the error style
@@ -33,17 +33,18 @@ export const ValidationApp = () => (
 )
 
 function validateFieldValue(payload) {
-  console.log('validating')
-
   const { name, value } = payload
-  let isValid = value !== 'off' && value !== 'other' && value !== 'warn'
+  let isValid =
+    !value.includes('off') &&
+    !value.includes('other') &&
+    !value.includes('warn')
 
   return new Promise(resolve => {
     setTimeout(function () {
       if (isValid) {
         resolve({ isValid, name, value })
       } else {
-        if (value === 'off') {
+        if (value.includes('off')) {
           resolve({
             isValid,
             name,
@@ -51,7 +52,7 @@ function validateFieldValue(payload) {
             type: 'error',
             message: 'That is definitely not right',
           })
-        } else if (value === 'warn') {
+        } else if (value.includes('warn')) {
           resolve({
             isValid,
             name,
@@ -59,7 +60,7 @@ function validateFieldValue(payload) {
             type: 'warning',
             message: "That's it, you have been warned",
           })
-        } else if (value === 'other') {
+        } else if (value.includes('other')) {
           resolve({
             isValid,
             name,


### PR DESCRIPTION
# Problem

The validation icon is positioned too close to the border bottom.

<img width="557" alt="CleanShot 2021-08-30 at 15 00 25@2x" src="https://user-images.githubusercontent.com/1414086/131342909-af0cb8bf-cb53-49dd-828b-819a16aa9c0e.png">

## Solution

Update the `position`, instead of `top` use `bottom`:

One line:

<img width="281" alt="CleanShot 2021-08-30 at 14 48 08@2x" src="https://user-images.githubusercontent.com/1414086/131343007-4ceb71a9-9e18-408d-a44e-e55887480427.png">

Multiple lines:

<img width="279" alt="CleanShot 2021-08-30 at 14 55 19@2x" src="https://user-images.githubusercontent.com/1414086/131343044-7610e1bd-7d91-4d2b-a405-be463d8362d8.png">
