### PR TITLE
trapped focus and ChoiceGroup fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5596,9 +5596,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.12.0.tgz",
-      "integrity": "sha512-N9Y82b2Z3j6wzIoAqajlKVF1Zt7sOH0pPee0sUHXHc5cv2Fdn23r+vpWm0MBBoGJtPOly5+Bdx1lnc3CD+A+ow==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.15.1.tgz",
+      "integrity": "sha512-kmj8opVDRE1E4GXyLlESsQthCXK7An28dFWxhiMwD7ZUI7ZxA6sjdJRxLerD9Jd8cHX4BDc1jzXaaZKqzlUkvg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
@@ -5607,6 +5607,7 @@
         "chalk": "^3.0.0",
         "css": "^3.0.0",
         "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
         "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
@@ -5643,6 +5644,12 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "dom-accessibility-api": {
+          "version": "0.5.10",
+          "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+          "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
           "dev": true
         },
         "has-flag": {
@@ -6139,9 +6146,9 @@
       "dev": true
     },
     "@types/testing-library__jest-dom": {
-      "version": "5.9.5",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
-      "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz",
+      "integrity": "sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==",
       "dev": true,
       "requires": {
         "@types/jest": "*"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@storybook/cli": "6.3.12",
     "@storybook/react": "6.3.12",
     "@storybook/theming": "6.3.12",
-    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/jest-dom": "5.15.1",
     "@testing-library/react": "^11.0.4",
     "@testing-library/react-hooks": "^7.0.2",
     "@testing-library/user-event": "^12.1.5",

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -159,7 +159,7 @@ const CheckMarkCard = props => {
         <Mark cardChecked={cardChecked} {...markProps} />
         {shouldShowAvatar && (
           <AvatarWrapperUI>
-            <Avatar size="xl" image={avatar} name={label} />
+            <Avatar size="xl" image={avatar} name={label} aria-hidden />
           </AvatarWrapperUI>
         )}
         {shouldDisplayHeading && <HeadingUI>{heading || label}</HeadingUI>}
@@ -172,7 +172,6 @@ const CheckMarkCard = props => {
           disabled={disabled || shouldShowStatus}
           id={id}
           inputRef={setInputNodeRef}
-          label={label || valueProp}
           onBlur={handleOnBlur}
           onFocus={handleOnFocus}
           onChange={handleOnChange}

--- a/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
+++ b/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
@@ -80,6 +80,7 @@ This component provides richer context to the of the default HTML `<input>` of t
       onChange={value => {
         console.log(`onChange(selectedValue: ${value.toString()})`)
       }}
+      multiSelect={boolean('multiSelect', true)}
     >
       <CheckMarkCard
         label="Derek"

--- a/src/components/CheckMarkCard/CheckMarkCard.test.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.test.js
@@ -5,6 +5,7 @@ import Checkbox from '../Checkbox'
 import Icon from '../Icon'
 import Tooltip from '../Tooltip'
 import VisuallyHidden from '../VisuallyHidden'
+import { render, screen } from '@testing-library/react'
 
 describe('className', () => {
   test('Has default className', () => {
@@ -204,5 +205,19 @@ describe('Focus', () => {
 
     wrapper.find('input').first().simulate('blur')
     expect(wrapper.getDOMNode().classList.contains('is-focused')).toBeFalsy()
+  })
+})
+
+describe('Label', () => {
+  it('should use content as a label for checkbox', () => {
+    render(
+      <CheckMarkCard
+        label="John"
+        subtitle="NYC"
+        avatar={'https://exmaple-image'}
+      />
+    )
+
+    expect(screen.getByRole('checkbox')).toHaveAccessibleName('John NYC')
   })
 })

--- a/src/components/ChoiceGroup/ChoiceGroup.jsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.jsx
@@ -66,6 +66,8 @@ class ChoiceGroup extends React.Component {
     return selectedValue.filter(v => v !== value)
   }
 
+  getSingleSelectValue = (value, checked) => (checked ? value : [])
+
   getSelectLimitState = (props, selectedValue) => {
     const { multiSelect, multiSelectLimit } = props
 
@@ -81,7 +83,7 @@ class ChoiceGroup extends React.Component {
     const { multiSelect, onChange } = this.props
     const selectedValue = multiSelect
       ? this.getMultiSelectValue(value, checked)
-      : value
+      : this.getSingleSelectValue(value, checked)
     const limitReached = this.getSelectLimitState(this.props, selectedValue)
 
     this.setState({ selectedValue, limitReached })

--- a/src/components/ChoiceGroup/ChoiceGroup.test.js
+++ b/src/components/ChoiceGroup/ChoiceGroup.test.js
@@ -202,6 +202,24 @@ describe('ChoiceGroup', () => {
       input3.simulate('change', { target: { checked: true } })
       expect(spy).toHaveBeenCalledWith('mugatu')
     })
+
+    test('returns empty array if deselected item with mutliSelect off', () => {
+      const spy = jest.fn()
+      const wrapper = mount(
+        <ChoiceGroup onChange={spy} multiSelect={false}>
+          <Checkbox value="derek" />
+          <Checkbox value="hansel" />
+          <Checkbox value="mugatu" />
+        </ChoiceGroup>
+      )
+      const input = wrapper.find(Checkbox).at(0).find('input')
+
+      input.simulate('change', { target: { checked: true } })
+      expect(spy).toHaveBeenCalledWith('derek')
+
+      input.simulate('change', { target: { checked: false } })
+      expect(spy).toHaveBeenCalledWith([])
+    })
   })
 
   describe('multiSelectLimit', () => {

--- a/src/components/SimpleModal/SimpleModal.stories.mdx
+++ b/src/components/SimpleModal/SimpleModal.stories.mdx
@@ -1,8 +1,8 @@
 import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs/blocks'
-import { boolean, number, text, select } from '@storybook/addon-knobs'
 import SimpleModal from './SimpleModal'
 import Button from '../Button'
 import { HeaderAndFooter } from './SimpleModal.layouts'
+import { SimpleModalWithTrigger } from './SimpleModal.storiesHelpers'
 
 <Meta
   title="Components/Overlay/SimpleModal"
@@ -103,6 +103,16 @@ Don't forget to add styles to position it yourself.
       >
         My modal with a custom button
       </SimpleModal>
+    </div>
+  </Story>
+</Canvas>
+
+### With button trigger
+
+<Canvas>
+  <Story name="with trigger">
+    <div style={{ position: 'relative', height: '450px' }}>
+      <SimpleModalWithTrigger />
     </div>
   </Story>
 </Canvas>

--- a/src/components/SimpleModal/SimpleModal.stories.mdx
+++ b/src/components/SimpleModal/SimpleModal.stories.mdx
@@ -107,10 +107,10 @@ Don't forget to add styles to position it yourself.
   </Story>
 </Canvas>
 
-### With button trigger
+### With button trigger (trapped focus)
 
 <Canvas>
-  <Story name="with trigger">
+  <Story name="with trigger (trapped focus)">
     <div style={{ position: 'relative', height: '450px' }}>
       <SimpleModalWithTrigger />
     </div>

--- a/src/components/SimpleModal/SimpleModal.storiesHelpers.js
+++ b/src/components/SimpleModal/SimpleModal.storiesHelpers.js
@@ -1,0 +1,24 @@
+import React, { useState } from 'react'
+import SimpleModal from './SimpleModal'
+import Button from '../Button'
+
+export const SimpleModalWithTrigger = () => {
+  const [isOpened, setIsOpened] = useState(false)
+
+  return (
+    <>
+      <Button kind="primary" onClick={() => setIsOpened(true)}>
+        Open modal
+      </Button>
+      <SimpleModal
+        show={isOpened}
+        focusModalOnShow
+        trapFocus
+        onClose={() => setIsOpened(false)}
+      >
+        <div>My modal</div>
+        <Button kind="primary">Some button</Button>
+      </SimpleModal>
+    </>
+  )
+}

--- a/src/utilities/focus.js
+++ b/src/utilities/focus.js
@@ -88,25 +88,24 @@ export function getClosestFocusableParent(element) {
  */
 export function manageTrappedFocus(container, e) {
   const focusedNode = e.target
+  const isContainerFocused = focusedNode === container
 
-  if (focusedNode !== container) {
-    const focusableNodes = findFocusableNodes(container)
+  const focusableNodes = findFocusableNodes(container)
 
-    if (focusableNodes != null) {
-      const focusedNodeIndex = Array.prototype.indexOf.call(
-        focusableNodes,
-        focusedNode
-      )
-      const isFirstNode = focusedNodeIndex === 0
-      const isLastNode = focusedNodeIndex === focusableNodes.length - 1
+  if (focusableNodes != null) {
+    const focusedNodeIndex = Array.prototype.indexOf.call(
+      focusableNodes,
+      focusedNode
+    )
+    const isFirstNode = focusedNodeIndex === 0
+    const isLastNode = focusedNodeIndex === focusableNodes.length - 1
 
-      if (!e.shiftKey && isLastNode) {
-        e.preventDefault()
-        focusableNodes[0].focus()
-      } else if (e.shiftKey && isFirstNode) {
-        e.preventDefault()
-        focusableNodes[focusableNodes.length - 1].focus()
-      }
+    if (!e.shiftKey && isLastNode) {
+      e.preventDefault()
+      focusableNodes[0].focus()
+    } else if (e.shiftKey && (isFirstNode || isContainerFocused)) {
+      e.preventDefault()
+      focusableNodes[focusableNodes.length - 1].focus()
     }
   }
 }


### PR DESCRIPTION
# Problem/Feature
In this PR two things has been change, all related to issues found in Messages app: https://github.com/helpscout/hs-app-ui/pull/209

## Trapped focus
There was an issue that if container was focused, for example SimpleModal, and user pressed Shift+Tab, the focus was moved to the previous element in the DOM, not witihn the container, even if `trapFocus` was set to true.
The fix here is to always move within container, even if it is the one focused.

To test this, I have create `SimpleModal` -> `with trigger` story that would open and focus modal once the button is clicked.

## ChoiceGroup single select 
If ChoiceGroup was used with `multiSelect={false}` and children are `Checkboxes` (or variant of them) - then clicking the same item twice was de-selecting on the UI, but clicked third time was not selecting it again. The reason being that we were always returning the clicked value from `onChange` in `ChoiceGroup` component, no matter what was the `checked` argument. The change here is to include the `checked` value.

It only affects usage with Checkbox, as Radio would not call `onChange` if clicked again on the same element (it is not possible to de-select radio button)

In the case I am fixing here, there were `CheckMarkCard` items used.

To test this, go to `CheckMarkCard` -> `inside group` story and change `Knobs` to have `multiSelectLimit = 1` and `multiSelect` to not be checked.

`RadioCard` -> `inside a group` story can be used to verify the change does not break if `Radio` is used.

## CheckMarkCard accessibility fix
Before the fix, the CheckMarkCrad had multiple labels that was causing heading to be read twice (or even 3 times with avatar). I have changed to remove label prop from the Checkbox itself, because it's already being labelled by `label` element and `htmlFor` prop is used. I've also hidden avatar from the screen readers as it was also containing a name.

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
