### PR TITLE
HSDS-215: Add onchange prop for DropList combobox input

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -41,6 +41,7 @@ function Combobox({
   onMenuBlur = noop,
   onMenuFocus = noop,
   onListItemSelectEvent = noop,
+  onComboboxInputChange = noop,
   renderCustomListItem = null,
   selectedItem = null,
   selectedItems,
@@ -201,6 +202,9 @@ function Combobox({
                 ['DropListToggler'],
                 onDropListLeave
               )
+            },
+            onChange: event => {
+              onComboboxInputChange(event.target.value)
             },
             onFocus: event => {
               onMenuFocus(event)

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -52,6 +52,7 @@ function DropListManager({
   onDropListLeave = noop,
   onMenuBlur = noop,
   onMenuFocus = noop,
+  onComboboxInputChange = noop,
   onListItemSelectEvent = noop,
   onOpenedStateChange = noop,
   onSelect = noop,
@@ -293,6 +294,7 @@ function DropListManager({
             onMenuBlur={onMenuBlur}
             onMenuFocus={onMenuFocus}
             onListItemSelectEvent={onListItemSelectEvent}
+            onComboboxInputChange={onComboboxInputChange}
             renderCustomListItem={renderCustomListItem}
             selectedItem={selectedItem}
             selectedItems={selectedItems}
@@ -370,6 +372,8 @@ DropListManager.propTypes = {
   menuCSS: PropTypes.any,
   /** Custom width for the Menu */
   menuWidth: PropTypes.any,
+  /** Callback that fires when combobox search input changes */
+  onComboboxInputChange: PropTypes.func,
   /** Callback that fires when the menu loses focus */
   onMenuBlur: PropTypes.func,
   /** Callback that fires when the menu gets focus */

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -527,6 +527,42 @@ const groupedItems = [
   </Story>
 </Canvas>
 
+- If you need to have custom behavior based on combobox input, pass a callback to the `onComboboxInputChange` prop to receive changes
+
+<Canvas>
+  <Story name="Callback for keyboard events">
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        variant="combobox"
+        onComboboxInputChange={input => console.log(input)}
+        items={[]}
+        customEmptyListItems={[
+          {
+            label: 'No tags found',
+            type: 'inert',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            label: 'Create tag',
+            type: 'action',
+          },
+        ]}
+        toggler={<SimpleButton text="This is a select" />}
+      />
+    </div>
+  </Story>
+</Canvas>
+
 - On a combobox, you can customize the label of your items with the value of the input by adding a `customizeLabel` function on the item:
 
 ```js

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -528,6 +528,23 @@ describe('Combobox', () => {
     expect(getByPlaceholderText('Search')).toHaveFocus()
   })
 
+  test('should return input to onComboboxInputChange', () => {
+    const onComboboxInputChangeSpy = jest.fn()
+    const { getByPlaceholderText } = render(
+      <DropList
+        isMenuOpen
+        items={someItems}
+        toggler={<SimpleButton text="Button Toggler" />}
+        variant="combobox"
+        onComboboxInputChange={onComboboxInputChangeSpy}
+      />
+    )
+
+    user.type(getByPlaceholderText('Search'), 'Aoki')
+
+    expect(onComboboxInputChangeSpy).toHaveBeenCalledWith('Aoki')
+  })
+
   test('should hide the search input on combobox if list empty', () => {
     const { queryByRole, getByPlaceholderText } = render(
       <DropList


### PR DESCRIPTION
# Problem/Feature
[Jira](https://helpscout.atlassian.net/browse/HSDS-215)
Per @luketlancaster's comment [here](https://github.com/helpscout/hs-app-ui/pull/110#pullrequestreview-759920710-permalink), for the design requirement of this card, I need to make the DropList work so that if:
-if there's no text entered into the search input, we don't render the dropdown at all, _just the input_
-if there's text in the search input and there are matches, we render the matches
-if there's text in the search input and there are no matches, we render the custom empty list items

![ex](https://i.hlp.sc/lj6JS0/download)

I don't think I can accomplish that first requirement with the current DropList implementation because there's not a way to access the search input value. In order to do that, I would think that what's needed is a prop for DropList that passes down a callback for onChange events for the search input. I could then use that to hide the dropdown (using CSS) where there's no text in the search input. 

That's what I've PRed simply here—does that sound correct or is there another way you'd recommend approaching this?

## Guidelines

Make sure the pull request:

- [x] Follows the established folder/file structure
- [x] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [x] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [x] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [x] Add label (bug? feature?)
