### PR TITLE
Removes @types/styled-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7015,27 +7015,6 @@
         "@types/unist": "*"
       }
     },
-    "@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-          "dev": true,
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        }
-      }
-    },
     "@types/html-minifier-terser": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
@@ -7313,17 +7292,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
-    },
-    "@types/styled-components": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.9.tgz",
-      "integrity": "sha512-kbEG6YlwK8rucITpKEr6pA4Ho9KSQHUUOzZ9lY3va1mtcjvS3D0wDciFyHEiNHKLL/npZCKDQJqm0x44sPO9oA==",
-      "dev": true,
-      "requires": {
-        "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "@types/tapable": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "@types/react": "^16.4.14",
     "@types/react-dom": "^16.0.8",
     "@types/react-transition-group": "^2.0.14",
-    "@types/styled-components": "^5.1.9",
     "@welldone-software/why-did-you-render": "^6.2.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^26.1.0",


### PR DESCRIPTION
# Problem

This really is unused and it makes VSCode behave in a very annoying manner when jumping to definition using cmd+click on your own authored styled components.

Context: https://github.com/microsoft/vscode/issues/68782