### PR TITLE
AvatarRow: dynamic number of avatars

### DIFF
--- a/src/components/AvatarRow/AvatarRow.jsx
+++ b/src/components/AvatarRow/AvatarRow.jsx
@@ -27,8 +27,9 @@ function AvatarRow({
     avatarProps.size || 'md'
   ]
   const avatarRowRef = useRef(null)
+  const numberOfAvatars = avatars.length
   const [numberOfItemsOnDisplay, setNumberOfItemsOnDisplay] = useState(
-    avatars.length
+    numberOfAvatars
   )
 
   const throttledOnResize = !ieCompatible
@@ -54,7 +55,7 @@ function AvatarRow({
       resizeObserver.unobserve(avatarRowEl)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [numberOfAvatars])
 
   useEffect(() => {
     if (ieCompatible && adaptable) {
@@ -76,7 +77,7 @@ function AvatarRow({
         )
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [numberOfAvatars])
 
   function handleWindowResize() {
     if (avatarRowRef.current != null) {
@@ -88,7 +89,7 @@ function AvatarRow({
 
   function onResize({ width: containerWidth }) {
     /** Only act if we have more than 1 avatar */
-    if (!containerWidth || avatars.length <= 1) {
+    if (!containerWidth || numberOfAvatars <= 1) {
       return
     }
 
@@ -98,10 +99,10 @@ function AvatarRow({
      * Margin space: gap between avatars * the number of gaps. For example, for 3 avatars, there are 2 gaps => [AV]gap[AV]gap[AV]
      */
     const spaceForAllAvatars =
-      avatarSize * avatars.length + (avatars.length - 1) * gap
+      avatarSize * numberOfAvatars + (numberOfAvatars - 1) * gap
 
     if (containerWidth >= spaceForAllAvatars) {
-      setNumberOfItemsOnDisplay(avatars.length)
+      setNumberOfItemsOnDisplay(numberOfAvatars)
     } else {
       const numberOfGaps = numberOfItemsOnDisplay - 1
       const itemsThatFit = Math.floor(

--- a/src/components/AvatarRow/AvatarRow.jsx
+++ b/src/components/AvatarRow/AvatarRow.jsx
@@ -70,10 +70,6 @@ function AvatarRow({
     if (ieCompatible && adaptable) {
       // Avoid adding multiple resize events
       if (typeof windowResizeRef.current === 'function') {
-        console.log(
-          '🚀 ~ file: AvatarRow.jsx ~ line 73 ~ windowResizeRef.current',
-          windowResizeRef.current
-        )
         window.removeEventListener('resize', windowResizeRef.current)
       }
 

--- a/src/components/AvatarRow/AvatarRow.jsx
+++ b/src/components/AvatarRow/AvatarRow.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useCallback } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import throttle from 'lodash.throttle'
 import classNames from 'classnames'

--- a/src/components/AvatarRow/AvatarRow.jsx
+++ b/src/components/AvatarRow/AvatarRow.jsx
@@ -35,8 +35,6 @@ function AvatarRow({
     numberOfAvatars
   )
 
-  const throttledOnResize = throttle(onResize, throttleWait)
-
   useEffect(() => {
     if (!adaptable || avatarRowRef.current == null) return
 
@@ -50,7 +48,7 @@ function AvatarRow({
 
     const avatarRowEl = avatarRowRef.current
     const resizeObserver = setupObserver(
-      throttleOnResize ? throttledOnResize : onResize
+      throttleOnResize ? throttle(onResize, throttleWait) : onResize
     )
 
     observerRef.current = resizeObserver

--- a/src/components/AvatarRow/AvatarRow.jsx
+++ b/src/components/AvatarRow/AvatarRow.jsx
@@ -61,7 +61,7 @@ function AvatarRow({
     return () => {
       if (!adaptable || ieCompatible || avatarRowEl == null) return
 
-      resizeObserver.unobserve(avatarRowEl)
+      resizeObserver.disconnect()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [numberOfAvatars])

--- a/src/components/AvatarRow/AvatarRow.stories.mdx
+++ b/src/components/AvatarRow/AvatarRow.stories.mdx
@@ -123,7 +123,9 @@ By default the component will use a [ResizeObserver](https://caniuse.com/resizeo
 
 <Canvas>
   <Story name="Dynamic number of avatars">
-    <span>Resize the window</span>
+    <span>
+      Resize the window or the purple box dragging from its right border
+    </span>
     <br />
     <br />
     <AvatarRowPlayground />

--- a/src/components/AvatarRow/AvatarRow.stories.mdx
+++ b/src/components/AvatarRow/AvatarRow.stories.mdx
@@ -3,6 +3,7 @@ import { boolean, number, text, select } from '@storybook/addon-knobs'
 import AvatarRow from './AvatarRow'
 import { generateAvatarList } from '../../utilities/specs/avatar.specs'
 import { Resizable } from 're-resizable'
+import { AvatarRowPlayground } from './AvatarRow.utils'
 
 <Meta
   title="Components/Structural/AvatarRow"
@@ -137,5 +138,14 @@ Turning `ieCompatible` on, will use a resize event listener on the `window` inst
       gap={10}
       avatars={generateAvatarList(10, true)}
     />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="playground">
+    <span>Resize the window</span>
+    <br />
+    <br />
+    <AvatarRowPlayground />
   </Story>
 </Canvas>

--- a/src/components/AvatarRow/AvatarRow.stories.mdx
+++ b/src/components/AvatarRow/AvatarRow.stories.mdx
@@ -3,7 +3,7 @@ import { boolean, number, text, select } from '@storybook/addon-knobs'
 import AvatarRow from './AvatarRow'
 import { generateAvatarList } from '../../utilities/specs/avatar.specs'
 import { Resizable } from 're-resizable'
-import { AvatarRowPlayground } from './AvatarRow.utils'
+import { AvatarRowPlayground } from './AvatarRow.storiesHelpers'
 
 <Meta
   title="Components/Structural/AvatarRow"
@@ -77,12 +77,6 @@ Yes, you can make a bit of a mess if you wanted to (why would you though? why?),
 
 By default the component will use a [ResizeObserver](https://caniuse.com/resizeobserver) to calculate how many avatars to display and when. This works in all scenarios, whether the change in available width is due to resizing the window or anything else.
 
-The issue is that IE doesn't support, so if you need that IE compatibility...
-
-### Window resize event
-
-Turning `ieCompatible` on, will use a resize event listener on the `window` instead of the observer, what it means is that the adaptability of `AvatarRow` will only be triggered on the resize of the browser window, which is what you need most of the time anyways.
-
 <Canvas>
   <Story name="default">
     <span>
@@ -125,24 +119,10 @@ Turning `ieCompatible` on, will use a resize event listener on the `window` inst
 
 ## Stories
 
-#### IE compatibility
+#### Dynamic number of avatars
 
 <Canvas>
-  <Story name="IE compatible">
-    <span>Resize the window</span>
-    <br />
-    <br />
-    <AvatarRow
-      ieCompatible
-      size="lg"
-      gap={10}
-      avatars={generateAvatarList(10, true)}
-    />
-  </Story>
-</Canvas>
-
-<Canvas>
-  <Story name="playground">
+  <Story name="Dynamic number of avatars">
     <span>Resize the window</span>
     <br />
     <br />

--- a/src/components/AvatarRow/AvatarRow.storiesHelpers.js
+++ b/src/components/AvatarRow/AvatarRow.storiesHelpers.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import AvatarRow from './AvatarRow'
+import { generateAvatarList } from '../../utilities/specs/avatar.specs'
+import { Resizable } from 're-resizable'
+
+export const AvatarRowPlayground = () => {
+  const [avatars, setAvatars] = React.useState(generateAvatarList(3, true))
+
+  const handleClick = () => {
+    setAvatars([...avatars, ...generateAvatarList(1, true)])
+  }
+
+  return (
+    <>
+      <Resizable
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          outline: 'solid 1px #444cf770',
+          backgroundColor: '#e5e5f730',
+          backgroundImage: 'radial-gradient(#444cf770 0.5px, #e5e5f730 0.5px)',
+          backgroundSize: '10px 10px',
+        }}
+        defaultSize={{
+          width: '50%',
+          height: 200,
+        }}
+      >
+        <AvatarRow size="lg" gap={10} avatars={avatars} />
+      </Resizable>
+      <button onClick={handleClick}>increase avatar count</button>
+    </>
+  )
+}

--- a/src/components/AvatarRow/AvatarRow.storiesHelpers.js
+++ b/src/components/AvatarRow/AvatarRow.storiesHelpers.js
@@ -29,6 +29,8 @@ export const AvatarRowPlayground = () => {
       >
         <AvatarRow size="lg" gap={10} avatars={avatars} />
       </Resizable>
+      <br />
+      <br />
       <button onClick={handleClick}>increase avatar count</button>
     </>
   )

--- a/src/components/AvatarRow/AvatarRow.utils.js
+++ b/src/components/AvatarRow/AvatarRow.utils.js
@@ -1,7 +1,3 @@
-import React from 'react'
-import AvatarRow from './AvatarRow'
-import { generateAvatarList } from '../../utilities/specs/avatar.specs'
-import { Resizable } from 're-resizable'
 export const MARGIN_LEFT = 2
 
 export function splitAvatarsArray(avatars, itemsDisplayed) {
@@ -34,33 +30,34 @@ export function setupObserver(callback) {
   })
 }
 
-export const AvatarRowPlayground = () => {
-  const [avatars, setAvatars] = React.useState(generateAvatarList(3, true))
-
-  const handleClick = () => {
-    setAvatars([...avatars, ...generateAvatarList(1, true)])
+export function getNumberOfItemsToDisplay({
+  avatarSize,
+  containerWidth,
+  gap,
+  numberOfAvatars,
+  numberOfItemsOnDisplay,
+}) {
+  /** Only act if we have more than 1 avatar */
+  if (!containerWidth || numberOfAvatars <= 1) {
+    return
   }
 
-  return (
-    <>
-      <Resizable
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          outline: 'solid 1px #444cf770',
-          backgroundColor: '#e5e5f730',
-          backgroundImage: 'radial-gradient(#444cf770 0.5px, #e5e5f730 0.5px)',
-          backgroundSize: '10px 10px',
-        }}
-        defaultSize={{
-          width: '50%',
-          height: 200,
-        }}
-      >
-        <AvatarRow size="lg" gap={10} avatars={avatars} />
-      </Resizable>
-      <button onClick={handleClick}>increase avatar count</button>
-    </>
-  )
+  /** The total space for the avatars is comprised of:
+   * Avatar space: Number of avatars * the size of the avatar
+   * +
+   * Margin space: gap between avatars * the number of gaps. For example, for 3 avatars, there are 2 gaps => [AV]gap[AV]gap[AV]
+   */
+  const spaceForAllAvatars =
+    avatarSize * numberOfAvatars + (numberOfAvatars - 1) * gap
+
+  if (containerWidth >= spaceForAllAvatars) {
+    return numberOfAvatars
+  } else {
+    const numberOfGaps = numberOfItemsOnDisplay - 1
+    const itemsThatFit = Math.floor(
+      (containerWidth - numberOfGaps * gap) / avatarSize
+    )
+
+    return itemsThatFit > 0 ? itemsThatFit : 1
+  }
 }

--- a/src/components/AvatarRow/AvatarRow.utils.js
+++ b/src/components/AvatarRow/AvatarRow.utils.js
@@ -1,3 +1,7 @@
+import React from 'react'
+import AvatarRow from './AvatarRow'
+import { generateAvatarList } from '../../utilities/specs/avatar.specs'
+
 export const MARGIN_LEFT = 2
 
 export function splitAvatarsArray(avatars, itemsDisplayed) {
@@ -28,4 +32,19 @@ export function setupObserver(callback) {
       }
     }
   })
+}
+
+export const AvatarRowPlayground = () => {
+  const [avatars, setAvatars] = React.useState(generateAvatarList(10, true))
+
+  const handleClick = () => {
+    setAvatars([...avatars, ...generateAvatarList(1, true)])
+  }
+
+  return (
+    <div>
+      <AvatarRow size="lg" gap={10} avatars={avatars} />
+      <button onClick={handleClick}>increase avatar count</button>
+    </div>
+  )
 }

--- a/src/components/AvatarRow/AvatarRow.utils.js
+++ b/src/components/AvatarRow/AvatarRow.utils.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import AvatarRow from './AvatarRow'
 import { generateAvatarList } from '../../utilities/specs/avatar.specs'
-
+import { Resizable } from 're-resizable'
 export const MARGIN_LEFT = 2
 
 export function splitAvatarsArray(avatars, itemsDisplayed) {
@@ -35,16 +35,32 @@ export function setupObserver(callback) {
 }
 
 export const AvatarRowPlayground = () => {
-  const [avatars, setAvatars] = React.useState(generateAvatarList(10, true))
+  const [avatars, setAvatars] = React.useState(generateAvatarList(3, true))
 
   const handleClick = () => {
     setAvatars([...avatars, ...generateAvatarList(1, true)])
   }
 
   return (
-    <div>
-      <AvatarRow size="lg" gap={10} avatars={avatars} />
+    <>
+      <Resizable
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          outline: 'solid 1px #444cf770',
+          backgroundColor: '#e5e5f730',
+          backgroundImage: 'radial-gradient(#444cf770 0.5px, #e5e5f730 0.5px)',
+          backgroundSize: '10px 10px',
+        }}
+        defaultSize={{
+          width: '50%',
+          height: 200,
+        }}
+      >
+        <AvatarRow size="lg" gap={10} avatars={avatars} />
+      </Resizable>
       <button onClick={handleClick}>increase avatar count</button>
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## Problem

Adding or removing avatars is not supported. The ResizeObserver callback gets binded on mount and needs to be re-done if the number of avatars change.

## Solution

- Add the number of avatars to the useEffect hook so that the `onResize` gets updated if that number changes
- Make sure not to add multiple ResizeObservers by holding on to values with a `ref`

https://deploy-preview-986--hsds-react.netlify.app/?path=/story/components-structural-avatarrow--dynamic-number-of-avatars

### Other
- Remove ie compat mode, will re add if necessary
- Refactor the onResize fn to be able to test easily (jsdom does not support ResizeObserver)
