### PR TITLE
Upgrade colorway to 0.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,9 +2011,9 @@
       }
     },
     "@helpscout/colorway": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@helpscout/colorway/-/colorway-0.9.6.tgz",
-      "integrity": "sha512-JYQwyFbFiB2JchPAMhTXD+Od7b/fsiy2eJov7we4UlUoUqQwPJJ/cyPrM/xBq3YmfTKZxRlff428EKohZqvPMw==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@helpscout/colorway/-/colorway-0.9.7.tgz",
+      "integrity": "sha512-OCujSRhTek+YQcMRvW4hPqLDbwVpNwt8ickKbTxiaRenN2kNxFOm326h5uzhPVDwgG6plunarGRwLp6vfelhEQ==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,9 +2011,9 @@
       }
     },
     "@helpscout/colorway": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@helpscout/colorway/-/colorway-0.9.5.tgz",
-      "integrity": "sha512-tRik2m+8lpTWGIxFxQqScdjm+kSKkG+mjpHjPr2xaeNMa8WlXGJ441k3FKyuFCfJH6cMhsrGHGXNVj1B0i6eAA==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@helpscout/colorway/-/colorway-0.9.6.tgz",
+      "integrity": "sha512-JYQwyFbFiB2JchPAMhTXD+Od7b/fsiy2eJov7we4UlUoUqQwPJJ/cyPrM/xBq3YmfTKZxRlff428EKohZqvPMw==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@babel/plugin-transform-runtime": "^7.4.3",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@helpscout/colorway": "0.9.5",
+    "@helpscout/colorway": "0.9.6",
     "@helpscout/helix": "0.2.0",
     "@helpscout/prestart": "^0.0.9",
     "@storybook/addon-a11y": "6.3.4",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@babel/plugin-transform-runtime": "^7.4.3",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@helpscout/colorway": "0.9.6",
+    "@helpscout/colorway": "0.9.7",
     "@helpscout/helix": "0.2.0",
     "@helpscout/prestart": "^0.0.9",
     "@storybook/addon-a11y": "6.3.4",

--- a/src/styles/configs/colorway.js
+++ b/src/styles/configs/colorway.js
@@ -1,4 +1,4 @@
-// Generated with @helpscout/colorway (v0.9.5)
+// Generated with @helpscout/colorway (v0.9.6)
 //
 // This file was automatically generated with @helpscout/colorway
 // Please don't modify this file. Your changes will be overwritten.
@@ -48,6 +48,7 @@ const palette = {
     '700': '#E89635',
     '800': '#CE7129',
     '900': '#B24319',
+    '950': '#84142D',
     default: '#FFC555',
   },
   green: {
@@ -57,6 +58,7 @@ const palette = {
     '400': '#87DBAE',
     '500': '#56C288',
     '600': '#39AC6E',
+    '650': '#248451',
     '700': '#268C55',
     '800': '#106236',
     '900': '#003C1C',

--- a/src/styles/configs/colorway.js
+++ b/src/styles/configs/colorway.js
@@ -1,4 +1,4 @@
-// Generated with @helpscout/colorway (v0.9.6)
+// Generated with @helpscout/colorway (v0.9.7)
 //
 // This file was automatically generated with @helpscout/colorway
 // Please don't modify this file. Your changes will be overwritten.
@@ -58,8 +58,8 @@ const palette = {
     '400': '#87DBAE',
     '500': '#56C288',
     '600': '#39AC6E',
-    '650': '#248451',
     '700': '#268C55',
+    '750': '#248451',
     '800': '#106236',
     '900': '#003C1C',
     default: '#56C288',


### PR DESCRIPTION
This update adds two new color to the palette: `green.650` and `yellow.950`. We introduce those two blended shades to improves our accessibility effort across all application. They will be used to increase readability on a green or yellow background.

<img width="563" alt="CleanShot 2021-09-29 at 15 17 06@2x" src="https://user-images.githubusercontent.com/203992/135334254-f562530e-d27d-4012-81cc-a5c35d4a6784.png">
<img width="564" alt="CleanShot 2021-09-29 at 15 18 27@2x" src="https://user-images.githubusercontent.com/203992/135334365-5c897022-a3af-4352-9819-2423706f441a.png">

