### PR TITLE
Some tweaks on PopOver, Tooltip and DropList

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -36,6 +36,7 @@ function Combobox({
   items = [],
   isOpen = false,
   menuCSS,
+  menuWidth,
   onDropListLeave = noop,
   onMenuBlur = noop,
   onMenuFocus = noop,
@@ -184,8 +185,8 @@ function Combobox({
     <DropListWrapperUI
       className="DropList DropList__Combobox"
       data-cy={dataCy}
-      variant="combobox"
       menuCSS={menuCSS}
+      menuWidth={menuWidth}
       {...getComboboxProps()}
     >
       <InputSearchHolderUI show={allItems.length > 0}>

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -28,6 +28,7 @@ function Select({
   isOpen = false,
   items = [],
   menuCSS,
+  menuWidth,
   focusToggler = noop,
   onDropListLeave = noop,
   onMenuBlur = noop,
@@ -169,6 +170,7 @@ function Select({
       className="DropList DropList__Select"
       data-cy={dataCy}
       menuCSS={menuCSS}
+      menuWidth={menuWidth}
     >
       <A11yTogglerUI {...getToggleButtonProps()}>Toggler</A11yTogglerUI>
       <MenuListUI

--- a/src/components/DropList/DropList.css.js
+++ b/src/components/DropList/DropList.css.js
@@ -5,7 +5,7 @@ import Icon from '../Icon'
 
 export const DropListWrapperUI = styled('div')`
   box-sizing: border-box;
-  width: ${({ variant }) => (variant === 'combobox' ? '220px' : '200px')};
+  width: ${({ menuWidth }) => menuWidth};
   padding: 0;
   background-color: white;
   border: 1px solid ${getColor('grey.600')};

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -12,6 +12,7 @@ import {
   flattenListItems,
   getDropListVariant,
   getItemContentKeyName,
+  getMenuWidth,
   isItemAction,
   isItemRegular,
   isTogglerOfType,
@@ -47,6 +48,7 @@ function DropListManager({
   isMenuOpen = false,
   items = [],
   menuCSS,
+  menuWidth,
   onDropListLeave = noop,
   onMenuBlur = noop,
   onMenuFocus = noop,
@@ -286,6 +288,7 @@ function DropListManager({
             isOpen={isOpen}
             items={parsedItems}
             menuCSS={menuCSS}
+            menuWidth={getMenuWidth(DropListVariant.name, menuWidth)}
             onDropListLeave={onDropListLeave}
             onMenuBlur={onMenuBlur}
             onMenuFocus={onMenuFocus}
@@ -365,6 +368,8 @@ DropListManager.propTypes = {
   ),
   /** Custom css for the Menu */
   menuCSS: PropTypes.any,
+  /** Custom width for the Menu */
+  menuWidth: PropTypes.any,
   /** Callback that fires when the menu loses focus */
   onMenuBlur: PropTypes.func,
   /** Callback that fires when the menu gets focus */

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -4,7 +4,11 @@ import user from '@testing-library/user-event'
 import { css } from 'styled-components'
 import DropList from './DropList'
 import { SimpleButton, SelectTag, SplittedButton } from './DropList.togglers'
-import { flattenListItems, getEnabledItemIndex } from './DropList.utils'
+import {
+  flattenListItems,
+  getEnabledItemIndex,
+  getMenuWidth,
+} from './DropList.utils'
 import {
   itemsWithDivider,
   groupAndDividerItems,
@@ -1676,5 +1680,19 @@ describe('More open close behaviours', () => {
     await waitFor(() => {
       expect(onDropListLeaveSpy).toHaveBeenCalled()
     })
+  })
+})
+
+describe('getMenuWidth', () => {
+  test('should return select default width', () => {
+    expect(getMenuWidth('Select')).toBe('200px')
+  })
+
+  test('should return select default width', () => {
+    expect(getMenuWidth('Combobox')).toBe('220px')
+  })
+
+  test('should return custom width if provided', () => {
+    expect(getMenuWidth('Combobox', '400px')).toBe('400px')
   })
 })

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -319,3 +319,9 @@ export function checkNextElementFocusedAndThenRun(
     }
   }, timeout)
 }
+
+export function getMenuWidth(variant, menuWidth) {
+  if (menuWidth != null) return menuWidth
+
+  return variant.toLowerCase() === 'combobox' ? '220px' : '200px'
+}

--- a/src/components/Popover/Popover.css.js
+++ b/src/components/Popover/Popover.css.js
@@ -1,14 +1,11 @@
 import styled from 'styled-components'
 import { getColor } from '../../styles/utilities/color'
-import { getShadow } from '../../styles/utilities/shadow'
-
+import { d500 } from '../../styles/mixins/depth.css'
 import { ArrowUI, TooltipUI } from '../Tooltip/Tooltip.css'
-
 import Heading from '../Heading'
 
 export const config = {
   borderColor: getColor('grey.600'),
-  boxShadow: getShadow(100),
   padding: '15px',
   background: 'white',
 }
@@ -37,11 +34,8 @@ export const ArrowPopoverUI = styled(ArrowUI)`
     left: 0;
   }
 `
-
 export const PopoverUI = styled(TooltipUI)`
-  background: ${config.background};
-  border: 1px solid ${config.borderColor};
-  box-shadow: ${config.boxShadow};
+  ${d500}
   color: inherit;
   font-size: inherit;
   padding: ${config.padding};

--- a/src/components/Popover/Popover.jsx
+++ b/src/components/Popover/Popover.jsx
@@ -46,20 +46,19 @@ const PopoverHeader = ({ header, renderHeader }) => {
   return null
 }
 
-export const Popover = props => {
-  const {
-    arrowSize = 14,
-    innerRef = noop,
-    header,
-    renderHeader,
-    content,
-    renderContent,
-    className,
-    placement,
-    triggerOn = 'click',
-    withArrow = true,
-    ...rest
-  } = props
+export const Popover = ({
+  arrowSize = 14,
+  innerRef = noop,
+  header,
+  renderHeader,
+  content,
+  renderContent,
+  className,
+  placement,
+  triggerOn = 'click',
+  withArrow = true,
+  ...rest
+}) => {
   const render = ({ scope, ...tooltipProps }) => {
     const toolTipComponent = (
       <TooltipAnimationUI>

--- a/src/components/Popover/Popover.jsx
+++ b/src/components/Popover/Popover.jsx
@@ -48,15 +48,16 @@ const PopoverHeader = ({ header, renderHeader }) => {
 
 export const Popover = props => {
   const {
-    arrowSize,
-    innerRef,
+    arrowSize = 14,
+    innerRef = noop,
     header,
     renderHeader,
     content,
     renderContent,
     className,
     placement,
-    triggerOn,
+    triggerOn = 'click',
+    withArrow = true,
     ...rest
   } = props
   const render = ({ scope, ...tooltipProps }) => {
@@ -65,11 +66,13 @@ export const Popover = props => {
         <PopoverUI {...tooltipProps} data-cy="PopoverContent">
           <PopoverHeader header={header} renderHeader={renderHeader} />
           <PopoverContent content={content} renderContent={renderContent} />
-          <ArrowPopoverUI
-            className="ArrowPopoverUI"
-            arrowSize={arrowSize}
-            data-popper-arrow
-          />
+          {withArrow && (
+            <ArrowPopoverUI
+              className="ArrowPopoverUI"
+              arrowSize={arrowSize}
+              data-popper-arrow
+            />
+          )}
         </PopoverUI>
       </TooltipAnimationUI>
     )
@@ -89,13 +92,6 @@ export const Popover = props => {
   )
 }
 
-Popover.defaultProps = {
-  arrowSize: 14,
-  'data-cy': 'Popover',
-  innerRef: noop,
-  triggerOn: 'click',
-}
-
 Popover.propTypes = {
   /** Size of the "arrow" or "tip" for the popover */
   arrowSize: PropTypes.number,
@@ -103,6 +99,7 @@ Popover.propTypes = {
   className: PropTypes.string,
   /** Body content to render within the component. */
   content: PropTypes.any,
+  innerRef: PropTypes.func,
   /** Title content to render within the component. */
   header: PropTypes.any,
   /** Where to place the Tooltip. */
@@ -113,9 +110,8 @@ Popover.propTypes = {
   renderHeader: PropTypes.any,
   /** Determines how to engage the component. */
   triggerOn: PropTypes.string,
-  innerRef: PropTypes.func,
-  /** Data attr for Cypress tests. */
-  'data-cy': PropTypes.string,
+  /** Whether to render the arrow */
+  withArrow: PropTypes.bool,
 }
 
 export default Popover

--- a/src/components/Popover/Popover.stories.mdx
+++ b/src/components/Popover/Popover.stories.mdx
@@ -32,6 +32,7 @@ Tooltip is powered by [react-tippy](https://github.com/atomiks/tippyjs-react) an
         onOpen={action('onOpen')}
         onClose={action('onClose')}
         isOpen={boolean('isOpen', true)}
+        withArrow={boolean('withArrow', true)}
         triggerOn={select(
           'triggerOn',
           {

--- a/src/components/Popover/Popover.test.js
+++ b/src/components/Popover/Popover.test.js
@@ -29,6 +29,12 @@ describe('Tooltip', () => {
 
     expect(wrapper.find(ArrowPopoverUI).length).toBeTruthy()
   })
+
+  test('Does not render arrow', () => {
+    const wrapper = mount(<Popover content="Hello" withArrow={false} />)
+
+    expect(wrapper.find(ArrowPopoverUI).length).toBeFalsy()
+  })
 })
 
 describe('renderContent', () => {

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -67,6 +67,7 @@ const Tooltip = props => {
     title,
     triggerOn,
     withTriggerWrapper,
+    withArrow = true,
     zIndex: zIndexProp,
     ...rest
   } = props
@@ -125,11 +126,13 @@ const Tooltip = props => {
         <TooltipUI className={tooltipClassnames} {...props}>
           {renderContent ? renderContent() : titleContent}
           {hasKeyboardBadge ? <KeyboardBadge value={badge} /> : null}
-          <ArrowUI
-            className="c-Tooltip_ArrowUI"
-            arrowSize={arrowSize}
-            data-popper-arrow
-          />
+          {withArrow && (
+            <ArrowUI
+              className="c-Tooltip_ArrowUI"
+              arrowSize={arrowSize}
+              data-popper-arrow
+            />
+          )}
         </TooltipUI>
       </TooltipAnimationUI>
     )
@@ -280,6 +283,8 @@ Tooltip.propTypes = {
   visible: PropTypes.bool,
   /** Wrap the trigger with a span */
   withTriggerWrapper: PropTypes.bool,
+  /** Whether to render the arrow */
+  withArrow: PropTypes.bool,
 }
 
 export default Tooltip

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -44,34 +44,32 @@ const hideOnEsc = {
   },
 }
 
-const Tooltip = props => {
-  const {
-    animationDelay,
-    animationDuration,
-    arrowSize,
-    badge,
-    children,
-    className,
-    closeOnContentClick,
-    closeOnEscPress,
-    display,
-    'data-cy': dataCy,
-    getTippyInstance = () => {},
-    innerRef,
-    isOpen,
-    minWidth,
-    maxWidth,
-    placement,
-    render: renderProp,
-    renderContent,
-    title,
-    triggerOn,
-    withTriggerWrapper,
-    withArrow = true,
-    zIndex: zIndexProp,
-    ...rest
-  } = props
-
+const Tooltip = ({
+  animationDelay,
+  animationDuration,
+  arrowSize,
+  badge,
+  children,
+  className,
+  closeOnContentClick,
+  closeOnEscPress,
+  display,
+  'data-cy': dataCy,
+  getTippyInstance = () => {},
+  innerRef,
+  isOpen,
+  minWidth,
+  maxWidth,
+  placement,
+  render: renderProp,
+  renderContent,
+  title,
+  triggerOn,
+  withTriggerWrapper,
+  withArrow = true,
+  zIndex: zIndexProp,
+  ...rest
+}) => {
   const { getCurrentScope } = useContext(GlobalContext) || {}
   const { zIndex = zIndexProp, animationDuration: animationDurationContext } =
     useContext(TooltipContext) || {}
@@ -187,7 +185,7 @@ const Tooltip = props => {
   }
 
   // only set those props if the component is not in a controlled way
-  if (!props.hasOwnProperty('visible')) {
+  if (!rest.hasOwnProperty('visible')) {
     defaultTippyProps.showOnCreate = isOpen
     defaultTippyProps.trigger = triggerOn === 'hover' ? 'mouseenter' : triggerOn
   }

--- a/src/components/Tooltip/Tooltip.storiesHelpers.js
+++ b/src/components/Tooltip/Tooltip.storiesHelpers.js
@@ -45,6 +45,7 @@ export const Default = () => {
     title: text('title', '"Hello"'),
     minWidth: number('minWidth', ''),
     maxWidth: number('maxWidth', ''),
+    withArrow: boolean('withArrow', true),
   }
 
   return (

--- a/src/components/Tooltip/Tooltip.test.js
+++ b/src/components/Tooltip/Tooltip.test.js
@@ -6,6 +6,7 @@ import user from '@testing-library/user-event'
 import Tooltip, { TooltipContext } from './index'
 import Tippy from '@tippyjs/react/headless'
 import { act } from 'react-dom/test-utils'
+import { ArrowUI } from './Tooltip.css'
 
 describe('classNames', () => {
   test('Can accept custom className', () => {
@@ -126,6 +127,18 @@ describe('Tippy', () => {
     const pop = wrapper.find(Tippy).props()
     expect(pop.showOnCreate).toBeFalsy()
     expect(pop.trigger).toBeFalsy()
+  })
+
+  test('Renders arrow', () => {
+    const wrapper = mount(<Tooltip visible title="Hello" />)
+
+    expect(wrapper.find(ArrowUI).length).toBeTruthy()
+  })
+
+  test('Does not render arrow', () => {
+    const wrapper = mount(<Tooltip visible title="Hello" withArrow={false} />)
+
+    expect(wrapper.find(ArrowUI).length).toBeFalsy()
   })
 })
 


### PR DESCRIPTION
## PopOver and Tooltip

https://helpscout.atlassian.net/browse/HSDS-211

Adds the `withArrow` (default `true`) prop to be able to render without it.

PopOver's styles get update to use depth.500

<img width="143" alt="Screen Shot 2021-09-16 at 12 44 37 PM" src="https://user-images.githubusercontent.com/1414086/133604859-cc039bcc-7288-429a-8ad4-b2b066d97e89.png">

<img width="143" alt="Screen Shot 2021-09-16 at 12 49 26 PM" src="https://user-images.githubusercontent.com/1414086/133604866-6ddfc5a4-057b-41dd-bd26-c1c197d83c57.png">


## DropList

https://helpscout.atlassian.net/browse/HSDS-212

The initial desire of not deviating too much from the original design of the DropList menu made us make the choice of making it a bit difficult to customize some things, including the width of the menu.

I've noticed almost everywhere that is used, this is the first thing that gets overridden... 🙈

So might as well add the prop 🤷‍♀️

I introduce you `menuWidth`