### PR TITLE
HSDS-215: Add hideCustomListIfEmptyInput option to combobox DropList

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -233,7 +233,9 @@ function Combobox({
       <MenuListUI
         className={classNames(
           `${DROPLIST_MENULIST} MenuList-Combobox`,
-          hideCustomListIfEmptyInput && 'hideCustomListIfEmptyInput'
+          hideCustomListIfEmptyInput &&
+            !inputValue &&
+            'hideCustomListIfEmptyInput'
         )}
         {...getMenuProps()}
       >

--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -22,6 +22,7 @@ import {
 } from './DropList.css'
 import ListItem, { generateListItemKey } from './DropList.ListItem'
 import { DROPLIST_MENULIST, VARIANTS } from './DropList.constants'
+import classNames from 'classnames'
 
 function Combobox({
   clearOnSelect = false,
@@ -32,6 +33,7 @@ function Combobox({
   'data-cy': dataCy = `DropList.${VARIANTS.COMBOBOX}`,
   focusToggler = noop,
   handleSelectedItemChange = noop,
+  hideCustomListIfEmptyInput = false,
   inputPlaceholder = 'Search',
   items = [],
   isOpen = false,
@@ -229,11 +231,15 @@ function Combobox({
         />
       </InputSearchHolderUI>
       <MenuListUI
-        className={`${DROPLIST_MENULIST} MenuList-Combobox`}
+        className={classNames(
+          `${DROPLIST_MENULIST} MenuList-Combobox`,
+          hideCustomListIfEmptyInput && 'hideCustomListIfEmptyInput'
+        )}
         {...getMenuProps()}
       >
         {renderListContents({
           customEmptyList,
+          hideCustomListIfEmptyInput,
           inputValue,
           items: allItems,
           renderListItem,

--- a/src/components/DropList/DropList.css.js
+++ b/src/components/DropList/DropList.css.js
@@ -34,6 +34,10 @@ export const MenuListUI = styled('ul')`
     padding: 0 0 5px 0;
   }
 
+  &.MenuList-Combobox.hideCustomListIfEmptyInput {
+    padding: 0 0 0 0;
+  }
+
   &:focus {
     outline: 0;
   }

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -44,6 +44,7 @@ function DropListManager({
   enableLeftRightNavigation = false,
   focusTogglerOnMenuClose = true,
   getTippyInstance = noop,
+  hideCustomListIfEmptyInput = false,
   inputPlaceholder = 'Search',
   isMenuOpen = false,
   items = [],
@@ -284,6 +285,7 @@ function DropListManager({
             enableLeftRightNavigation={enableLeftRightNavigation}
             focusToggler={focusToggler}
             handleSelectedItemChange={handleSelectedItemChange}
+            hideCustomListIfEmptyInput={hideCustomListIfEmptyInput}
             inputPlaceholder={inputPlaceholder}
             isOpen={isOpen}
             items={parsedItems}
@@ -358,6 +360,8 @@ DropListManager.propTypes = {
   focusTogglerOnMenuClose: PropTypes.bool,
   /** Retrieves the tippy instance */
   getTippyInstance: PropTypes.any,
+  /** Don't render the list if using combobox variant and there's no input value*/
+  hideCustomListIfEmptyInput: PropTypes.bool,
   /** Customize the placeholder text on the combobox input */
   inputPlaceholder: PropTypes.string,
   /** Open/close the DropList externally */

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -586,6 +586,56 @@ const groupedItems = [
   </Story>
 </Canvas>
 
+- Sometimes on a combobox you might want to not render the list if there's no input value. You can use the `hideCustomListIfEmptyInput` prop for this.
+
+<Canvas>
+  <Story name="Hide list if no input value (Combobox)">
+    <div
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        hideCustomListIfEmptyInput={true}
+        variant="combobox"
+        items={select(
+          'Items',
+          {
+            empty: [],
+            full: regularItems,
+          },
+          regularItems
+        )}
+        customEmptyListItems={[
+          {
+            label: 'No tags found',
+            type: 'inert',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            label: 'Create tag',
+            customizeLabel(inputValue) {
+              return `Create ${inputValue} tag`
+            },
+            type: 'action',
+          },
+        ]}
+        onSelect={(selection, clickedItem) => {
+          console.log('🚀 ~ selection', selection)
+          console.log('🚀 ~ clickedItem', clickedItem)
+        }}
+        toggler={<SimpleButton text="This is a combobox" />}
+      />
+    </div>
+  </Story>
+</Canvas>
+
 #### Custom List Items
 
 Sometimes you might need to render the list items in a different manner, for that you can use the render prop `renderCustomListItem`.

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -267,6 +267,37 @@ describe('Render', () => {
     expect(container.querySelectorAll('.DropListItem').length).toBe(2)
   })
 
+  test('should not render custom list if hideCustomListIfEmptyInput is true and there is no input value', () => {
+    const { queryByText, getByPlaceholderText } = render(
+      <DropList
+        variant="combobox"
+        items={[]}
+        hideCustomListIfEmptyInput={true}
+        customEmptyListItems={[
+          {
+            label: 'No tags found',
+            type: 'inert',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            label: 'Create tag',
+            type: 'action',
+          },
+        ]}
+        isMenuOpen
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+
+    expect(queryByText('No tags found')).not.toBeInTheDocument()
+
+    user.type(getByPlaceholderText('Search'), 'Z')
+
+    expect(queryByText('No tags found')).toBeInTheDocument()
+  })
+
   test('should render a the empty menu list if no items in the array (invalid custom element)', () => {
     const { queryByText } = render(
       <DropList

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -193,11 +193,16 @@ export function flattenListItems(listItems) {
 
 export function renderListContents({
   customEmptyList,
+  hideCustomListIfEmptyInput,
   inputValue,
   items,
   renderListItem,
 }) {
   const isEmptyList = items.length === 0
+
+  if (hideCustomListIfEmptyInput && !inputValue) {
+    return null
+  }
 
   if (!isEmptyList) {
     return items.map(renderListItem)


### PR DESCRIPTION
# Problem/Feature

Re: @luketlancaster's comment [here](https://github.com/helpscout/hs-app-ui/pull/110#pullrequestreview-759920710-permalink), for the design requirement of this card, I need to make `DropList` work so that if:
-if there's no text entered into the search input, we don't render the dropdown at all, just the input
-if there's text in the search input and there are matches, we render the matches
-if there's text in the search input and there are no matches, we render the custom empty list items

The current `DropList` implementation doesn't provide the ability to meet requirement 1, so this adds a prop, `hideCustomListIfEmptyInput` to support that functionality. Pretty straightforward (thanks to helpful directions from @plbabin !). This is a second go at #982—per guidance in the comments [there](https://github.com/helpscout/hsds-react/pull/982#issuecomment-925246898).

There's a small CSS tweak that's added because `MenuListUI` usually has some extra padding on the bottom when the menu is rendered and that was still there without the items.

## Guidelines

Make sure the pull request:

- [x] Follows the established folder/file structure
- [x] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [x] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [x] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [x] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [x] Add label (bug? feature?)
