### PR TITLE
Allow deselecting ChoiceGroup item via Enter/Space keypress

### DIFF
--- a/src/components/ChoiceGroup/ChoiceGroup.jsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.jsx
@@ -94,7 +94,7 @@ class ChoiceGroup extends React.Component {
     const { multiSelect, onEnter, onChange } = this.props
     const selectedValue = multiSelect
       ? this.getMultiSelectValue(value, checked)
-      : value
+      : this.getSingleSelectValue(value, checked)
     const limitReached = this.getSelectLimitState(this.props, selectedValue)
 
     this.setState({ selectedValue, limitReached })

--- a/src/components/ChoiceGroup/ChoiceGroup.test.js
+++ b/src/components/ChoiceGroup/ChoiceGroup.test.js
@@ -203,7 +203,7 @@ describe('ChoiceGroup', () => {
       expect(spy).toHaveBeenCalledWith('mugatu')
     })
 
-    test('returns empty array if deselected item with mutliSelect off', () => {
+    test('returns empty array if deselected item with multiSelect off', () => {
       const spy = jest.fn()
       const wrapper = mount(
         <ChoiceGroup onChange={spy} multiSelect={false}>
@@ -218,6 +218,24 @@ describe('ChoiceGroup', () => {
       expect(spy).toHaveBeenCalledWith('derek')
 
       input.simulate('change', { target: { checked: false } })
+      expect(spy).toHaveBeenCalledWith([])
+    })
+
+    test('returns empty array if deselected item via enter press with multiSelect off', () => {
+      const spy = jest.fn()
+      const wrapper = mount(
+        <ChoiceGroup onChange={spy} multiSelect={false}>
+          <Checkbox value="derek" />
+          <Checkbox value="hansel" />
+          <Checkbox value="mugatu" />
+        </ChoiceGroup>
+      )
+      const input = wrapper.find(Checkbox).at(0).find('input')
+
+      input.simulate('keydown', { key: 'Enter' })
+      expect(spy).toHaveBeenCalledWith('derek')
+
+      input.simulate('keydown', { key: 'Enter' })
       expect(spy).toHaveBeenCalledWith([])
     })
   })


### PR DESCRIPTION
# Problem/Feature
This PR lets user deselect `ChoiceGroup` item (Checkbox or a variant) via pressing Enter or Space when in single select mode.

To test this, use `CheckMarkCard` -> `inside group` story, change Knobs to deselect `multiSelect` option. Then use your keyboard to select and deselect (and select again) some item.

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
