### PR TITLE
Table: Updates styles to latest (header row)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9701,9 +9701,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001219",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz",
-      "integrity": "sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==",
+      "version": "1.0.30001279",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
       "dev": true
     },
     "capture-exit": {

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -66,10 +66,9 @@ const Icon = props => {
       className={componentClassName}
       onClick={onClick}
       data-icon-name={name}
+      title={iconTitle}
     >
-      <span className="c-Icon__icon" title={iconTitle}>
-        {IconComponent && <IconComponent />}
-      </span>
+      <span className="c-Icon__icon">{IconComponent && <IconComponent />}</span>
       {caretMarkup}
       {isWithHiddenTitle ? <VisuallyHidden>{iconTitle}</VisuallyHidden> : null}
     </IconUI>

--- a/src/components/Table/Table.Cell.jsx
+++ b/src/components/Table/Table.Cell.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import equal from 'fast-deep-equal'
 import get from 'lodash.get'
 import { isObject } from '../../utilities/is'
 import Truncate from '../Truncate'
@@ -69,12 +68,4 @@ TableCell.propTypes = {
   row: PropTypes.shape(dataShape),
 }
 
-function areEqual(prevProps, nextProps) {
-  if (equal(prevProps, nextProps)) {
-    return true
-  }
-
-  return false
-}
-
-export default React.memo(TableCell, areEqual)
+export default TableCell

--- a/src/components/Table/Table.HeaderCell.jsx
+++ b/src/components/Table/Table.HeaderCell.jsx
@@ -56,11 +56,11 @@ export default function HeaderCell({ column, columns, isLoading, sortedInfo }) {
             `${TABLE_CLASSNAME}__SortableHeaderCell`,
             columnSortStatus !== 'none' && 'sorted'
           )}
-          onClick={handleClick}
         >
           <SortableCellContentUI
             align={column.align}
             className={`${TABLE_CLASSNAME}__SortableHeaderCell__title`}
+            onClick={handleClick}
           >
             {withCustomContent ? (
               generateCustomHeaderCell(column, sortedInfo)

--- a/src/components/Table/Table.HeaderCell.jsx
+++ b/src/components/Table/Table.HeaderCell.jsx
@@ -14,7 +14,7 @@ import {
   generateCustomHeaderCell,
 } from './Table.utils'
 
-export default function HeaderCell({ column, columns, isLoading, sortedInfo }) {
+export default function HeaderCell({ column, isLoading, sortedInfo }) {
   function getColumnSortStatus() {
     const colKey = Array.isArray(column.columnKey)
       ? column.sortKey
@@ -98,8 +98,6 @@ export default function HeaderCell({ column, columns, isLoading, sortedInfo }) {
 HeaderCell.propTypes = {
   /** The column */
   column: PropTypes.shape(columnShape),
-  /** List of all columns */
-  columns: PropTypes.arrayOf(PropTypes.shape(columnShape)),
   /** Whether tha table is in the loading state */
   isLoading: PropTypes.bool,
   /** When sortable, indicates which column tha table is sorted by, and in which order (ascending or descending) */

--- a/src/components/Table/Table.HeaderCell.jsx
+++ b/src/components/Table/Table.HeaderCell.jsx
@@ -1,9 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 import Icon from '../Icon'
-import { SortableCellUI, HeaderCellUI } from './Table.css'
+import {
+  SortableCellUI,
+  SortableCellContentUI,
+  HeaderCellUI,
+} from './Table.css'
 import { TABLE_CLASSNAME } from './Table'
-import { columnShape, generateCellClassNames } from './Table.utils'
+import {
+  columnShape,
+  generateCellClassNames,
+  generateCustomHeaderCell,
+} from './Table.utils'
 
 export default function HeaderCell({ column, columns, isLoading, sortedInfo }) {
   function getColumnSortStatus() {
@@ -30,29 +39,43 @@ export default function HeaderCell({ column, columns, isLoading, sortedInfo }) {
   }
 
   function renderCellContents() {
-    if (column.renderHeaderCell) {
-      return column.renderHeaderCell(column, sortedInfo)
+    const withCustomContent = column.renderHeaderCell != null
+    const isSortable = column.sorter != null
+
+    if (withCustomContent && !isSortable) {
+      return generateCustomHeaderCell(column, sortedInfo)
     }
 
-    if (column.sorter) {
+    if (isSortable) {
       const columnSortStatus = getColumnSortStatus()
 
       return (
         <SortableCellUI
           align={column.align}
-          className={`${TABLE_CLASSNAME}__SortableHeaderCell`}
+          className={classNames(
+            `${TABLE_CLASSNAME}__SortableHeaderCell`,
+            columnSortStatus !== 'none' && 'sorted'
+          )}
           onClick={handleClick}
         >
-          <span className={`${TABLE_CLASSNAME}__SortableHeaderCell__title`}>
-            {column.title}
-          </span>
-          {columnSortStatus !== 'none' ? (
-            <Icon
-              name={
-                columnSortStatus === 'descending' ? 'caret-down' : 'caret-up'
-              }
-            />
-          ) : null}
+          <SortableCellContentUI
+            align={column.align}
+            className={`${TABLE_CLASSNAME}__SortableHeaderCell__title`}
+          >
+            {withCustomContent ? (
+              generateCustomHeaderCell(column, sortedInfo)
+            ) : (
+              <span>{column.title}</span>
+            )}
+            {columnSortStatus !== 'none' ? (
+              <Icon
+                name={
+                  columnSortStatus === 'descending' ? 'caret-down' : 'caret-up'
+                }
+                size={13}
+              />
+            ) : null}
+          </SortableCellContentUI>
         </SortableCellUI>
       )
     }

--- a/src/components/Table/Table.Row.jsx
+++ b/src/components/Table/Table.Row.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import equal from 'fast-deep-equal'
 import classNames from 'classnames'
 import { generateCellKey, columnShape, dataShape } from './Table.utils'
 import { TABLE_CLASSNAME } from './Table'

--- a/src/components/Table/Table.Row.jsx
+++ b/src/components/Table/Table.Row.jsx
@@ -115,16 +115,4 @@ TableRow.propTypes = {
   withSelectableRows: PropTypes.bool,
 }
 
-function areEqual(prevProps, nextProps) {
-  const { onRowClick, ...rest } = prevProps
-  const { onRowClick: onRowClickNext, ...restNext } = nextProps
-
-  if (equal(rest, restNext)) {
-    return true
-  }
-
-  return false
-}
-
-// export default React.memo(TableRow, areEqual)
 export default TableRow

--- a/src/components/Table/Table.css.js
+++ b/src/components/Table/Table.css.js
@@ -222,6 +222,7 @@ export const SortableCellUI = styled('div')`
   .is-iconName-caret-down,
   .is-iconName-caret-up {
     margin-left: 4px;
+    margin-right: -2px;
   }
 
   .column-title-as-icon + .is-iconName-caret-down,

--- a/src/components/Table/Table.css.js
+++ b/src/components/Table/Table.css.js
@@ -89,8 +89,8 @@ export const TableUI = styled('table')`
   }
 
   th {
-    padding: 8px 14px;
-    height: 24px;
+    padding: 0 14px;
+    height: ${props => props.theme.headerRowHeight};
     color: ${props => props.theme.fontColorHeader};
   }
 
@@ -210,6 +210,8 @@ export const TableUI = styled('table')`
 export const HeaderCellUI = styled('th')`
   text-align: ${props => props.align || 'left'};
   width: ${props => props.cellWidth || 'auto'};
+  font-size: 13px;
+  font-weight: 400;
 `
 
 export const CellUI = styled('td')`
@@ -217,19 +219,38 @@ export const CellUI = styled('td')`
 `
 
 export const SortableCellUI = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: ${props => getCellAlignment(props.align)};
-  cursor: pointer;
-
-  .SortableCell_title {
-    margin: -2px 5px 0 0;
+  .is-iconName-caret-down,
+  .is-iconName-caret-up {
+    margin-left: 4px;
   }
 
-  &:hover {
-    .SortableCell_title {
-      opacity: 0.8;
-    }
+  .column-title-as-icon + .is-iconName-caret-down,
+  .column-title-as-icon + .is-iconName-caret-up {
+    margin-left: 0;
+    margin-right: -2px;
+  }
+
+  .column-title-as-icon {
+    margin-left: -2px;
+    margin-top: -2px;
+    margin-bottom: -2px;
+  }
+`
+
+export const SortableCellContentUI = styled('div')`
+  display: inline-flex;
+  align-items: center;
+  justify-content: ${props => getCellAlignment(props.align)};
+  padding: 5px 8px;
+  margin-left: -8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out;
+
+  &:hover,
+  .sorted & {
+    color: ${getColor('charcoal.700')};
+    background-color: ${getColor('grey.300')};
   }
 `
 

--- a/src/components/Table/Table.css.js
+++ b/src/components/Table/Table.css.js
@@ -211,7 +211,7 @@ export const HeaderCellUI = styled('th')`
   text-align: ${props => props.align || 'left'};
   width: ${props => props.cellWidth || 'auto'};
   font-size: 13px;
-  font-weight: 400;
+  font-weight: 500;
 `
 
 export const CellUI = styled('td')`
@@ -232,8 +232,8 @@ export const SortableCellUI = styled('div')`
 
   .column-title-as-icon {
     margin-left: -2px;
-    margin-top: -2px;
-    margin-bottom: -2px;
+    margin-top: -4px;
+    margin-bottom: -4px;
   }
 `
 
@@ -241,7 +241,7 @@ export const SortableCellContentUI = styled('div')`
   display: inline-flex;
   align-items: center;
   justify-content: ${props => getCellAlignment(props.align)};
-  padding: 5px 8px;
+  padding: 6px 8px;
   margin-left: -8px;
   border-radius: 4px;
   cursor: pointer;

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -8,7 +8,7 @@ import Button from '../Button'
 import Scrollable from '../Scrollable'
 import { HeaderUI, TableWrapperUI, TableUI, LoadingUI } from './Table.css'
 import { defaultSkin, chooseSkin } from './Table.skins'
-import { columnShape, dataShape } from './Table.utils'
+import { columnShape, dataShape, isTableSortable } from './Table.utils'
 import { useTable } from './Table.hooks'
 import TableBody from './Table.Body'
 import TableHead from './Table.Head'
@@ -111,6 +111,7 @@ export function Table({
         className={classNames(
           `${TABLE_CLASSNAME}__Wrapper`,
           isCollapsed && 'is-collapsed',
+          isTableSortable(columns) && 'is-sortable',
           className
         )}
         containerWidth={containerWidth}
@@ -262,7 +263,7 @@ Table.propTypes = {
   ]),
   /** Customize which key from your data should be used for selection */
   selectionKey: PropTypes.string,
-  /** When sortable, indicates which column tha table is sorted by, and in which order (ascending or descending) */
+  /** When sortable, indicates which column the table is sorted by, and in which order (ascending or descending) */
   sortedInfo: PropTypes.shape({
     columnKey: PropTypes.string,
     order: PropTypes.string,

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -259,6 +259,11 @@ Table.propTypes = {
       borderTableHeader: PropTypes.string,
       borderRows: PropTypes.string,
       borderColumns: PropTypes.string,
+      bgFocus: PropTypes.string,
+      bgFocusIndicator: PropTypes.string,
+      bgSelected: PropTypes.string,
+      bgSelectedHover: PropTypes.string,
+      headerRowHeight: PropTypes.string,
     }),
   ]),
   /** Customize which key from your data should be used for selection */

--- a/src/components/Table/Table.skins.js
+++ b/src/components/Table/Table.skins.js
@@ -16,6 +16,7 @@ export const defaultSkin = {
   bgFocusIndicator: getColor('blue.500'),
   bgSelected: getColor('blue.100'),
   bgSelectedHover: getColor('blue.100'),
+  headerRowHeight: '48px',
 }
 
 export const alternativeSkin = {

--- a/src/components/Table/Table.test.js
+++ b/src/components/Table/Table.test.js
@@ -388,7 +388,7 @@ describe('Sortable', () => {
       'ascending'
     )
 
-    user.click(container.querySelector('thead th div'))
+    user.click(container.querySelector('.c-Table__SortableHeaderCell__title'))
 
     expect(regularColumnSpy).toHaveBeenCalled()
     expect(regularColumnSpy).toHaveBeenCalledWith(columns[0].columnKey)
@@ -404,7 +404,9 @@ describe('Sortable', () => {
     // Compound column sorting, should be called with 'sortKey'
     const customerHeaderCell = container.querySelectorAll('thead th')[1]
 
-    user.click(customerHeaderCell.querySelector('div'))
+    user.click(
+      customerHeaderCell.querySelector('.c-Table__SortableHeaderCell__title')
+    )
 
     expect(compoundColumnSpy).toHaveBeenCalled()
     expect(compoundColumnSpy).toHaveBeenCalledWith(columns[1].sortKey)

--- a/src/components/Table/Table.test.js
+++ b/src/components/Table/Table.test.js
@@ -106,6 +106,26 @@ describe('Table Header', () => {
     expect(nameHeaderCell.text()).toBe('Name')
   })
 
+  test('Icon Header cells', () => {
+    const { container } = render(
+      <Table
+        tableDescription="test-table"
+        columns={defaultColumnsCustomContent}
+        data={createFakeCustomers({ amount: 5 })}
+      />
+    )
+
+    const headerCellWithIcon = container.querySelector(
+      '.c-Table__HeaderCell.Column_Company'
+    )
+
+    expect(
+      headerCellWithIcon.querySelector(
+        '.c-Icon.is-iconName-chat.column-title-as-icon'
+      )
+    ).toBeInTheDocument()
+  })
+
   test('Custom cells', () => {
     const wrapper = mount(
       <Table
@@ -350,6 +370,7 @@ describe('Sortable', () => {
     expect(container.querySelector(`thead th`).getAttribute('aria-sort')).toBe(
       'none'
     )
+    expect(container.querySelector('.is-sortable')).toBeInTheDocument()
 
     rerender(
       <Table

--- a/src/components/Table/Table.testUtils.js
+++ b/src/components/Table/Table.testUtils.js
@@ -67,6 +67,7 @@ export const defaultColumnsCustomContent = [
   },
   {
     title: 'Company',
+    renderHeaderCell: { iconName: 'chat' },
     columnKey: 'companyName',
     width: '25%',
   },

--- a/src/components/Table/Table.utils.js
+++ b/src/components/Table/Table.utils.js
@@ -1,9 +1,15 @@
+import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { createUniqueIDFactory } from '../../utilities/id'
+import { isFunction, isObject } from '../../utilities/is'
 import { TABLE_CLASSNAME } from './Table'
+import Icon from '../Icon'
 
 const uniqueCellKeyFactory = createUniqueIDFactory('Cell')
+const renderHeaderCellObjectShape = {
+  iconName: PropTypes.string,
+}
 
 export const columnShape = {
   title: PropTypes.string,
@@ -14,7 +20,10 @@ export const columnShape = {
   width: PropTypes.string,
   align: PropTypes.string,
   renderCell: PropTypes.func,
-  renderHeaderCell: PropTypes.func,
+  renderHeaderCell: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape(renderHeaderCellObjectShape),
+  ]),
   sortKey: PropTypes.string,
   sorter: PropTypes.func,
   show: PropTypes.bool,
@@ -100,4 +109,34 @@ export function createColumnChooserListItems(columns, columnChooserResetLabel) {
       action: 'RESET',
     },
   ])
+}
+
+export function isTableSortable(columns) {
+  return (
+    Array.isArray(columns) && columns.find(column => Boolean(column.sorter))
+  )
+}
+
+export function generateCustomHeaderCell(column, sortedInfo) {
+  if (isFunction(column.renderHeaderCell)) {
+    return column.renderHeaderCell(column, sortedInfo)
+  }
+
+  if (isObject(column.renderHeaderCell)) {
+    const { iconName } = column.renderHeaderCell
+
+    return iconName ? (
+      <Icon
+        className="column-title-as-icon"
+        name={iconName}
+        size={20}
+        title={column.title}
+        ignoreClick={false}
+      />
+    ) : (
+      'Please pass iconName'
+    )
+  }
+
+  return null
 }

--- a/src/components/Table/Table.utils.js
+++ b/src/components/Table/Table.utils.js
@@ -129,7 +129,7 @@ export function generateCustomHeaderCell(column, sortedInfo) {
       <Icon
         className="column-title-as-icon"
         name={iconName}
-        size={20}
+        size={24}
         title={column.title}
         ignoreClick={false}
       />

--- a/src/components/Table/stories/Table.stories.mdx
+++ b/src/components/Table/stories/Table.stories.mdx
@@ -67,7 +67,9 @@ Full list of acceptable fields 👇:
 - `title`: The string that renders by default in the header for this column
 - `width`: Column width, ideally the sum of all the columns should be 100%
 - `align`: Horizontal cell alignment for this column, one of "left" (default), "center" or "right"
-- `renderHeaderCell`: To customize how to render the column header. A function that takes the column object and returns a React Component/Element
+- `renderHeaderCell`: To customize how to render the column header.
+  - A function that takes the column object and returns a React Component/Element
+  - If you need an icon, you can pass on object `{ iconName: 'chat' }` to get the `<Icon />` with the correct styles applied.
 - `renderCell`: To customize how each cell renders it corresponding data on this column. A function that takes the corresponding data and returns a React Component/Element, its arguments are the data provided by `columnKey` above, if using nested data, access it by replaceing the dot (`.`) with an underscore (`_`), for example: `customer.email` in `columnKey` becomes `customer_email` in `renderCell` (see code example below). It also gives you access to the `row`
 - `sorter`: A function that instructs how to sort the data based on this column
 - `sortKey`: If this column contains more than one columnKey, sorting will be based on this value which should exist in the list of Column Keys for this column.

--- a/src/components/Table/stories/TableWithSorting.js
+++ b/src/components/Table/stories/TableWithSorting.js
@@ -46,6 +46,7 @@ export default class TablePlayground extends Component {
           columnKey: 'companyName',
           align: 'center',
           width: '35%',
+          renderHeaderCell: { iconName: 'chat' },
           sorter: this.sortAlphabetically,
         },
       ],


### PR DESCRIPTION
Some updates to the styles have been requested, mostly regarding the Header Row:

![image](https://user-images.githubusercontent.com/1414086/141312617-b4a6a8f3-649f-408b-ad2c-13b21ae65053.png)

## Solution

Most of the changes will just happen but we did add a couple of convenience things:

1. `renderHeaderCell` has always been available to render icons (or whatever), since icons can be a common occurrence and to avoid each developer having to implement the right styles, you can now pass an object with a key `iconName`, and that's it:
```js
// example column
{
          title: 'Company',
          columnKey: 'companyName',
          align: 'center',
          width: '35%',
          renderHeaderCell: { iconName: 'chat' },
          sorter: this.sortAlphabetically,
},
```
2. Previously, if the table was sortable and `renderHeaderCell` was passed, the markup was incorrect, this is fixed now.
3. If the table is sortable, it gets the class name: `is-sortable` 
4. Removes the Table Cell memoization, as mentioned [here](https://github.com/helpscout/hs-app-ui/pull/191#discussion_r744992183)
5. The Icon title was not being displayed, moved it up a level in the markup

## Stories

The [`Table` stories](https://deploy-preview-999--hsds-react.netlify.app/?path=/story/components-structural-table--with-sorting) reflect the changes

## Screenshots

Icon header cell (hover):
<img width="316" alt="Screen Shot 2021-11-11 at 2 47 22 PM" src="https://user-images.githubusercontent.com/1414086/141312697-2ef67d75-3e63-4536-9b38-16728273f387.png">

Icon header cell (sorted):
<img width="316" alt="Screen Shot 2021-11-11 at 2 47 42 PM" src="https://user-images.githubusercontent.com/1414086/141312711-cea2808c-87f0-4485-86e0-24a15b462083.png">

Regular text header cell (hover):
<img width="316" alt="Screen Shot 2021-11-11 at 2 48 09 PM" src="https://user-images.githubusercontent.com/1414086/141312705-751da11b-f90b-4320-b1b0-0fd610a20087.png">

Regular text header cell (sorted):
<img width="316" alt="Screen Shot 2021-11-11 at 2 47 51 PM" src="https://user-images.githubusercontent.com/1414086/141312708-83334129-96be-41ce-9e69-a4c51b0b97ad.png">

Table with border on header row (normal height):
<img width="841" alt="Screen Shot 2021-11-11 at 2 48 21 PM" src="https://user-images.githubusercontent.com/1414086/141312700-f341c5fb-c6b6-40ce-b3d7-d640b32dfac6.png">

Custom header row height:
<img width="841" alt="Screen Shot 2021-11-11 at 2 49 00 PM" src="https://user-images.githubusercontent.com/1414086/141312693-bcd86b3f-51b3-4693-b6f9-a44476e76f90.png">