### PR TITLE
[HSDS-205] DropList features

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -90,8 +90,10 @@ function Combobox({
 
           return item
         })
+
         filtered = filtered.concat(processed)
       }
+
       setHighlightedIndex(filtered.findIndex(isItemHighlightable))
       setInputItems(filtered)
     },

--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -91,7 +91,7 @@ function Combobox({
           return item
         })
 
-        filtered = filtered.concat(processed)
+        filtered = processed
       }
 
       setHighlightedIndex(filtered.findIndex(isItemHighlightable))

--- a/src/components/DropList/DropList.ListItem.jsx
+++ b/src/components/DropList/DropList.ListItem.jsx
@@ -3,9 +3,9 @@ import classNames from 'classnames'
 import { isFunction, isObject, isString } from '../../utilities/is'
 import {
   getItemContentKeyName,
+  isItemAction,
   isItemADivider,
   isItemAGroupLabel,
-  isItemReset,
   objectHasKey,
 } from './DropList.utils'
 import {
@@ -37,7 +37,6 @@ const ListItem = forwardRef(
     }
 
     const contentKey = getItemContentKeyName(item)
-    const isReset = isItemReset(item)
 
     if (isItemAGroupLabel(item)) {
       return (
@@ -55,7 +54,7 @@ const ListItem = forwardRef(
         'DropListItem',
         isSelected && 'is-selected',
         isDisabled && 'is-disabled',
-        isReset && 'is-reset-item',
+        objectHasKey(item, 'type') && `is-type-${item.type}`,
         highlightedIndex === index && 'is-highlighted',
         withMultipleSelection && 'with-multiple-selection',
         isString(extraClassNames) && extraClassNames,
@@ -93,7 +92,7 @@ const ListItem = forwardRef(
         <ListItemTextUI>
           {isObject(item) ? item[contentKey] : item}
         </ListItemTextUI>
-        {withMultipleSelection && !isReset ? (
+        {withMultipleSelection && !isItemAction(item) ? (
           <SelectedBadge isSelected={isSelected} />
         ) : null}
       </ListItemUI>

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -20,6 +20,7 @@ function Select({
   closeOnBlur = true,
   closeOnSelection = true,
   customEmptyList = null,
+  customEmptyListItems,
   'data-cy': dataCy = `DropList.${VARIANTS.SELECT}`,
   enableLeftRightNavigation = false,
   handleSelectedItemChange = noop,
@@ -35,6 +36,11 @@ function Select({
   toggleOpenedState = noop,
   withMultipleSelection = false,
 }) {
+  const isListEmpty = items.length === 0
+  const allItems =
+    isListEmpty && Array.isArray(customEmptyListItems)
+      ? customEmptyListItems
+      : items
   const {
     highlightedIndex,
     getItemProps,
@@ -44,7 +50,7 @@ function Select({
   } = useSelect({
     initialIsOpen: isOpen,
     isOpen,
-    items,
+    items: allItems,
     itemToString,
     selectedItem,
 
@@ -85,7 +91,7 @@ function Select({
       return stateReducerCommon({
         changes,
         closeOnSelection,
-        items,
+        items: allItems,
         selectedItems,
         state,
         type: `${VARIANTS.SELECT}.${type}`,
@@ -129,7 +135,7 @@ function Select({
   function handleMenuKeyDown(event) {
     if (enableLeftRightNavigation) {
       if (event.key === 'ArrowRight') {
-        if (highlightedIndex !== items.length - 1) {
+        if (highlightedIndex !== allItems.length - 1) {
           setHighlightedIndex(highlightedIndex + 1)
         }
       } else if (event.key === 'ArrowLeft') {
@@ -195,8 +201,7 @@ function Select({
       >
         {renderListContents({
           customEmptyList,
-          emptyList: items.length === 0,
-          items,
+          items: allItems,
           renderListItem,
         })}
       </MenuListUI>

--- a/src/components/DropList/DropList.constants.js
+++ b/src/components/DropList/DropList.constants.js
@@ -9,7 +9,6 @@ export const ITEM_TYPES = {
   GROUP: 'group',
   GROUP_LABEL: 'group_label',
   INERT: 'inert',
-  RESET_DROPLIST: 'reset_droplist',
 }
 
 export const DROPLIST_TOGGLER = 'DropListToggler'

--- a/src/components/DropList/DropList.constants.js
+++ b/src/components/DropList/DropList.constants.js
@@ -4,9 +4,11 @@ export const VARIANTS = {
 }
 
 export const ITEM_TYPES = {
+  ACTION: 'action',
   DIVIDER: 'divider',
   GROUP: 'group',
   GROUP_LABEL: 'group_label',
+  INERT: 'inert',
   RESET_DROPLIST: 'reset_droplist',
 }
 

--- a/src/components/DropList/DropList.css.js
+++ b/src/components/DropList/DropList.css.js
@@ -128,22 +128,6 @@ export const ListItemUI = styled('li')`
     background-color: transparent;
     cursor: default;
   }
-
-  &.is-reset-item {
-    height: 50px;
-    margin: 0 5px;
-    padding: 0 15px;
-    line-height: 50px;
-    color: ${getColor('charcoal.300')};
-
-    &.is-highlighted,
-    &:hover {
-      color: ${getColor('charcoal.300')};
-      text-decoration: underline;
-      cursor: pointer;
-      background-color: transparent;
-    }
-  }
 `
 
 export const ListItemTextUI = styled('span')`

--- a/src/components/DropList/DropList.css.js
+++ b/src/components/DropList/DropList.css.js
@@ -128,6 +128,13 @@ export const ListItemUI = styled('li')`
     background-color: transparent;
     cursor: default;
   }
+
+  &.is-type-inert,
+  &.is-highlighted.is-type-inert,
+  &.with-multiple-selection.is-highlighted.is-type-inert {
+    background-color: transparent;
+    cursor: default;
+  }
 `
 
 export const ListItemTextUI = styled('span')`

--- a/src/components/DropList/DropList.downshift.common.js
+++ b/src/components/DropList/DropList.downshift.common.js
@@ -22,7 +22,6 @@ export function stateReducerCommon({
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputChange}`:
       return {
         ...changes,
-        highlightedIndex: 0,
       }
 
     case `${COMBOBOX}.${useCombobox.stateChangeTypes.InputBlur}`:

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -12,14 +12,16 @@ import {
   flattenListItems,
   getDropListVariant,
   getItemContentKeyName,
-  isItemReset,
+  isItemAction,
   isItemRegular,
+  isItemReset,
   isTogglerOfType,
   itemToString,
   parseSelectionFromProps,
   removeItemFromArray,
   requiredItemPropsCheck,
   useWarnings,
+  isItemInert,
 } from './DropList.utils'
 import {
   SimpleButton,
@@ -36,6 +38,7 @@ function DropListManager({
   closeOnClickOutside = true,
   closeOnSelection = true,
   customEmptyList = null,
+  customEmptyListItems,
   'data-cy': dataCy,
   enableLeftRightNavigation = false,
   focusTogglerOnMenuClose = true,
@@ -163,7 +166,12 @@ function DropListManager({
       return
     }
 
-    if (selectedItem.isDisabled) {
+    if (selectedItem.isDisabled || isItemInert(selectedItem)) {
+      return
+    }
+
+    if (isItemAction(selectedItem)) {
+      onSelect(null, selectedItem)
       return
     }
 
@@ -267,6 +275,7 @@ function DropListManager({
             closeOnBlur={closeOnBlur}
             closeOnSelection={closeOnSelection}
             customEmptyList={customEmptyList}
+            customEmptyListItems={customEmptyListItems}
             data-cy={dataCy}
             enableLeftRightNavigation={enableLeftRightNavigation}
             handleSelectedItemChange={handleSelectedItemChange}
@@ -328,8 +337,12 @@ DropListManager.propTypes = {
   closeOnClickOutside: PropTypes.bool,
   /** Whether to close the DropList when an item is selected */
   closeOnSelection: PropTypes.bool,
-  /** Pass a React Element to render a custom message or style when the List is empty */
+  /** Pass an Element to render a custom message or style when the List is empty */
   customEmptyList: PropTypes.any,
+  /** To render "extra" items when the list is empty, as opposed to just customizind the rendering like `customEmptyList` does */
+  customEmptyListItems: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, itemShape, dividerShape, groupShape])
+  ),
   /** Data attr applied to the DropList for Cypress tests. By default one of 'DropList.Select' or 'DropList.Combobox' depending on the variant used */
   'data-cy': PropTypes.string,
   /** Enable navigation with Right and Left arrows (useful for horizontally rendered lists) */

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -14,7 +14,6 @@ import {
   getItemContentKeyName,
   isItemAction,
   isItemRegular,
-  isItemReset,
   isTogglerOfType,
   itemToString,
   parseSelectionFromProps,
@@ -58,7 +57,6 @@ function DropListManager({
   toggler = {},
   variant = VARIANTS.SELECT,
   withMultipleSelection = false,
-  withResetSelectionItem,
 }) {
   const [isOpen, setOpenedState] = useState(false)
   const tippyInstanceRef = useRef(null)
@@ -71,7 +69,7 @@ function DropListManager({
     withMultipleSelection ? parsedSelection : []
   )
   const [parsedItems, setParsedItems] = useState(
-    flattenListItems(items, withMultipleSelection && withResetSelectionItem)
+    flattenListItems(items, withMultipleSelection)
   )
 
   const { getCurrentScope } = useContext(GlobalContext) || {}
@@ -98,10 +96,8 @@ function DropListManager({
   }, [{ state: parsedSelection }, withMultipleSelection])
 
   useDeepCompareEffect(() => {
-    setParsedItems(
-      flattenListItems(items, withMultipleSelection && withResetSelectionItem)
-    )
-  }, [items, withMultipleSelection, withResetSelectionItem])
+    setParsedItems(flattenListItems(items, withMultipleSelection))
+  }, [items, withMultipleSelection])
 
   useEffect(() => {
     setOpenedState(isMenuOpen)
@@ -196,8 +192,6 @@ function DropListManager({
               item: itemToRemove,
               key: contentKey,
             })
-          } else if (isItemReset(selectedItem)) {
-            updatedSelection = selectedItems
           }
         }
 
@@ -387,11 +381,6 @@ DropListManager.propTypes = {
   variant: PropTypes.oneOf(['select', 'Select', 'combobox', 'Combobox']),
   /** Enable multiple selection of items */
   withMultipleSelection: PropTypes.bool,
-  /** Adds an "inert" item at the end of the list with a type of `reset_droplist`, use it to implement a "Clear Selection" or "Reset to defaults" type of option */
-  withResetSelectionItem: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.bool,
-  ]),
 }
 
 export default DropListManager

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs/blocks'
 import { boolean, number, text, select } from '@storybook/addon-knobs'
 import DropList from './DropList'
+import { DividerUI, ListItemUI, ListItemTextUI } from './DropList.css'
 import {
   IconBtn,
   MeatButton,
@@ -250,6 +251,10 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
           },
           regularItems
         )}
+        onSelect={(selection, clickedItem) => {
+          console.log('🚀 ~ selection', selection)
+          console.log('🚀 ~ clickedItem', clickedItem)
+        }}
         toggler={<SimpleButton text="This is a combobox" />}
       />
     </div>
@@ -272,7 +277,9 @@ const itemShape = PropTypes.shape({
 })
 ```
 
-- Laser Targeting: if you need to target a specific List Item for styling (or else), you can add the property `className` to each item in the array, the value will be added to the existing css class names on the `DropListItem`:
+#### Laser Targeting
+
+If you need to target a specific List Item for styling (or else), you can add the property `className` to each item in the array, the value will be added to the existing css class names on the `DropListItem`:
 
 ```js
 const items = [
@@ -284,7 +291,60 @@ const items = [
 ]
 ```
 
-- Dividers: Add a `type = divider` property to an object to create a divider
+#### Inert items
+
+If you need to add an item that does nothing but be there, effectively a "non-item" which semantically is different to a disabled item, just add a `type = inert`:
+
+```js
+{
+  label: 'Some info here perhaps...?',
+  type: 'inert',
+}
+```
+
+This might be useful when using `customEmptyListItems`:
+
+```jsx
+customEmptyListItems={[
+  {
+    label: 'No tags found',
+    type: 'inert',
+  },
+  {
+    type: 'divider',
+  },
+  {
+    label: 'Create tag',
+    customizeLabel(inputValue) {
+      return `Create ${inputValue} tag`
+    },
+    type: 'action',
+  },
+]}
+```
+
+#### Action items
+
+If you want to add an item that:
+
+1. should **not** be selected
+2. behaves as any other regular item (fires `onSelect`, keyboard nav works, closes DropList on choosing it, etc)
+3. Basically you need it to fire some random action unrelated to the DropList
+
+Add a `type = action`:
+
+```js
+{
+  label: 'Create tag',
+  type: 'action',
+}
+```
+
+> This is a similar effect to using `clearOnSelect`, except only for action items as opposed to all items in the list
+
+#### Dividers
+
+Add a `type = divider` property to an object to create a divider
 
 ```js
 const items = [
@@ -315,7 +375,9 @@ const items = [
   </Story>
 </Canvas>
 
-- Groups: Add a `type = group` property (don't forget to add `label` or `value` to the group) and nest items to an object to create a group:
+#### Groups
+
+Add a `type = group` property (don't forget to add `label` or `value` to the group) and nest items to an object to create a group:
 
 ```js
 const groupedItems = [
@@ -372,7 +434,7 @@ const groupedItems = [
   </Story>
 </Canvas>
 
-- Empty list
+#### Empty list
 
 <Canvas>
   <Story name="Items: empty list">
@@ -423,7 +485,102 @@ const groupedItems = [
   </Story>
 </Canvas>
 
-- Custom List Items: Sometimes you might need to render the list items in a different manner, for that you can use the render prop `renderCustomListItem`.
+- Sometimes you might need to add some items when the list is empty, instead of rendering just a custom empty list, use `customEmptyListItems` with an array of items.
+
+<Canvas>
+  <Story name="Items: custom empty list items (Select)">
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        items={[]}
+        customEmptyListItems={[
+          {
+            label: 'No tags found',
+            type: 'inert',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            label: 'Create tag',
+            type: 'action',
+          },
+        ]}
+        toggler={<SimpleButton text="This is a select" />}
+      />
+    </div>
+  </Story>
+</Canvas>
+
+- On a combobox, you can customize the label of your items with the value of the input by adding a `customizeLabel` function on the item:
+
+```js
+{
+  label: 'Create tag',
+  customizeLabel(inputValue) {
+    return `Create ${inputValue} tag`
+  },
+  type: 'action',
+}
+```
+
+<Canvas>
+  <Story name="Items: custom empty list items (Combobox)">
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        variant="combobox"
+        items={select(
+          'Items',
+          {
+            empty: [],
+            full: regularItems,
+          },
+          regularItems
+        )}
+        customEmptyListItems={[
+          {
+            label: 'No tags found',
+            type: 'inert',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            label: 'Create tag',
+            customizeLabel(inputValue) {
+              return `Create ${inputValue} tag`
+            },
+            type: 'action',
+          },
+        ]}
+        onSelect={(selection, clickedItem) => {
+          console.log('🚀 ~ selection', selection)
+          console.log('🚀 ~ clickedItem', clickedItem)
+        }}
+        toggler={<SimpleButton text="This is a combobox" />}
+      />
+    </div>
+  </Story>
+</Canvas>
+
+#### Custom List Items
+
+Sometimes you might need to render the list items in a different manner, for that you can use the render prop `renderCustomListItem`.
 
 ```jsx
 // Signature
@@ -492,7 +649,9 @@ function renderCustomListItem({
   </Story>
 </Canvas>
 
-- Disabled List Items: Sometimes you might need to render the list items that would be disabled, for that you can pass `isDisbaled` flag with an item.
+#### Disabled List Items
+
+Sometimes you might need to render the list items that would be disabled, for that you can pass `isDisabled` flag with an item.
 
 <Canvas>
   <Story name="Items: disabled list items">

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -789,30 +789,8 @@ Depending on your use case, you might want to set `closeOnSelection = false` whe
   </Story>
 </Canvas>
 
-### With Reset Selection Item
-
-Use `withResetSelectionItem` to add an extra item to the end of the list that will have a type of `reset_droplist` so you can assign a different action when clicked, this normally only makes sense in multiple selection DropLists.
-
-Pass a string to customize the text, by default is "Reset".
-
-Example:
-
-```jsx
-<DropList
-  items={items}
-  onSelect={(selection, clickedItem) => {
-    if (clickedItem.type === 'reset_droplist') {
-      clearSelection()
-    }
-  }}
-  selection={columns.filter(shouldColumnShow)}
-  withMultipleSelection
-  withResetSelectionItem="Clear selection"
-/>
-```
-
 <Canvas>
-  <Story name="With Reset Item">
+  <Story name="With action Item">
     <div
       style={{
         width: '400px',
@@ -823,15 +801,23 @@ Example:
       }}
     >
       <DropList
-        items={regularItems.slice(0, 3)}
+        items={regularItems.slice(0, 3).concat([
+          {
+            type: 'divider',
+          },
+          {
+            label: 'Reset to defaults',
+            type: 'action',
+            action: 'RESET',
+          },
+        ])}
         onSelect={(selection, clickedItem) => {
-          if (clickedItem.type === 'reset_droplist') {
+          if (clickedItem.type === 'action' && clickedItem.action === 'RESET') {
             console.log('RESET CLICKED')
           }
         }}
         toggler={<SimpleButton text="Click" />}
         withMultipleSelection
-        withResetSelectionItem="Clear selection"
       />
     </div>
   </Story>

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -254,6 +254,67 @@ describe('Render', () => {
     })
   })
 
+  test('should render empty menu list items if no items in the array and customEmptyListItems present (select)', async () => {
+    const { container } = render(
+      <DropList
+        items={[]}
+        customEmptyListItems={[
+          {
+            label: 'No tags found',
+            type: 'inert',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            label: 'Create tag',
+            type: 'action',
+          },
+        ]}
+        isMenuOpen
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.DropListItem--divider').length).toBe(
+        1
+      )
+      expect(container.querySelectorAll('.DropListItem').length).toBe(2)
+    })
+  })
+
+  test('should render empty menu list items if no items in the array and customEmptyListItems present (combobox)', async () => {
+    const { container } = render(
+      <DropList
+        variant="combobox"
+        items={[]}
+        customEmptyListItems={[
+          {
+            label: 'No tags found',
+            type: 'inert',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            label: 'Create tag',
+            type: 'action',
+          },
+        ]}
+        isMenuOpen
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.DropListItem--divider').length).toBe(
+        1
+      )
+      expect(container.querySelectorAll('.DropListItem').length).toBe(2)
+    })
+  })
+
   test('should render a the empty menu list if no items in the array (invalid custom element)', async () => {
     const { queryByText } = render(
       <DropList
@@ -811,6 +872,35 @@ describe('Selection', () => {
           listItemNode: getByText(itemToSelect.label).parentElement,
         })
       )
+    })
+  })
+
+  test('should not select an action item when clicked but fire onSelect', async () => {
+    const onSelectSpy = jest.fn()
+    const items = [
+      {
+        label: 'something',
+        type: 'action',
+      },
+    ].concat(someItems)
+    const { getByText } = render(
+      <DropList
+        isMenuOpen
+        onSelect={onSelectSpy}
+        items={items}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+    const itemToSelect = items[0]
+    user.click(getByText(itemToSelect.label).parentElement)
+
+    await waitFor(() => {
+      expect(
+        getByText(itemToSelect.label).parentElement.classList.contains(
+          'is-selected'
+        )
+      ).toBeFalsy()
+      expect(onSelectSpy).toHaveBeenCalledWith(null, itemToSelect)
     })
   })
 
@@ -1651,5 +1741,93 @@ describe('getEnabledItemIndex', () => {
         arrowKey: 'UP',
       })
     ).toBe(9)
+  })
+
+  test('Inert items', () => {
+    const items = [
+      {
+        label: '0004',
+        value: '0004',
+      },
+      {
+        label: '0005',
+        value: '0005',
+        type: 'inert',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        label: '0005',
+        value: '0005',
+      },
+    ]
+
+    expect(
+      getEnabledItemIndex({
+        currentHighlightedIndex: -1,
+        nextHighlightedIndex: 0,
+        items,
+        arrowKey: 'DOWN',
+      })
+    ).toBe(0)
+    expect(
+      getEnabledItemIndex({
+        currentHighlightedIndex: 1,
+        nextHighlightedIndex: 2,
+        items,
+        arrowKey: 'DOWN',
+      })
+    ).toBe(3)
+    expect(
+      getEnabledItemIndex({
+        currentHighlightedIndex: 3,
+        nextHighlightedIndex: 2,
+        items,
+        arrowKey: 'UP',
+      })
+    ).toBe(0)
+  })
+
+  test('One highlightable item', () => {
+    const items = [
+      {
+        label: '0005',
+        value: '0005',
+        type: 'inert',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        label: '0005',
+        value: '0005',
+      },
+    ]
+
+    expect(
+      getEnabledItemIndex({
+        currentHighlightedIndex: -1,
+        nextHighlightedIndex: 0,
+        items,
+        arrowKey: 'DOWN',
+      })
+    ).toBe(2)
+    expect(
+      getEnabledItemIndex({
+        currentHighlightedIndex: 2,
+        nextHighlightedIndex: 0,
+        items,
+        arrowKey: 'DOWN',
+      })
+    ).toBe(2)
+    expect(
+      getEnabledItemIndex({
+        currentHighlightedIndex: 2,
+        nextHighlightedIndex: 0,
+        items,
+        arrowKey: 'UP',
+      })
+    ).toBe(2)
   })
 })

--- a/src/components/DropList/DropList.togglers.jsx
+++ b/src/components/DropList/DropList.togglers.jsx
@@ -238,6 +238,7 @@ export const MeatButton = forwardRef(
       meatIcon = 'kebab',
       onClick = noop,
       withTooltip = false,
+      tooltipProps,
       ...rest
     },
     ref
@@ -274,6 +275,7 @@ export const MeatButton = forwardRef(
             triggerTarget={
               tooltipRef.current && tooltipRef.current.parentElement
             }
+            {...tooltipProps}
           >
             <Icon name={meatIcon} size={iconSize} />
           </Tooltip>
@@ -300,6 +302,7 @@ export const IconBtn = forwardRef(
       onClick = noop,
       withCaret = true,
       withTooltip = false,
+      tooltipProps,
       ...rest
     },
     ref
@@ -336,6 +339,7 @@ export const IconBtn = forwardRef(
             triggerTarget={
               tooltipRef.current && tooltipRef.current.parentElement
             }
+            {...tooltipProps}
           >
             <Icon name={iconName} size={iconSize} />
           </Tooltip>

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -153,10 +153,6 @@ export function isItemAGroupLabel(item) {
   return objectHasKey(item, 'type') && item.type === ITEM_TYPES.GROUP_LABEL
 }
 
-export function isItemReset(item) {
-  return objectHasKey(item, 'type') && item.type === ITEM_TYPES.RESET_DROPLIST
-}
-
 export function isItemInert(item) {
   return objectHasKey(item, 'type') && item.type === ITEM_TYPES.INERT
 }
@@ -167,15 +163,12 @@ export function isItemAction(item) {
 
 export function isItemRegular(item) {
   return (
-    !isItemADivider(item) &&
-    !isItemAGroup(item) &&
-    !isItemAGroupLabel(item) &&
-    !isItemReset(item)
+    !isItemADivider(item) && !isItemAGroup(item) && !isItemAGroupLabel(item)
   )
 }
 
-export function flattenListItems(listItems, withResetItem) {
-  const items = listItems.reduce((accumulator, listItem) => {
+export function flattenListItems(listItems) {
+  return listItems.reduce((accumulator, listItem) => {
     const contentKey = getItemContentKeyName(listItem)
 
     if (isItemAGroup(listItem)) {
@@ -196,19 +189,6 @@ export function flattenListItems(listItems, withResetItem) {
 
     return accumulator.concat(listItem)
   }, [])
-
-  return withResetItem
-    ? items.concat([
-        {
-          type: 'divider',
-        },
-        {
-          type: ITEM_TYPES.RESET_DROPLIST,
-          label: isString(withResetItem) ? withResetItem : 'Reset',
-          remove: true,
-        },
-      ])
-    : items
 }
 
 export function renderListContents({

--- a/src/components/Table/Table.ColumnChooser.jsx
+++ b/src/components/Table/Table.ColumnChooser.jsx
@@ -11,12 +11,12 @@ const shouldColumnShow = column => !!column.show
 function ColumnChooser({
   columns,
   defaultColumns,
-  columnChooserResetLabel = 'Reset to defaults',
+  columnChooserResetLabel,
   onColumnChoose = noop,
   resetColumns = noop,
   updateColumns = noop,
 }) {
-  const items = createColumnChooserListItems(columns)
+  const items = createColumnChooserListItems(columns, columnChooserResetLabel)
 
   return (
     <DropList

--- a/src/components/Table/Table.ColumnChooser.jsx
+++ b/src/components/Table/Table.ColumnChooser.jsx
@@ -20,8 +20,6 @@ function ColumnChooser({
 
   return (
     <DropList
-      isMenuOpen
-      closeOnBlur={false}
       autoSetComboboxAt={10}
       items={items}
       onSelect={(selection, clickedItem) => {

--- a/src/components/Table/Table.ColumnChooser.jsx
+++ b/src/components/Table/Table.ColumnChooser.jsx
@@ -20,10 +20,12 @@ function ColumnChooser({
 
   return (
     <DropList
+      isMenuOpen
+      closeOnBlur={false}
       autoSetComboboxAt={10}
       items={items}
       onSelect={(selection, clickedItem) => {
-        if (clickedItem.type === 'reset_droplist') {
+        if (clickedItem.type === 'action' && clickedItem.action === 'RESET') {
           if (!equal(columns, defaultColumns)) {
             resetColumns(defaultColumns)
           }
@@ -43,7 +45,6 @@ function ColumnChooser({
         />
       }
       withMultipleSelection
-      withResetSelectionItem={columnChooserResetLabel}
     />
   )
 }

--- a/src/components/Table/Table.css.js
+++ b/src/components/Table/Table.css.js
@@ -43,6 +43,22 @@ export const TableWrapperUI = styled('div')`
   .DropList__MenuList {
     max-height: 400px;
   }
+
+  .is-type-action {
+    height: 50px;
+    margin: 0 5px;
+    padding: 0 15px;
+    line-height: 50px;
+    color: ${getColor('charcoal.300')};
+
+    &.is-highlighted,
+    &:hover {
+      color: ${getColor('charcoal.300')};
+      text-decoration: underline;
+      cursor: pointer;
+      background-color: transparent;
+    }
+  }
 `
 
 export const LoadingUI = styled('div')`

--- a/src/components/Table/Table.test.js
+++ b/src/components/Table/Table.test.js
@@ -821,6 +821,14 @@ describe('Column Chooser', () => {
       label: 'Other',
       type: 'group',
     },
+    {
+      type: 'divider',
+    },
+    {
+      label: 'Reset to defaults',
+      type: 'action',
+      action: 'RESET',
+    },
   ]
 
   const plain_columns = COLUMNS_PARSED.reduce((acc, current) => {
@@ -868,14 +876,14 @@ describe('Column Chooser', () => {
     expect(container.querySelectorAll('.DropListItem').length).toBe(5)
 
     // Should add the reset item
-    expect(container.querySelectorAll('.is-reset-item').length).toBe(1)
-    expect(container.querySelector('.is-reset-item')).toHaveTextContent(
+    expect(container.querySelectorAll('.is-type-action').length).toBe(1)
+    expect(container.querySelector('.is-type-action')).toHaveTextContent(
       'Reset to defaults'
     )
 
     container.querySelectorAll('.DropListItem').forEach((item, index) => {
       if (
-        !item.classList.contains('is-reset-item') &&
+        !item.classList.contains('is-type-action') &&
         plain_columns[index].show
       ) {
         // If show is set to true in the columns, the item in the list should be selected
@@ -917,7 +925,7 @@ describe('Column Chooser', () => {
     ).toBe(2)
 
     // click the reset item, brings it back to the initial state
-    user.click(container.querySelector('.is-reset-item'))
+    user.click(container.querySelector('.is-type-action'))
 
     expect(
       container.querySelector('.c-Table__Row').querySelectorAll('td').length

--- a/src/components/Table/Table.utils.js
+++ b/src/components/Table/Table.utils.js
@@ -56,7 +56,7 @@ export function getDisplayTableData({ data, rowsToDisplay }) {
   return data
 }
 
-export function createColumnChooserListItems(columns) {
+export function createColumnChooserListItems(columns, columnChooserResetLabel) {
   const items = columns.reduce((acc, currentCol) => {
     const group = currentCol.group || 'Other'
     currentCol.label = currentCol.title
@@ -95,7 +95,7 @@ export function createColumnChooserListItems(columns) {
       type: 'divider',
     },
     {
-      label: 'Reset to defaults',
+      label: columnChooserResetLabel || 'Reset to defaults',
       type: 'action',
       action: 'RESET',
     },

--- a/src/components/Table/Table.utils.js
+++ b/src/components/Table/Table.utils.js
@@ -90,5 +90,14 @@ export function createColumnChooserListItems(columns) {
     return acc
   }, [])
 
-  return items
+  return items.concat([
+    {
+      type: 'divider',
+    },
+    {
+      label: 'Reset to defaults',
+      type: 'action',
+      action: 'RESET',
+    },
+  ])
 }


### PR DESCRIPTION
# Feature

https://helpscout.atlassian.net/browse/HSDS-205

To enable this [workflow](https://helpscout.atlassian.net/browse/HSAPPUI-137):

<img width="459" alt="Screen Shot 2021-09-07 at 2 21 56 PM" src="https://user-images.githubusercontent.com/1414086/132343662-07472090-1eac-46ae-b662-bc0db7fd8311.png">

When there are no items either on the initial mount of the DropList or when in combobox mode we filter down to 0 results.

➡️

We want to show "extra" items, that enables us to perform some action

## customEmptyListItems
For this, we add the new prop `customEmptyListItems` which accepts an array of items, any item that is accepted by DropList is valid here.

> `customEmptyList` still exists, this customizes the rendering of an empty list, use this if what you need is to display something static

```jsx
customEmptyListItems={[
  {
    label: 'No tags found',
    type: 'inert',
  },
  {
    type: 'divider',
  },
  {
    label: 'Create tag',
    type: 'action',
  },
]}
```

### Combobox feature

On a combobox, you can customize the label of your items with the value of the input by adding a `customizeLabel` function on the item

```jsx
customEmptyListItems={[
  {
    label: 'No tags found',
    type: 'inert',
  },
  {
    type: 'divider',
  },
  {
    label: 'Create tag',
    customizeLabel(inputValue) {
      return `Create ${inputValue} tag`
    },
    type: 'action',
  },
]}
```

## New item type: 'action'

Some times you need an item in the list that is not "selectable" but "actionable", add a type of `action`. To reiterate, these items:

1. Fire `onSelect`
2. Are interacted with like any other DropList item (ie with keyboard)
3. Do not get added to the selection, so `onSelect` will fire like `onSelect(null, clickedItem)`

## New item type: 'inert'

If you need an item that is just there and really doesn't do anything (like the "No tags Found" in the screenshot above), add an item with a type of `inert`. Technically similar to disabling an item, but with different semantics.


## Styles

Several class names are added to the items so you can target and style yourself if you need other than the default list item styles.

## Screenshots

### Variant select, no items

![CleanShot 2021-09-07 at 14 16 10](https://user-images.githubusercontent.com/1414086/132345148-bc7c8085-0fd7-46e8-9019-c44c63069100.gif)

### Variant Combobox, no items on mount

![CleanShot 2021-09-07 at 14 17 31](https://user-images.githubusercontent.com/1414086/132345237-67190dbe-5558-42b3-860e-65f2fc78e3e9.gif)

### Variant Combobox, filtered down to no items

![CleanShot 2021-09-07 at 14 16 50](https://user-images.githubusercontent.com/1414086/132345224-f65b8e33-0a2c-4f54-9af2-a8ca7f0adf26.gif)

## Reset item

With the addition of `action` items, there is no need for the reset functionality previously added as this can easily be implemented with these. The Table Column Chooser has been updated to use this workflow instead and the reset options and implementation have been removed from DropList.





