### PR TITLE
Fix enter/space keypress for Radio input

### DIFF
--- a/src/components/Choice/Choice.Input.jsx
+++ b/src/components/Choice/Choice.Input.jsx
@@ -36,10 +36,20 @@ class ChoiceInput extends React.PureComponent {
   runKeyPress = event => {
     event.stopPropagation()
     event.preventDefault()
-    const { id, onEnter, value, type } = this.props
-    const checked =
-      type === 'checkbox' ? !event.target.checked : event.target.checked
+    const { id, onEnter, value } = this.props
+    const checked = this.newCheckedOnKeyPress(event)
     onEnter(value, checked, id)
+  }
+
+  newCheckedOnKeyPress(event) {
+    const { type } = this.props
+    if (type === 'checkbox') {
+      return !event.target.checked
+    }
+    if (type === 'radio') {
+      return true
+    }
+    return event.target.checked
   }
 
   handleOnKeyUp = event => {

--- a/src/components/Choice/ChoiceInput.test.js
+++ b/src/components/Choice/ChoiceInput.test.js
@@ -83,6 +83,16 @@ describe('Events', () => {
     expect(spy).toHaveBeenCalled()
   })
 
+  test('onEnter callback for Radio input always returns checked true', () => {
+    const spy = jest.fn()
+    const wrapper = mount(<Input onEnter={spy} type="radio" value="Value" />)
+    const input = wrapper.find('input')
+
+    input.simulate('keydown', { key: 'Enter' })
+
+    expect(spy).toHaveBeenCalledWith('Value', true, undefined)
+  })
+
   test('Can trigger onEnter callback using space', () => {
     const spy = jest.fn()
     const wrapper = mount(<Input onEnter={spy} checked value="Value" />)


### PR DESCRIPTION
# Problem/Feature

This PR fixes a bug introduced in one of the previous PRs (https://github.com/helpscout/hsds-react/pull/1007). The problem was that it was not possible to select Radio item inside a group using space or enter keys.

To test that it works, go to `Radio` -> `In a group` story and try using enter/space to select item.

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
