### PR TITLE
Fix tag remove icon border-radius

### DIFF
--- a/src/components/Tag/Tag.css.js
+++ b/src/components/Tag/Tag.css.js
@@ -26,6 +26,7 @@ export const config = {
 export const RemoveTagUI = styled.button`
   ${focusRing}
 
+  border-radius: 3px;
   width: 16px;
   height: 16px;
   display: flex;


### PR DESCRIPTION
# Problem
An update on focusRing in another PR broke the border-radius on the tag remove icon, making it square. 

We added a border-radius value to the container element, that way the `focusRing` will be rounded with the same value as the parent.