### PR TITLE
Allow to provide Error message to ActionSelect component

### DIFF
--- a/src/components/ActionSelect/ActionSelect.jsx
+++ b/src/components/ActionSelect/ActionSelect.jsx
@@ -130,6 +130,8 @@ export class ActionSelect extends React.PureComponent {
       shouldRefocusOnClose,
       disabled,
       id,
+      ariaLabel,
+      error,
     } = this.props
     const { isOpen, resizeCount, selection } = this.state
 
@@ -151,6 +153,8 @@ export class ActionSelect extends React.PureComponent {
                 text={getSelectTagText(selection, items)}
                 disabled={disabled}
                 id={id}
+                aria-label={ariaLabel || 'action toggle menu'}
+                error={error}
               />
             }
             selection={selection}
@@ -232,6 +236,10 @@ ActionSelect.propTypes = {
   disabled: PropTypes.bool,
   /** Id of the trigger element */
   id: PropTypes.string,
+  /** Aria Label of the Toggler */
+  ariaLabel: PropTypes.string,
+  /** Error message */
+  error: PropTypes.string,
 }
 
 export default ActionSelect

--- a/src/components/ActionSelect/ActionSelect.test.js
+++ b/src/components/ActionSelect/ActionSelect.test.js
@@ -47,6 +47,14 @@ describe('DropList', () => {
     await waitFor(() => expect(getByRole('button')).toBeDisabled())
   })
 
+  test('Marks droplist toggler with an error', async () => {
+    const { getByRole } = render(
+      <ActionSelect items={mockItems} error="Some error" />
+    )
+
+    await waitFor(() => expect(getByRole('button')).toHaveClass('is-error'))
+  })
+
   test('Provides ID to the toggler', async () => {
     const { getByRole } = render(<ActionSelect items={mockItems} id="123" />)
 


### PR DESCRIPTION
# Problem/Feature
Goal of this change is to allow to provide error message to the Action Select component, so that DropList is marked with an error state. Additionally, I've parameterized aria-label attribute.

There is no functionality change.

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
