### PR TITLE
Allow component props to overwrite pagination attributes

### DIFF
--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -231,10 +231,10 @@ export const Pagination = props => {
 
   return (
     <PaginationUI
-      {...getValidProps(rest)}
       data-testid="Pagination"
       role="navigation"
       aria-label="Pagination Navigation"
+      {...getValidProps(rest)}
       className={componentClassName}
     >
       {renderCustomContent ? (


### PR DESCRIPTION
# Problem

While testing hs-app with the  refactored pagination, we realized that it was not possible to overwrite some props from the parent component.

This update move the location of `getValidProps` after `data-testid`, `role` and `aria-label`. That way the parent component will be able to change the value of those props _if needed_