### PR TITLE
Change SplitButton focus ring color

### DIFF
--- a/src/components/SplitButton/SplitButton.css.js
+++ b/src/components/SplitButton/SplitButton.css.js
@@ -1,6 +1,17 @@
 import styled from 'styled-components'
 import Button from '../Button'
+import { FocusUI } from '../Button/Button.css'
 import { getColor } from '../../styles/utilities/color'
+import config from '../Button/Button.config'
+
+export const SplitButtonUI = styled(Button)`
+  &.is-primary {
+    ${FocusUI} {
+      box-shadow: 0 0 0 ${config.focusOutlineWidth}px ${getColor('blue.600')},
+        inset 0 0 0 2px white;
+    }
+  }
+`
 
 export const OptionsTriggerButtonUI = styled(Button)`
   min-width: 30px !important;
@@ -17,6 +28,11 @@ export const OptionsTriggerButtonUI = styled(Button)`
     }
     &[disabled] {
       box-shadow: -1px 0 0 ${getColor('grey.600')};
+    }
+
+    ${FocusUI} {
+      box-shadow: 0 0 0 ${config.focusOutlineWidth}px ${getColor('blue.600')},
+        inset 0 0 0 2px white;
     }
   }
 

--- a/src/components/SplitButton/SplitButton.jsx
+++ b/src/components/SplitButton/SplitButton.jsx
@@ -3,10 +3,9 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { noop } from '../../utilities/other'
 import SearchableDropdown from '../SearchableDropdown'
-import Button from '../Button'
 import ControlGroup from '../ControlGroup'
 import Icon from '../Icon'
-import { OptionsTriggerButtonUI } from './SplitButton.css'
+import { OptionsTriggerButtonUI, SplitButtonUI } from './SplitButton.css'
 
 const defaultDropdownProps = {
   className: 'c-SplitButton__dropdown',
@@ -20,7 +19,7 @@ export class SplitButton extends React.PureComponent {
   renderButton() {
     const { dropdownProps, ...rest } = this.props
 
-    return <Button {...rest} className="c-SplitButton__button" />
+    return <SplitButtonUI {...rest} className="c-SplitButton__button" />
   }
 
   renderDropdownTrigger() {


### PR DESCRIPTION
# Problem
When the SplitButton is a primary one, the focus ring blended with the button. It looks weird
<img width="174" alt="CleanShot 2021-09-02 at 13 56 49@2x" src="https://user-images.githubusercontent.com/203992/131893511-1478ba6f-a0eb-40a7-a7a0-54e664d4c9af.png">

# Solution
In that situation, we bump the ring color to "blue.600". We also add an inset white shadow to increase the floating effect
<img width="186" alt="CleanShot 2021-09-02 at 13 58 18@2x" src="https://user-images.githubusercontent.com/203992/131893716-39ae4868-d238-4935-b344-1af7180c316a.png">
