### PR TITLE
Call onLoad for Avatar in constructor, when image already in cache

### DIFF
--- a/src/components/Avatar/Avatar.Image.jsx
+++ b/src/components/Avatar/Avatar.Image.jsx
@@ -45,6 +45,7 @@ export class AvatarImage extends React.PureComponent {
 
       if (cache[this.sourceList[i]] === true) {
         this.state = { currentIndex: i, isLoading: false, isLoaded: true }
+        this.props.onLoad()
         return
       }
     }

--- a/src/components/Avatar/Avatar.test.js
+++ b/src/components/Avatar/Avatar.test.js
@@ -499,6 +499,17 @@ describe('onLoad', () => {
     wrapper.find(AvatarImage).instance().image.onload()
     expect(spy).toHaveBeenCalled()
   })
+
+  test('onLoad handler gets called when the avatar image already in cache and set immediately', () => {
+    const spy = jest.fn()
+    const wrapper = mount(
+      <Avatar name="Buddy" image="buddy.jpg" onLoad={spy} />
+    )
+    wrapper.find(AvatarImage).instance().image.onload()
+
+    mount(<Avatar name="Buddy" image="buddy.jpg" onLoad={spy} />)
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('Action', () => {


### PR DESCRIPTION
# Problem/Feature
This PR improves Avatar to call `onLoad` callback in constructor for case that image is already in cache (so regular onLoad after fetching image would not be fired).
The use case for that is in Messages app where we need to perform some action when image is loaded and can be rendered. 

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
