### PR TITLE
Fix portal trigger to not re-focus when unrelated props changed [BEMBED-305]

### DIFF
--- a/src/components/Modal/Modal.stories.mdx
+++ b/src/components/Modal/Modal.stories.mdx
@@ -8,7 +8,7 @@ import DropList from '../DropList'
 import { SimpleButton } from '../DropList/DropList.togglers'
 import EditableTextarea from '../EditableTextarea'
 import EditableField from '../EditableField'
-import { MyModal } from './Modal.storiesHelpers'
+import { ModalWithTriggerAndInput, MyModal } from './Modal.storiesHelpers'
 
 <Meta
   title="Components/Overlay/Modal"
@@ -228,5 +228,11 @@ There are components like `DropList`, `EditableField` and `EditableTextarea` tha
 <Canvas>
   <Story name="focusing element from content">
     <MyModal />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="modal trigger next to input">
+    <ModalWithTriggerAndInput />
   </Story>
 </Canvas>

--- a/src/components/Modal/Modal.storiesHelpers.js
+++ b/src/components/Modal/Modal.storiesHelpers.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Modal from './'
 
 export function MyModal() {
@@ -17,5 +17,25 @@ export function MyModal() {
         <input type="text" ref={inputRef} />
       </Modal.Body>
     </Modal>
+  )
+}
+
+export function ModalWithTriggerAndInput() {
+  const inputRef = React.useRef(null)
+  const [text, setText] = useState('')
+
+  return (
+    <>
+      <input onChange={e => setText(e.target.value)} value={text} />
+      <Modal
+        focusModalOnShow={false}
+        trigger={<button>Clicky</button>}
+        version={2}
+      >
+        <Modal.Body version={2}>
+          <input type="text" ref={inputRef} />
+        </Modal.Body>
+      </Modal>
+    </>
   )
 }

--- a/src/components/PortalWrapper/PortalWrapper.jsx
+++ b/src/components/PortalWrapper/PortalWrapper.jsx
@@ -129,8 +129,9 @@ const PortalWrapper = (options = defaultOptions) => ComposedComponent => {
       }
     }
 
-    componentDidUpdate() {
-      if (!this.state.isOpen) {
+    componentDidUpdate(prevProps, prevState, snapshot) {
+      // Only refocus if closed and was previously opened
+      if (!this.state.isOpen && prevState.isOpen) {
         this.refocusTriggerNode()
       }
     }

--- a/src/components/PortalWrapper/PortalWrapper.test.js
+++ b/src/components/PortalWrapper/PortalWrapper.test.js
@@ -24,6 +24,22 @@ const TestButton = props => {
   )
 }
 
+const TestCloseButton = props => {
+  const { className, children, closePortal } = props
+  const componentClassName = classNames('button', className, 'close-button')
+  const handleClick = () => {
+    closePortal()
+  }
+  return (
+    <div>
+      <button className={componentClassName} onClick={handleClick}>
+        Click
+      </button>
+      {children}
+    </div>
+  )
+}
+
 beforeEach(() => {
   window.HSDSPortalWrapperGlobalManager = undefined
 })
@@ -221,10 +237,42 @@ describe('Trigger', () => {
     const trigger = <button>Trigger</button>
     const wrapper = mount(<TestComponent timeout={0} trigger={trigger} />)
     const o = wrapper.find('button')
-    o.getDOMNode().onfocus = spy
+    o.getDOMNode().focus = spy
     wrapper.setProps({ isOpen: false })
+    wrapper.update()
 
     expect(spy).not.toHaveBeenCalled()
+  })
+
+  test('Does not focus triggerNode if prop remains false, but some other prop has changed', () => {
+    const spy = jest.fn()
+    const TestComponent = PortalWrapper(options)(TestButton)
+    const trigger = <button>Trigger</button>
+    const wrapper = mount(
+      <TestComponent timeout={0} trigger={trigger} isOpen={false} />
+    )
+    const o = wrapper.find('button')
+    o.getDOMNode().focus = spy
+    wrapper.setProps({ closeOnEscape: false })
+    wrapper.update()
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  test('Does focus triggerNode if prop is false, but was true', () => {
+    const spy = jest.fn()
+    const TestComponent = PortalWrapper(options)(TestCloseButton)
+    const trigger = <button className="trigger">Trigger</button>
+    const wrapper = mount(
+      <TestComponent timeout={0} trigger={trigger} isOpen={true} />
+    )
+    const closeButton = wrapper.find('.close-button')
+    const triggerButton = wrapper.find('.trigger')
+    triggerButton.getDOMNode().focus = spy
+    closeButton.prop('onClick')()
+    wrapper.update()
+
+    expect(spy).toHaveBeenCalled()
   })
 
   test('Allows for ref', () => {


### PR DESCRIPTION
# Problem/Feature
Relates to: https://helpscout.atlassian.net/browse/CTRIAGE-2697

There was a bug that trigger element of a Modal has be re-focused when `isOpen` state value is false and if any property has changed. This is causing some issues with a Beacon message form. Follow the steps to reproduce:

- Go to docs.helpscout.com and click the Contact Us button to open the Beacon
- Start typing a message into the main body text area
- Add an image attachment
- Try editing the message - as soon as you start typing, focus moves to the "1 file" button and you can't type any more

This happens because the button for files is a trigger and we don't have modal opened. The implementation was lacking a check if the portal has been opened before, so we re-trigger when it is closed. Adding the check solves the problem.

I have added a story that I have used to find the issue (for future reference) and fixed some tests that were not really checking anything (one was always success and 2 more are added based on the fixed version).


## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
