### PR TITLE
HSAPPUI-310: Add onInputChange callback to DropList

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -41,6 +41,7 @@ function Combobox({
   onMenuBlur = noop,
   onMenuFocus = noop,
   onListItemSelectEvent = noop,
+  onInputChange = noop,
   renderCustomListItem = null,
   selectedItem = null,
   selectedItems,
@@ -204,6 +205,9 @@ function Combobox({
                 ['DropListToggler'],
                 onDropListLeave
               )
+            },
+            onChange: event => {
+              onInputChange(event.target.value)
             },
             onFocus: event => {
               onMenuFocus(event)

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -50,6 +50,7 @@ function DropListManager({
   menuCSS,
   menuWidth,
   onDropListLeave = noop,
+  onInputChange = noop,
   onMenuBlur = noop,
   onMenuFocus = noop,
   onListItemSelectEvent = noop,
@@ -290,6 +291,7 @@ function DropListManager({
             menuCSS={menuCSS}
             menuWidth={getMenuWidth(DropListVariant.name, menuWidth)}
             onDropListLeave={onDropListLeave}
+            onInputChange={onInputChange}
             onMenuBlur={onMenuBlur}
             onMenuFocus={onMenuFocus}
             onListItemSelectEvent={onListItemSelectEvent}
@@ -370,6 +372,8 @@ DropListManager.propTypes = {
   menuCSS: PropTypes.any,
   /** Custom width for the Menu */
   menuWidth: PropTypes.any,
+  /** Callback that fires when combobox search input changes */
+  onInputChange: PropTypes.func,
   /** Callback that fires when the menu loses focus */
   onMenuBlur: PropTypes.func,
   /** Callback that fires when the menu gets focus */

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -528,7 +528,7 @@ describe('Combobox', () => {
     expect(getByPlaceholderText('Search')).toHaveFocus()
   })
 
-  test('should return input to onComboboxInputChange', () => {
+  test('should return input to onInputChange', () => {
     const onInputChangeSpy = jest.fn()
     const { getByPlaceholderText } = render(
       <DropList

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -528,6 +528,22 @@ describe('Combobox', () => {
     expect(getByPlaceholderText('Search')).toHaveFocus()
   })
 
+  test('should return input to onComboboxInputChange', () => {
+    const onInputChangeSpy = jest.fn()
+    const { getByPlaceholderText } = render(
+      <DropList
+        isMenuOpen
+        items={someItems}
+        toggler={<SimpleButton text="Button Toggler" />}
+        variant="combobox"
+        onInputChange={onInputChangeSpy}
+      />
+    )
+
+    user.type(getByPlaceholderText('Search'), 'Aoki')
+
+    expect(onInputChangeSpy).toHaveBeenCalledWith('Aoki')
+  })
   test('should hide the search input on combobox if list empty', () => {
     const { queryByRole, getByPlaceholderText } = render(
       <DropList


### PR DESCRIPTION
# Problem/Feature

For the DropList used for the Tags menu in the convo redesign, we want to alter the elements displayed based on whether the search input has a value ([Jira](https://helpscout.atlassian.net/browse/HSAPPUI-303)). This PR adds an `onInputChange` callback to allow for that as recommended by @tinkertrain [here](https://github.com/helpscout/hs-app-ui/pull/192#issuecomment-964051693)

- [ ] A link to the Figma design in your story (list regularly updated [here](https://docs.google.com/spreadsheets/d/19-5gNbYuKjOb-kk7VTQZ0i_VWVd_8lubx-uhrlPUu1E/edit#gid=0))
- [ ] A link to the Story(ies) in the description
- [x] Is there a Jira ticket associated?
- [ ] If useful, add screenshots or videos
- [ ] If useful (and unclear), add a little explanation of why a certain path was taken
- [ ] Instructions on how to test
- [ ] Found any restrictions/limitations? Let us know!

## Guidelines

Make sure the pull request:

- [x] Follows the established folder/file structure
- [x] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [x] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [x] Add label (bug? feature?)
