### PR TITLE
Improve accessibility for Condition Select element

### DIFF
--- a/src/components/Condition/Condition.jsx
+++ b/src/components/Condition/Condition.jsx
@@ -63,9 +63,12 @@ export class Condition extends React.PureComponent {
       onChange,
       value,
       noSelect,
+      ariaDescribedBy,
       ...rest
     } = this.props
 
+    const selectedItem = this.getSelectedItem(options, value)
+    const baseSelectLabel = 'conditions toggle menu'
     return (
       <ConditionUI
         {...getValidProps(rest)}
@@ -88,8 +91,17 @@ export class Condition extends React.PureComponent {
                 <DropList
                   onSelect={this.handleConditionSelect}
                   items={options}
-                  selection={this.getSelectedItem(options, value)}
-                  toggler={<SelectTag aria-label="conditions toggle menu" />}
+                  selection={selectedItem}
+                  toggler={
+                    <SelectTag
+                      a11yLabel={
+                        selectedItem
+                          ? `${baseSelectLabel}, ${selectedItem.label} currently selected`
+                          : baseSelectLabel
+                      }
+                      aria-describedby={ariaDescribedBy}
+                    />
+                  }
                 />
               )}
             </OptionsWrapperUI>
@@ -129,6 +141,8 @@ Condition.propTypes = {
   'data-cy': PropTypes.string,
   /** Flag indicating if should not render Select component */
   noSelect: PropTypes.bool,
+  /** ID of element used for aria-describedby attribute */
+  ariaDescribedBy: PropTypes.string,
 }
 
 export default Condition

--- a/src/components/Condition/Condition.test.js
+++ b/src/components/Condition/Condition.test.js
@@ -27,7 +27,9 @@ describe('DropList', () => {
     render(<Condition options={options} value="ron" />)
 
     expect(
-      screen.getByRole('button', { name: 'conditions toggle menu' })
+      screen.getByRole('button', {
+        name: 'conditions toggle menu, Ron currently selected',
+      })
     ).toHaveTextContent('Ron')
   })
 
@@ -39,7 +41,7 @@ describe('DropList', () => {
     const mock = jest.fn()
     render(<Condition options={options} value="ron" onChange={mock} />)
     userEvent.click(
-      screen.getByRole('button', { name: 'conditions toggle menu' })
+      screen.getByRole('button', { name: /conditions toggle menu/ })
     )
 
     await waitFor(() => expect(screen.getAllByRole('option').length).toBe(2))
@@ -55,7 +57,7 @@ describe('DropList', () => {
     render(<Condition options={options} value="brick" noSelect={true} />)
 
     expect(
-      screen.queryByRole('button', { name: 'conditions toggle menu' })
+      screen.queryByRole('button', { name: /conditions toggle menu/ })
     ).not.toBeInTheDocument()
   })
 
@@ -65,7 +67,19 @@ describe('DropList', () => {
     render(<Condition options={options} value="brick" noSelect={false} />)
 
     expect(
-      screen.getByRole('button', { name: 'conditions toggle menu' })
+      screen.getByRole('button', { name: /conditions toggle menu/ })
     ).toBeInTheDocument()
+  })
+
+  test('Allows to set aria-describedby for toggle menu', () => {
+    const options = [{ value: 'brick', label: 'Brick' }]
+
+    render(
+      <Condition options={options} value="brick" ariaDescribedBy="some-id" />
+    )
+
+    expect(
+      screen.getByRole('button', { name: /conditions toggle menu/ })
+    ).toHaveAttribute('aria-describedby', 'some-id')
   })
 })


### PR DESCRIPTION
# Problem/Feature
This PR improves aria-label attribute for Condition -> DropList SelectTag toggler, to add currently selected item.
Additionally, `ariaDescribedBy` property has been added to allow to set additional description for this field.

Both changes are necessary to fix accessibility issues in Messages app.

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
