### PR TITLE
SimpleModal layout: header and footer

### DIFF
--- a/src/components/ScrollableContainer/ScrollableContainer.css.js
+++ b/src/components/ScrollableContainer/ScrollableContainer.css.js
@@ -20,8 +20,8 @@ export const HeaderUI = styled(({ component, ref, ...props }) =>
   z-index: 3;
 `
 
-export const BodyUI = styled(({ component, ...props }) =>
-  React.cloneElement(component, props)
+export const BodyUI = styled(({ component, ref, ...props }) =>
+  React.cloneElement(component, { ref, ...props })
 )`
   width: 100%;
   flex-grow: 1;
@@ -32,8 +32,8 @@ export const SimpleBarUI = styled(SimpleBar)`
   height: ${({ height }) => height};
 `
 
-export const FooterUI = styled(({ component, ...props }) =>
-  React.cloneElement(component, props)
+export const FooterUI = styled(({ component, ref, ...props }) =>
+  React.cloneElement(component, { ref, ...props })
 )`
   width: 100%;
   transition: box-shadow 0.2s;

--- a/src/components/ScrollableContainer/ScrollableContainer.jsx
+++ b/src/components/ScrollableContainer/ScrollableContainer.jsx
@@ -36,35 +36,69 @@ function ScrollableContainer({
     withSimpleBar,
   })
 
-  function renderBody() {
-    if (body) {
-      if (withSimpleBar) {
-        const { children, className, ...rest } = body.props
+  function renderSection(section) {
+    let sectionContent
+    let SectionUI
+    let sectionRef
+
+    if (section === 'header') {
+      sectionContent = header
+      SectionUI = HeaderUI
+      sectionRef = headerRef
+    } else if (section === 'footer') {
+      sectionContent = footer
+      SectionUI = FooterUI
+      sectionRef = footerRef
+    } else if (section === 'body') {
+      sectionContent = body
+      SectionUI = BodyUI
+      sectionRef = bodyRef
+    }
+
+    if (sectionContent) {
+      if (React.isValidElement(sectionContent)) {
+        if (section === 'body' && withSimpleBar) {
+          const { children, className, ...rest } = body.props
+
+          return (
+            <SimpleBarUI
+              height={calculateSimpleBarHeight(height, headerRect, footerRect)}
+              onScroll={handleOnScroll}
+              scrollableNodeProps={{ ref: bodyRef }}
+              className={classNames('ScrollableContainer__body', className)}
+              {...rest}
+            >
+              {body}
+            </SimpleBarUI>
+          )
+        }
 
         return (
-          <SimpleBarUI
-            height={calculateSimpleBarHeight(height, headerRect, footerRect)}
-            onScroll={handleOnScroll}
-            scrollableNodeProps={{ ref: bodyRef }}
-            className={classNames('ScrollableContainer__Body', className)}
-            {...rest}
-          >
-            {body}
-          </SimpleBarUI>
+          <SectionUI
+            className={classNames(
+              `ScrollableContainer__${section}`,
+              sectionContent.props.className
+            )}
+            component={React.cloneElement(sectionContent, {
+              ...sectionContent.props,
+              ref: sectionRef,
+            })}
+            onScroll={section === 'body' ? handleOnScroll : null}
+          />
         )
       }
 
       return (
-        <BodyUI
-          className={classNames(
-            'ScrollableContainer__Body',
-            body.props.className
+        <SectionUI
+          className={classNames(`ScrollableContainer__${section}`)}
+          component={React.createElement(
+            'div',
+            {
+              ref: sectionRef,
+            },
+            [sectionContent]
           )}
-          component={React.cloneElement(body, {
-            ...body.props,
-            ref: bodyRef,
-          })}
-          onScroll={handleOnScroll}
+          onScroll={section === 'body' ? handleOnScroll : null}
         />
       )
     }
@@ -80,31 +114,9 @@ function ScrollableContainer({
       height={height}
       {...rest}
     >
-      {header ? (
-        <HeaderUI
-          className={classNames(
-            'ScrollableContainer__Header',
-            header.props.className
-          )}
-          component={React.cloneElement(header, {
-            ...header.props,
-            ref: headerRef,
-          })}
-        />
-      ) : null}
-      {renderBody()}
-      {footer ? (
-        <FooterUI
-          className={classNames(
-            'ScrollableContainer__Footer',
-            footer.props.className
-          )}
-          component={React.cloneElement(footer, {
-            ...footer.props,
-            ref: footerRef,
-          })}
-        />
-      ) : null}
+      {renderSection('header')}
+      {renderSection('body')}
+      {renderSection('footer')}
     </ContainerScrollUI>
   )
 }
@@ -132,16 +144,16 @@ ScrollableContainer.propTypes = {
   className: PropTypes.string,
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,
-  /** An element to render as the body (content), this is the one that gets scrolled */
-  body: PropTypes.element,
+  /** An element or content to render as the body (content), this is the one that gets scrolled */
+  body: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   /** If you're animating a component in, the scrollable element (body) might not have its height determined yet until that animation completes, pass a number in ms equal or larger to the length of the animation to account for this and give React time to get the size. */
   drawInitialShadowsDelay: PropTypes.number,
   /** If you want to use 'simplebar-react' in the body, turn this flag on */
   withSimpleBar: PropTypes.bool,
-  /** An element to render fixed at the top of the container */
-  header: PropTypes.element,
-  /** An element to render fixed at the bottom of the container */
-  footer: PropTypes.element,
+  /** An element or content to render fixed at the top of the container */
+  header: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  /** An element or content to render fixed at the bottom of the container */
+  footer: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   /** The container width, can also override with a styled component instead */
   width: PropTypes.string,
   /** The container height, can also override with a styled component instead */

--- a/src/components/ScrollableContainer/ScrollableContainer.jsx
+++ b/src/components/ScrollableContainer/ScrollableContainer.jsx
@@ -56,48 +56,40 @@ function ScrollableContainer({
     }
 
     if (sectionContent) {
-      if (React.isValidElement(sectionContent)) {
-        if (section === 'body' && withSimpleBar) {
-          const { children, className, ...rest } = body.props
-
-          return (
-            <SimpleBarUI
-              height={calculateSimpleBarHeight(height, headerRect, footerRect)}
-              onScroll={handleOnScroll}
-              scrollableNodeProps={{ ref: bodyRef }}
-              className={classNames('ScrollableContainer__body', className)}
-              {...rest}
-            >
-              {body}
-            </SimpleBarUI>
-          )
-        }
+      if (section === 'body' && withSimpleBar) {
+        const { children, className, ...rest } = body.props || {}
 
         return (
-          <SectionUI
-            className={classNames(
-              `ScrollableContainer__${section}`,
-              sectionContent.props.className
-            )}
-            component={React.cloneElement(sectionContent, {
-              ...sectionContent.props,
-              ref: sectionRef,
-            })}
-            onScroll={section === 'body' ? handleOnScroll : null}
-          />
+          <SimpleBarUI
+            height={calculateSimpleBarHeight(height, headerRect, footerRect)}
+            onScroll={handleOnScroll}
+            scrollableNodeProps={{ ref: bodyRef }}
+            className={classNames('ScrollableContainer__body', className)}
+            {...rest}
+          >
+            {body}
+          </SimpleBarUI>
         )
       }
 
-      return (
-        <SectionUI
-          className={classNames(`ScrollableContainer__${section}`)}
-          component={React.createElement(
+      const { children, className, ...rest } = sectionContent.props || {}
+      const component = React.isValidElement(sectionContent)
+        ? React.cloneElement(sectionContent, {
+            ...rest,
+            ref: sectionRef,
+          })
+        : React.createElement(
             'div',
             {
               ref: sectionRef,
             },
             [sectionContent]
-          )}
+          )
+
+      return (
+        <SectionUI
+          className={classNames(`ScrollableContainer__${section}`, className)}
+          component={component}
           onScroll={section === 'body' ? handleOnScroll : null}
         />
       )

--- a/src/components/ScrollableContainer/ScrollableContainer.test.js
+++ b/src/components/ScrollableContainer/ScrollableContainer.test.js
@@ -72,9 +72,9 @@ describe('renders', () => {
     )
 
     const containerScroll = container.querySelector('.c-ScrollableContainer')
-    const header = container.querySelector('.ScrollableContainer__Header')
-    const body = container.querySelector('.ScrollableContainer__Body')
-    const footer = container.querySelector('.ScrollableContainer__Footer')
+    const header = container.querySelector('.ScrollableContainer__header')
+    const body = container.querySelector('.ScrollableContainer__body')
+    const footer = container.querySelector('.ScrollableContainer__footer')
 
     // Elements present
     expect(containerScroll).toBeInTheDocument()
@@ -119,6 +119,57 @@ describe('renders', () => {
       'style',
       expect.stringContaining('--scroll-shadow')
     )
+  })
+
+  test('Should render with string sections', () => {
+    const { container } = render(
+      <ScrollableContainerUI
+        header="Header section"
+        body="Body section"
+        footer="Footer section"
+      />
+    )
+
+    const containerScroll = container.querySelector('.c-ScrollableContainer')
+    const header = container.querySelector('.ScrollableContainer__header')
+    const body = container.querySelector('.ScrollableContainer__body')
+    const footer = container.querySelector('.ScrollableContainer__footer')
+
+    // Elements present
+    expect(containerScroll).toBeInTheDocument()
+    expect(header).toBeInTheDocument()
+    expect(body).toBeInTheDocument()
+    expect(footer).toBeInTheDocument()
+    expect(header).toHaveTextContent('Header section')
+    expect(body).toHaveTextContent('Body section')
+    expect(footer).toHaveTextContent('Footer section')
+  })
+
+  test('Should render with string sections and simplebar', () => {
+    const { container } = render(
+      <ScrollableContainerUI
+        header="Header section"
+        body="Body section"
+        footer="Footer section"
+        withSimpleBar
+      />
+    )
+
+    const containerScroll = container.querySelector('.c-ScrollableContainer')
+    const header = container.querySelector('.ScrollableContainer__header')
+    const body = container.querySelector('.ScrollableContainer__body')
+    const footer = container.querySelector('.ScrollableContainer__footer')
+    const simplebar = container.querySelector('[data-simplebar]')
+
+    // Elements present
+    expect(simplebar).toBeInTheDocument()
+    expect(containerScroll).toBeInTheDocument()
+    expect(header).toBeInTheDocument()
+    expect(body).toBeInTheDocument()
+    expect(footer).toBeInTheDocument()
+    expect(header).toHaveTextContent('Header section')
+    expect(body).toHaveTextContent('Body section')
+    expect(footer).toHaveTextContent('Footer section')
   })
 
   test('Should work with simplebar', async () => {
@@ -187,9 +238,9 @@ describe('renders', () => {
     const containerScroll = container.querySelector('.c-ScrollableContainer')
     const simplebar = container.querySelector('[data-simplebar]')
     const scrollable = container.querySelector('.simplebar-content-wrapper')
-    const header = container.querySelector('.ScrollableContainer__Header')
-    const body = container.querySelector('.ScrollableContainer__Body')
-    const footer = container.querySelector('.ScrollableContainer__Footer')
+    const header = container.querySelector('.ScrollableContainer__header')
+    const body = container.querySelector('.ScrollableContainer__body')
+    const footer = container.querySelector('.ScrollableContainer__footer')
 
     // Elements present
     expect(simplebar).toBeInTheDocument()

--- a/src/components/SidePanel/SidePanel.layouts.jsx
+++ b/src/components/SidePanel/SidePanel.layouts.jsx
@@ -61,8 +61,6 @@ export function HeaderAndFooter({
 }
 
 HeaderAndFooter.propTypes = {
-  /** Custom classname on this component */
-  className: PropTypes.string,
   /** If the default footer is present, this is the label text for the button */
   mainActionButtonContent: PropTypes.oneOfType([
     PropTypes.string,

--- a/src/components/SidePanel/SidePanel.storiesHelpers.js
+++ b/src/components/SidePanel/SidePanel.storiesHelpers.js
@@ -84,6 +84,10 @@ const FakeMainUI = styled('main')`
   background-size: 10px 10px;
 `
 
+const SimpleModalUI = styled(SimpleModal)`
+  padding: 27px;
+`
+
 export default function SidePanelApp() {
   const [showPanel, setShowPanel] = useState(false)
   const [showModal, setShowModal] = useState(false)
@@ -162,7 +166,7 @@ export default function SidePanelApp() {
             >
               Step 3
             </FakeCardUI>
-            <SimpleModal
+            <SimpleModalUI
               show={showModal}
               zIndex={1000}
               onClose={() => setShowModal(false)}
@@ -174,7 +178,7 @@ export default function SidePanelApp() {
               <br />
               <br />
               <button>More Action!</button>
-            </SimpleModal>
+            </SimpleModalUI>
           </HeaderAndFooter>
         </SidePanel>
       </FakeMainUI>

--- a/src/components/SimpleModal/SimpleModal.css.js
+++ b/src/components/SimpleModal/SimpleModal.css.js
@@ -15,6 +15,7 @@ export const CloseModalButtonUI = styled('button')`
   height: 28px;
   width: 28px;
   background-color: ${getColor('grey.300')};
+  z-index: ${({ $zIndex }) => $zIndex};
 
   &:hover {
     color: ${getColor('charcoal.600')};
@@ -40,15 +41,14 @@ export const SimpleModalOverlayUI = styled('div')`
   bottom: 0;
   left: 0;
   background-color: ${rgba(getColor('blue.800'), 0.7)};
-  z-index: ${({ zIndex }) => zIndex};
+  z-index: ${({ $zIndex }) => $zIndex};
   ${overlayAnimation}
 `
 
 export const SimpleModalUI = styled('div')`
   position: relative;
-  width: 360px;
-  height: 390px;
-  padding: 27px;
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -16,14 +16,18 @@ function SimpleModal({
   ariaLabelledBy = '',
   children,
   className,
+  customCloseButton,
   closeOnClickOutside = false,
   'data-cy': dataCy = 'SimpleModal',
   focusModalOnShow = true,
   onClose = noop,
   show = false,
   trapFocus = true,
+  width = '360px',
+  height = '390px',
   withCloseButton = true,
   zIndex = 999,
+  zIndexCloseButton = 5,
   ...rest
 }) {
   const modalRef = useRef(null)
@@ -58,6 +62,29 @@ function SimpleModal({
     }
   }
 
+  function renderCloseButton() {
+    if (withCloseButton) {
+      if (customCloseButton && React.isValidElement(customCloseButton)) {
+        const clickHandler = customCloseButton.props.onClick || onClose
+        return React.cloneElement(customCloseButton, {
+          onClick: clickHandler,
+        })
+      }
+      return (
+        <CloseModalButtonUI
+          aria-label="close modal button"
+          className="SimpleModal__CloseButton"
+          onClick={onClose}
+          $zIndex={zIndexCloseButton}
+        >
+          <Icon size={18} name="cross" />
+        </CloseModalButtonUI>
+      )
+    }
+
+    return null
+  }
+
   return shouldRender ? (
     <SimpleModalOverlayUI
       className={classNames(
@@ -69,7 +96,7 @@ function SimpleModal({
       onAnimationEnd={onAnimationEnd}
       onKeyDown={handleOverlayKeyDown}
       ref={overlayRef}
-      zIndex={zIndex}
+      $zIndex={zIndex}
     >
       <SimpleModalUI
         aria-modal="true"
@@ -80,18 +107,12 @@ function SimpleModal({
         id="simple-modal"
         role="dialog"
         ref={modalRef}
+        height={height}
+        width={width}
         tabIndex="0"
         {...rest}
       >
-        {withCloseButton ? (
-          <CloseModalButtonUI
-            aria-label="close modal button"
-            className="SimpleModal__CloseButton"
-            onClick={onClose}
-          >
-            <Icon size={18} name="cross" />
-          </CloseModalButtonUI>
-        ) : null}
+        {renderCloseButton()}
         {children}
       </SimpleModalUI>
     </SimpleModalOverlayUI>
@@ -105,22 +126,30 @@ SimpleModal.propTypes = {
   children: PropTypes.any,
   /** Custom classname on this component */
   className: PropTypes.string,
+  /** Pass your own close button, don't forget to style it and position it. Your `onClose` handler will be attached to it automatically, or you can add your own click handler directly on it */
+  customCloseButton: PropTypes.element,
   /** Whether to close the Modal when clicking outside, pass a string with value "modal" if clicking ouside the Modal, or "overlay" if clicking outside the overlay should close it (in case of "contained modals") */
   closeOnClickOutside: PropTypes.oneOf([null, undefined, 'modal', 'overlay']),
   /** Data attr applied for Cypress tests */
   'data-cy': PropTypes.string,
   /** If you don't want the focus to be moved to the Modal when it enters */
   focusModalOnShow: PropTypes.bool,
+  /** Customize the modal's height */
+  height: PropTypes.string,
   /** Function that gets called when clicking the `x` button and when pressing `esc`, use this to close the modal in your app */
   onClose: PropTypes.func,
   /** Control whether the modal is open or close */
   show: PropTypes.bool,
   /** Whether to restrict focus to elements inside the modal */
   trapFocus: PropTypes.bool,
+  /** Customize the modal's width */
+  width: PropTypes.string,
   /** Whether to include a close button */
   withCloseButton: PropTypes.bool,
-  /** Customize the z-index */
+  /** Customize the z-index for the modal */
   zIndex: PropTypes.number,
+  /** Customize the z-index specifically for the close modal button */
+  zIndexCloseButton: PropTypes.number,
 }
 
 export default SimpleModal

--- a/src/components/SimpleModal/SimpleModal.layouts.css.js
+++ b/src/components/SimpleModal/SimpleModal.layouts.css.js
@@ -1,0 +1,35 @@
+import styled from 'styled-components'
+import { getColor } from '../../styles/utilities/color'
+
+export const HeaderUI = styled('header')`
+  height: 58px;
+  padding: 0 30px;
+  background-color: #fff;
+  border-radius: 4px 4px 0 0;
+  flex-shrink: 0;
+
+  &:not(.with-custom-header-content) {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+  }
+
+  h1 {
+    margin: 0;
+    font-weight: 500;
+    font-size: 16px;
+    color: ${getColor('charcoal.800')};
+  }
+`
+
+export const BodyUI = styled('div')`
+  padding: 40px 90px;
+`
+
+export const FooterUI = styled('footer')`
+  height: 80px;
+  padding: 0 30px;
+  background-color: #f7f9fc;
+  border-radius: 0 0 4px 4px;
+  flex-shrink: 0;
+`

--- a/src/components/SimpleModal/SimpleModal.layouts.jsx
+++ b/src/components/SimpleModal/SimpleModal.layouts.jsx
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'

--- a/src/components/SimpleModal/SimpleModal.layouts.jsx
+++ b/src/components/SimpleModal/SimpleModal.layouts.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import ScrollableContainer from '../ScrollableContainer'
 import { BodyUI, HeaderUI, FooterUI } from './SimpleModal.layouts.css'
@@ -33,4 +34,15 @@ export function HeaderAndFooter({
       {...rest}
     />
   )
+}
+
+HeaderAndFooter.propTypes = {
+  /** The content to put in the body of the modal*/
+  children: PropTypes.any,
+  /** Custom footer content */
+  footer: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** If you just need a modal title in the header, use this */
+  heading: PropTypes.string,
+  /** Custom header content */
+  header: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 }

--- a/src/components/SimpleModal/SimpleModal.layouts.jsx
+++ b/src/components/SimpleModal/SimpleModal.layouts.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import classNames from 'classnames'
+import ScrollableContainer from '../ScrollableContainer'
+import { BodyUI, HeaderUI, FooterUI } from './SimpleModal.layouts.css'
+
+export function HeaderAndFooter({
+  children,
+  heading,
+  header,
+  footer,
+  ...rest
+}) {
+  return (
+    <ScrollableContainer
+      width="100%"
+      height="100%"
+      header={
+        <HeaderUI
+          className={classNames(
+            'SimpleModal__header',
+            header && 'with-custom-header-content'
+          )}
+        >
+          {header ? header : <h1>{heading}</h1>}
+        </HeaderUI>
+      }
+      body={<BodyUI className="SimpleModal__body">{children}</BodyUI>}
+      footer={
+        footer ? (
+          <FooterUI className={'SimpleModal__footer'}>{footer}</FooterUI>
+        ) : null
+      }
+      {...rest}
+    />
+  )
+}

--- a/src/components/SimpleModal/SimpleModal.stories.mdx
+++ b/src/components/SimpleModal/SimpleModal.stories.mdx
@@ -1,6 +1,8 @@
 import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs/blocks'
 import { boolean, number, text, select } from '@storybook/addon-knobs'
 import SimpleModal from './SimpleModal'
+import Button from '../Button'
+import { HeaderAndFooter } from './SimpleModal.layouts'
 
 <Meta
   title="Components/Overlay/SimpleModal"
@@ -74,3 +76,86 @@ function SommeApp() {
 ### Props
 
 <ArgsTable of={SimpleModal} />
+
+## Stories
+
+### Custom close button
+
+If you need a different button, pass your own. The click handler will be attached automatically with whatever you pass to `onClose` or you can add a different handler by attaching it directly on your button.
+
+Don't forget to add styles to position it yourself.
+
+<Canvas>
+  <Story name="custom close button">
+    <div style={{ position: 'relative', height: '450px' }}>
+      <SimpleModal
+        show
+        focusModalOnShow={false}
+        customCloseButton={
+          <button
+            onClick={() => {
+              console.log('close it')
+            }}
+          >
+            close
+          </button>
+        }
+      >
+        My modal with a custom button
+      </SimpleModal>
+    </div>
+  </Story>
+</Canvas>
+
+### Layouts
+
+<Canvas>
+  <Story name="header and footer">
+    <div style={{ position: 'relative', height: '650px' }}>
+      <SimpleModal show focusModalOnShow={false} width="700px">
+        <HeaderAndFooter
+          withSimpleBar
+          heading="Modal title"
+          footer={
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                height: '100%',
+              }}
+            >
+              <Button kind="primary">Action!</Button>
+            </div>
+          }
+        >
+          <p>
+            Tempor Lorem consectetur non ut magna excepteur. Veniam veniam
+            eiusmod elit ullamco commodo laboris eiusmod quis enim eiusmod id.
+            Nisi eiusmod aute pariatur et non.
+          </p>
+          <p>
+            Tempor Lorem consectetur non ut magna excepteur. Veniam veniam
+            eiusmod elit ullamco commodo laboris eiusmod quis enim eiusmod id.
+            Nisi eiusmod aute pariatur et non.
+          </p>
+          <p>
+            Tempor Lorem consectetur non ut magna excepteur. Veniam veniam
+            eiusmod elit ullamco commodo laboris eiusmod quis enim eiusmod id.
+            Nisi eiusmod aute pariatur et non.
+          </p>
+          <p>
+            Tempor Lorem consectetur non ut magna excepteur. Veniam veniam
+            eiusmod elit ullamco commodo laboris eiusmod quis enim eiusmod id.
+            Nisi eiusmod aute pariatur et non.
+          </p>
+          <p>
+            Tempor Lorem consectetur non ut magna excepteur. Veniam veniam
+            eiusmod elit ullamco commodo laboris eiusmod quis enim eiusmod id.
+            Nisi eiusmod aute pariatur et non.
+          </p>
+        </HeaderAndFooter>
+      </SimpleModal>
+    </div>
+  </Story>
+</Canvas>


### PR DESCRIPTION
In order to start using `SimpleModal` instead of `Modal` we create the first layout: "HeaderAndFooter". The pattern is the same as what we started with `SidePanel`, instead of adding several props to get a spedific modal type, we provide some ready-to-use components to drop inside the modal.

In this PR we add one of the most commonly used layouts, the one that has:

1. A fixed at the top header
2. A scrollable body
3. A fixed at the bottom footer

Like this one:
<img width="957" alt="Screen Shot 2021-11-22 at 4 06 28 PM" src="https://user-images.githubusercontent.com/1414086/142885209-1541df46-37c7-4a30-a758-765b831d30b4.png">

Usage is better explained with some code:

```jsx
import SimpleModal from '@helpscout/hsds-react/SimpleModal'
import Button from '../Button'
import { HeaderAndFooter } from '@helpscout/hsds-react/SimpleModal/SimpleModal.layouts'

<SimpleModal>
        <HeaderAndFooter
          withSimpleBar // all `ScrollableContainer` props are accepted in this layout
          heading="Modal title"
          footer={
            <div
              style={{
                display: 'flex',
                flexDirection: 'column',
                justifyContent: 'center',
                height: '100%',
              }}
            >
              <Button kind="primary">Action!</Button>
            </div>
          }
        >
          <p>
            Tempor Lorem consectetur non ut magna excepteur. Veniam veniam
            eiusmod elit ullamco commodo laboris eiusmod quis enim eiusmod id.
            Nisi eiusmod aute pariatur et non.
          </p>
          <p>
            Tempor Lorem consectetur non ut magna excepteur. Veniam veniam
            eiusmod elit ullamco commodo laboris eiusmod quis enim eiusmod id.
            Nisi eiusmod aute pariatur et non.
          </p>
        </HeaderAndFooter>
      </SimpleModal>
```

To produce this:

<img width="757" alt="Screen Shot 2021-11-22 at 4 10 12 PM" src="https://user-images.githubusercontent.com/1414086/142885648-edc3a210-365d-416b-9fcc-3cb541f7abf2.png">

