### PR TITLE
HSDS-229: MessageCard body variable transformer

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -292,6 +292,7 @@ export const BodyUI = styled.div`
     font-style: normal;
     font-weight: normal;
     text-decoration: none;
+    white-space: nowrap;
   }
 `
 

--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -281,6 +281,7 @@ export const BodyUI = styled.div`
     display: inline-flex;
     align-items: center;
     padding: 3px 8px;
+    margin: 0 4px;
     height: 20px;
     line-height: 17px;
 

--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -281,7 +281,7 @@ export const BodyUI = styled.div`
     display: inline-flex;
     align-items: center;
     padding: 3px 8px;
-    margin: 0 4px;
+    margin-right: 4px;
     height: 20px;
     line-height: 17px;
 

--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -8,6 +8,7 @@ import Button from '../Button'
 import Heading from '../Heading'
 import Image from '../Image'
 import ArticleCard from '../ArticleCard'
+import { messageVariableClassName } from './utils/MessageCard.utils'
 
 export const MAX_IMAGE_SIZE = 258
 
@@ -274,6 +275,23 @@ export const BodyUI = styled.div`
   }
   s {
     text-decoration: line-through;
+  }
+
+  span.${messageVariableClassName} {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    height: 20px;
+    line-height: 17px;
+
+    color: ${getColor('purple.800')};
+    background-color: ${getColor('purple.200')};
+    border-radius: 100px;
+
+    // clearing any text style coming from b or i elements, as we want to have it always display the same
+    font-style: normal;
+    font-weight: normal;
+    text-decoration: none;
   }
 `
 

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -174,7 +174,7 @@ MessageCard.propTypes = {
   variables: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
-      label: PropTypes.string,
+      display: PropTypes.string,
     })
   ),
 }

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -35,6 +35,7 @@ export const MessageCard = React.memo(
         align,
         isMobile,
         isWithBoxShadow,
+        variables = [],
         ...rest
       },
       ref
@@ -96,7 +97,11 @@ export const MessageCard = React.memo(
               withMargin={!!(title || subtitle)}
               render={!!(body || image || children)}
             >
-              <MessageCardBody body={body} onClick={onBodyClick} />
+              <MessageCardBody
+                body={body}
+                onClick={onBodyClick}
+                variables={variables}
+              />
               <MessageCardImage image={image} onLoad={makeMessageVisible} />
               {children}
             </MessageCardContent>
@@ -165,6 +170,13 @@ MessageCard.propTypes = {
   onShow: PropTypes.func,
   /** Enable animations when showing the Message. */
   withAnimation: PropTypes.bool,
+  /** List of variables that can be highlighted inside Message. */
+  variables: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string,
+    })
+  ),
 }
 
 MessageCard.className = 'c-MessageCard'

--- a/src/components/MessageCard/MessageCard.stories.mdx
+++ b/src/components/MessageCard/MessageCard.stories.mdx
@@ -156,9 +156,9 @@ This component renders a Message Card Notification with (optional) Title, Subtit
         '<p>Hi {%customer.firstName,fallback=there%}!</p> <p>This <i>sentence</i> has five <u>words</u>. </p> <p>See you at our <b>amazing show with {%coordinator,fallback=Coordinator%}</b>!</p> <p>It would happen at {%date%}</p> <p>And this is non-existing variable {%nonExisting,fallback=no%}</p>'
       )}
       variables={[
-        { id: 'customer.firstName', label: 'First Name' },
-        { id: 'coordinator', label: 'Person' },
-        { id: 'date', label: 'Date' },
+        { id: 'customer.firstName', display: 'First Name' },
+        { id: 'coordinator', display: 'Person' },
+        { id: 'date', display: 'Date' },
       ]}
     />
   </Story>

--- a/src/components/MessageCard/MessageCard.stories.mdx
+++ b/src/components/MessageCard/MessageCard.stories.mdx
@@ -144,6 +144,26 @@ This component renders a Message Card Notification with (optional) Title, Subtit
   </Story>
 </Canvas>
 
+# With variables
+
+<Canvas>
+  <Story name="With variables">
+    <MessageCard
+      subtitle={text('Subtitle', 'The J&G Team is here')}
+      title={text('Title', 'Need help?')}
+      body={text(
+        'Body',
+        '<p>Hi {%customer.firstName,fallback=there%}!</p> <p>This <i>sentence</i> has five <u>words</u>. </p> <p>See you at our <b>amazing show with {%coordinator,fallback=Coordinator%}</b>!</p> <p>It would happen at {%date%}</p> <p>And this is non-existing variable {%nonExisting,fallback=no%}</p>'
+      )}
+      variables={[
+        { id: 'customer.firstName', label: 'First Name' },
+        { id: 'coordinator', label: 'Person' },
+        { id: 'date', label: 'Date' },
+      ]}
+    />
+  </Story>
+</Canvas>
+
 #### Reference
 
 - **Designer**: Buzz

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -191,7 +191,7 @@ describe('Body variables', () => {
   const variables = [
     {
       id: 'customer.firstName',
-      label: 'First Name',
+      display: 'First Name',
     },
   ]
 

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -1,62 +1,49 @@
 import React from 'react'
-import { mount, render } from 'enzyme'
+import { render, act, screen, fireEvent } from '@testing-library/react'
 import MessageCard from './MessageCard'
-import {
-  TitleUI,
-  SubtitleUI,
-  BodyUI,
-  ActionUI,
-  ImageUI,
-} from './MessageCard.css'
 import { MessageCardButton as Button } from './MessageCard.Button'
-import { act } from 'react-dom/test-utils'
+import userEvent from '@testing-library/user-event'
 
 describe('className', () => {
   test('Has default className', () => {
-    const wrapper = render(<MessageCard />)
-    const el = wrapper.find('.c-MessageCard')
+    const { container } = render(<MessageCard />)
 
-    expect(el.length).toBeTruthy()
+    expect(messageCard(container)).toBeInTheDocument()
   })
 
   test('Can render custom className', () => {
     const customClassName = 'blue'
-    const wrapper = render(<MessageCard className={customClassName} />)
-    const el = wrapper.find('.c-MessageCard')
+    const { container } = render(<MessageCard className={customClassName} />)
 
-    expect(el.hasClass(customClassName)).toBeTruthy()
+    expect(messageCard(container)).toHaveClass(customClassName)
   })
 })
 
 describe('Mobile', () => {
   test('Should not have mobile styles by default', () => {
-    const wrapper = mount(<MessageCard />)
-    const el = wrapper.find('div.c-MessageCard')
+    const { container } = render(<MessageCard />)
 
-    expect(el.getDOMNode().classList.contains('is-mobile')).toBeFalsy()
+    expect(messageCard(container)).not.toHaveClass('is-mobile')
   })
 
   test('Should have mobile styles if specified', () => {
-    const wrapper = mount(<MessageCard isMobile />)
-    const el = wrapper.find('div.c-MessageCard')
+    const { container } = render(<MessageCard isMobile />)
 
-    expect(el.getDOMNode().classList.contains('is-mobile')).toBeTruthy()
+    expect(messageCard(container)).toHaveClass('is-mobile')
   })
 })
 
 describe('Align', () => {
   test('Has default alignment of right', () => {
-    const wrapper = mount(<MessageCard />)
-    const el = wrapper.find('div.c-MessageCard')
+    const { container } = render(<MessageCard />)
 
-    expect(el.getDOMNode().classList.contains('is-align-right')).toBeTruthy()
+    expect(messageCard(container)).toHaveClass('is-align-right')
   })
 
   test('Can change alignment styles, if specified', () => {
-    const wrapper = mount(<MessageCard align="left" />)
-    const el = wrapper.find('div.c-MessageCard')
+    const { container } = render(<MessageCard align="left" />)
 
-    expect(el.getDOMNode().classList.contains('is-align-left')).toBeTruthy()
+    expect(messageCard(container)).toHaveClass('is-align-left')
   })
 })
 
@@ -65,201 +52,230 @@ describe('Visibility', () => {
 
   test('Should be visible by default if there is no image', () => {
     const onShowSpy = jest.fn()
-    const wrapper = mount(<MessageCard onShow={onShowSpy} />)
+    const { container } = render(<MessageCard onShow={onShowSpy} />)
 
-    expect(cardWrapperVisible(wrapper)).toEqual(false)
+    expect(cardWrapper(container)).not.toBeVisible()
     expect(onShowSpy).not.toHaveBeenCalled()
 
     act(() => {
       jest.runAllTimers()
-      wrapper.update()
     })
 
-    expect(cardWrapperVisible(wrapper)).toEqual(true)
+    expect(cardWrapper(container)).toBeVisible()
     expect(onShowSpy).toHaveBeenCalled()
   })
 
   test('Should not be visible by default if there is an image, but become visible when image loads', () => {
     const onShowSpy = jest.fn()
-    const wrapper = mount(
+    const { container } = render(
       <MessageCard
         image={{ url: 'https://path.to/image.png' }}
         onShow={onShowSpy}
       />
     )
 
-    expect(cardWrapperVisible(wrapper)).toEqual(false)
+    expect(cardWrapper(container)).not.toBeVisible()
     expect(onShowSpy).not.toHaveBeenCalled()
-
-    jest.runAllTimers()
-    wrapper.update()
-
-    expect(cardWrapperVisible(wrapper)).toEqual(false)
-    expect(onShowSpy).not.toHaveBeenCalled()
-
-    wrapper.find('img').simulate('load')
 
     act(() => {
       jest.runAllTimers()
-      wrapper.update()
     })
 
-    expect(wrapper.find('img')).toHaveLength(1)
-    expect(cardWrapperVisible(wrapper)).toEqual(true)
+    expect(cardWrapper(container)).not.toBeVisible()
+    expect(onShowSpy).not.toHaveBeenCalled()
+
+    fireEvent.load(screen.getByRole('img'))
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(screen.getByRole('img')).toBeInTheDocument()
+    expect(cardWrapper(container)).toBeVisible()
     expect(onShowSpy).toHaveBeenCalled()
   })
 
   test('Should become visible without image if image fails to load', () => {
     const onShowSpy = jest.fn()
-    const wrapper = mount(
+    const { container } = render(
       <MessageCard
         image={{ url: 'https://path.to/image.png' }}
         onShow={onShowSpy}
       />
     )
 
-    expect(cardWrapperVisible(wrapper)).toEqual(false)
+    expect(cardWrapper(container)).not.toBeVisible()
     expect(onShowSpy).not.toHaveBeenCalled()
-
-    jest.runAllTimers()
-    wrapper.update()
-
-    expect(cardWrapperVisible(wrapper)).toEqual(false)
-    expect(onShowSpy).not.toHaveBeenCalled()
-
-    wrapper.find('img').simulate('error')
 
     act(() => {
       jest.runAllTimers()
-      wrapper.update()
     })
 
-    expect(wrapper.find('img')).toHaveLength(0)
-    expect(cardWrapperVisible(wrapper)).toEqual(true)
+    expect(cardWrapper(container)).not.toBeVisible()
+    expect(onShowSpy).not.toHaveBeenCalled()
+
+    fireEvent.error(screen.getByRole('img'))
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(cardWrapper(container)).toBeVisible()
     expect(onShowSpy).toHaveBeenCalled()
   })
-
-  function cardWrapperVisible(wrapper) {
-    return wrapper.find('.c-MessageCardWrapper').at(0).prop('visible')
-  }
 })
 
 describe('Animation', () => {
   test('Should have no animation by default', () => {
-    const wrapper = mount(<MessageCard />)
+    const { container } = render(<MessageCard />)
 
-    expect(cardWrapperAnimation(wrapper)).toEqual(false)
+    expect(cardWrapper(container)).toHaveStyle({ transition: 'none' })
   })
 
   test('Should have animation if withAnimation is true', () => {
-    const wrapper = mount(<MessageCard withAnimation />)
+    const { container } = render(<MessageCard withAnimation />)
 
-    expect(cardWrapperAnimation(wrapper)).toEqual(true)
+    expect(cardWrapper(container)).toHaveStyle({
+      transition: 'all 300ms ease-in-out',
+    })
   })
-
-  function cardWrapperAnimation(wrapper) {
-    return wrapper.find('.c-MessageCardWrapper').at(0).prop('withAnimation')
-  }
 })
 
 describe('Body', () => {
   test('Does not render body if is not passed down as a prop', () => {
-    const wrapper = mount(<MessageCard />)
-    const o = wrapper.find(BodyUI)
+    const { container } = render(<MessageCard />)
 
-    expect(o.length).toBe(0)
+    expect(messageBody(container)).not.toBeInTheDocument()
   })
 
   test('Renders body if it is passed down as a prop', () => {
-    const wrapper = mount(<MessageCard body="Santa!" />)
-    const o = wrapper.find(BodyUI)
+    const { container } = render(<MessageCard body="Santa!" />)
 
-    expect(o.length).toBe(1)
-    expect(o.html()).toContain('Santa!')
+    expect(messageBody(container)).toHaveTextContent('Santa!')
   })
 
   test('Renders html in body', () => {
-    const wrapper = mount(<MessageCard body="<span>Santa!</span>" />)
-    const o = wrapper.find(BodyUI)
+    const { container } = render(<MessageCard body="<span>Santa!</span>" />)
 
-    expect(o.render().find('span').length).toBe(1)
+    expect(
+      container.querySelector('[data-cy="beacon-message-body-content"] span')
+    ).toHaveTextContent('Santa!')
   })
 
   test('Renders new line without html in body', () => {
     const body = 'this is a new line\nwith another line'
-    const wrapper = mount(<MessageCard body={body} />)
-    const o = wrapper.find(BodyUI)
+    const { container } = render(<MessageCard body={body} />)
 
-    expect(o.render().find('br').length).toBe(1)
+    expect(
+      container.querySelector('[data-cy="beacon-message-body-content"] br')
+    ).toBeInTheDocument()
   })
 
   test('Accepts a custom onBodyClick callback', () => {
     const body = 'some text with a <a href="#">link</a> in it'
     const callback = jest.fn()
-    const wrapper = mount(<MessageCard body={body} onBodyClick={callback} />)
+    const { container } = render(
+      <MessageCard body={body} onBodyClick={callback} />
+    )
 
-    wrapper.simulate('click')
+    userEvent.click(messageCard(container))
     expect(callback).not.toHaveBeenCalled()
 
-    wrapper.find(BodyUI).simulate('click')
+    userEvent.click(messageBody(container))
     expect(callback).toHaveBeenCalled()
+  })
+})
+
+describe('Body variables', () => {
+  const variables = [
+    {
+      id: 'customer.firstName',
+      label: 'First Name',
+    },
+  ]
+
+  it('should replace existing variables in body text', () => {
+    const body = `<p>Hi {%customer.firstName,fallback=there%}</p>`
+
+    render(<MessageCard body={body} variables={variables} />)
+
+    expect(screen.getByText('there')).toBeInTheDocument()
+  })
+
+  it('should replace existing variables in body text, when also having new line character', () => {
+    const body = `Hi\n{%customer.firstName,fallback=there%}`
+
+    render(<MessageCard body={body} variables={variables} />)
+
+    expect(screen.getByText('there')).toBeInTheDocument()
+  })
+
+  it('should NOT replace variable if none provided', () => {
+    const body = `<p>Hi {%customer.firstName,fallback=there%}</p>`
+
+    render(<MessageCard body={body} />)
+
+    expect(
+      screen.getByText('Hi {%customer.firstName,fallback=there%}')
+    ).toBeInTheDocument()
   })
 })
 
 describe('Title', () => {
   test('Does not render title if is not passed down as a prop', () => {
-    const wrapper = mount(<MessageCard />)
-    const o = wrapper.find(TitleUI)
+    const { container } = render(<MessageCard />)
 
-    expect(o.length).toBe(0)
+    expect(messageTitle(container)).not.toBeInTheDocument()
   })
 
   test('Renders title if it is passed down as a prop', () => {
-    const wrapper = mount(<MessageCard title="Santa!" />)
-    const o = wrapper.find(TitleUI)
+    const { container } = render(<MessageCard title="Santa!" />)
 
-    expect(o.length).toBe(1)
-    expect(o.html()).toContain('Santa!')
+    expect(messageTitle(container)).toHaveTextContent('Santa!')
   })
+
+  function messageTitle(container) {
+    return container.querySelector('[data-cy="beacon-message-title"]')
+  }
 })
 
 describe('Subtitle', () => {
   test('Does not render subtitle if is not passed down as a prop', () => {
-    const wrapper = mount(<MessageCard />)
-    const o = wrapper.find(SubtitleUI)
+    const { container } = render(<MessageCard />)
 
-    expect(o.length).toBe(0)
+    expect(messageSubtitle(container)).not.toBeInTheDocument()
   })
 
   test('Renders subtitle if it is passed down as a prop', () => {
-    const wrapper = mount(<MessageCard subtitle="Santa!" />)
-    const o = wrapper.find(SubtitleUI)
+    const { container } = render(<MessageCard subtitle="Santa!" />)
 
-    expect(o.length).toBe(1)
-    expect(o.html()).toContain('Santa!')
+    expect(messageSubtitle(container)).toHaveTextContent('Santa!')
   })
+
+  function messageSubtitle(container) {
+    return container.querySelector('[data-cy="beacon-message-subtitle"]')
+  }
 })
 
 describe('image', () => {
   test('Does not render image if is not passed down as a prop', () => {
-    const wrapper = mount(<MessageCard />)
-    const image = wrapper.find('img')
+    render(<MessageCard />)
 
-    expect(image).toHaveLength(0)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
 
   test('Renders image if it is passed down as a prop', () => {
-    const wrapper = mount(
-      <MessageCard image={{ url: 'https://path.to/image.png' }} />
-    )
-    const image = wrapper.find('img')
+    render(<MessageCard image={{ url: 'https://path.to/image.png' }} />)
 
-    expect(image).toHaveLength(1)
-    expect(image.prop('src')).toEqual('https://path.to/image.png')
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      'https://path.to/image.png'
+    )
   })
 
   test('Sets size of image when provided', () => {
-    const wrapper = mount(
+    render(
       <MessageCard
         image={{
           url: 'https://path.to/image.png',
@@ -268,14 +284,13 @@ describe('image', () => {
         }}
       />
     )
-    const image = wrapper.find(ImageUI)
 
-    expect(image.prop('width')).toEqual('100px')
-    expect(image.prop('height')).toEqual('200px')
+    expect(screen.getByRole('img')).toHaveStyle({ width: '100px' })
+    expect(screen.getByRole('img')).toHaveStyle({ height: '200px' })
   })
 
   test('Scales size of image when larger than fits and width is bigger', () => {
-    const wrapper = mount(
+    render(
       <MessageCard
         image={{
           url: 'https://path.to/image.png',
@@ -284,14 +299,13 @@ describe('image', () => {
         }}
       />
     )
-    const image = wrapper.find(ImageUI)
 
-    expect(image.prop('height')).toEqual('96.75px')
-    expect(image.prop('width')).toEqual('258px')
+    expect(screen.getByRole('img')).toHaveStyle({ width: '258px' })
+    expect(screen.getByRole('img')).toHaveStyle({ height: '96.75px' })
   })
 
   test('Scales size of image when larger than fits and height is bigger', () => {
-    const wrapper = mount(
+    render(
       <MessageCard
         image={{
           url: 'https://path.to/image.png',
@@ -300,114 +314,114 @@ describe('image', () => {
         }}
       />
     )
-    const image = wrapper.find(ImageUI)
 
-    expect(image.prop('height')).toEqual('258px')
-    expect(image.prop('width')).toEqual('96.75px')
+    expect(screen.getByRole('img')).toHaveStyle({ width: '96.75px' })
+    expect(screen.getByRole('img')).toHaveStyle({ height: '258px' })
   })
 
   test('Sets default size of image when not provided', () => {
-    const wrapper = mount(
-      <MessageCard image={{ url: 'https://path.to/image.png' }} />
-    )
-    const image = wrapper.find(ImageUI)
+    render(<MessageCard image={{ url: 'https://path.to/image.png' }} />)
 
-    expect(image.prop('width')).toEqual('100%')
-    expect(image.prop('height')).toEqual('auto')
+    expect(screen.getByRole('img')).toHaveStyle({ width: '100%' })
+    expect(screen.getByRole('img')).toHaveStyle({ height: 'auto' })
   })
 
   test('Sets provided alt text', () => {
-    const wrapper = mount(
+    render(
       <MessageCard
         image={{ url: 'https://path.to/image.png', altText: 'Alt text' }}
       />
     )
-    const image = wrapper.find('img')
 
-    expect(image.prop('alt')).toEqual('Alt text')
+    expect(screen.getByRole('img')).toHaveAttribute('alt', 'Alt text')
   })
 
   test('Sets default alt text', () => {
-    const wrapper = mount(
-      <MessageCard image={{ url: 'https://path.to/image.png' }} />
-    )
-    const image = wrapper.find('img')
+    render(<MessageCard image={{ url: 'https://path.to/image.png' }} />)
 
-    expect(image.prop('alt')).toEqual('Message image')
+    expect(screen.getByRole('img')).toHaveAttribute('alt', 'Message image')
   })
 })
 
 describe('Action', () => {
   test('Does not render action if is not passed down as a prop', () => {
-    const wrapper = mount(<MessageCard />)
-    const o = wrapper.find(ActionUI)
+    const { container } = render(<MessageCard />)
 
-    expect(o.length).toBe(0)
+    expect(
+      container.querySelector('[data-cy="beacon-message-cta-wrapper"]')
+    ).not.toBeInTheDocument()
   })
 
   test('Renders action if it is passed down as a prop', () => {
     const action = () => <div>Click here</div>
-    const wrapper = mount(<MessageCard action={action} />)
-    const o = wrapper.find(ActionUI)
+    const { container } = render(<MessageCard action={action} />)
 
-    expect(o.length).toBe(1)
-    expect(o.html()).toContain('Click here')
+    expect(
+      container.querySelector('[data-cy="beacon-message-cta-wrapper"]')
+    ).toHaveTextContent('Click here')
   })
 
   test('Should remove the box shadow', () => {
-    const wrapper = mount(<MessageCard isWithBoxShadow={false} />)
-    const el = wrapper.find('div.c-MessageCard')
+    const { container } = render(<MessageCard isWithBoxShadow={false} />)
 
-    expect(el.getDOMNode().classList.contains('is-with-box-shadow')).toBeFalsy()
+    expect(messageCard(container)).not.toHaveClass('is-with-box-shadow')
   })
 })
 
 describe('UrlAttachmentImage', () => {
   test('Does not render if url not provided', () => {
-    const wrapper = mount(<MessageCard.UrlAttachmentImage />)
-    const image = wrapper.find('img')
+    render(<MessageCard.UrlAttachmentImage />)
 
-    expect(image.length).toBe(0)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
 
   test('Renders image when url provided', () => {
-    const wrapper = mount(
-      <MessageCard.UrlAttachmentImage url="https://example.com" />
-    )
-    const image = wrapper.find('img')
+    render(<MessageCard.UrlAttachmentImage url="https://example.com" />)
 
-    expect(image.length).toBe(1)
-    expect(image.prop('src')).toEqual('https://example.com')
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      'https://example.com'
+    )
   })
 
   test('Allows to provide alt text', () => {
-    const wrapper = mount(
+    render(
       <MessageCard.UrlAttachmentImage
         url="https://example.com"
         altText="My alt text"
       />
     )
-    const image = wrapper.find('img')
 
-    expect(image.prop('alt')).toEqual('My alt text')
+    expect(screen.getByRole('img')).toHaveAttribute('alt', 'My alt text')
   })
 })
 
-describe('Message Button Children', () => {
+describe('Message Button', () => {
   test('Can render children', () => {
     const children = 'Hello world'
-    const wrapper = mount(<Button>{children}</Button>)
+    render(<Button>{children}</Button>)
 
-    expect(wrapper.html()).toContain(children)
+    expect(screen.getByRole('button', { name: children })).toBeInTheDocument()
   })
-})
 
-describe('Message Button onClick', () => {
   test('Can accept custom onClick callback', () => {
     const callback = jest.fn()
-    const wrapper = mount(<Button onClick={callback}>Click Me</Button>)
-    wrapper.simulate('click')
+    render(<Button onClick={callback}>Click Me</Button>)
+
+    userEvent.click(screen.getByRole('button'))
 
     expect(callback).toHaveBeenCalled()
   })
 })
+
+function messageCard(container) {
+  return container.querySelector('.c-MessageCard')
+}
+
+function cardWrapper(container) {
+  return container.querySelector('.c-MessageCardWrapper')
+}
+
+function messageBody(container) {
+  return container.querySelector('[data-cy="beacon-message-body-content"]')
+}

--- a/src/components/MessageCard/components/MessageCard.Body.jsx
+++ b/src/components/MessageCard/components/MessageCard.Body.jsx
@@ -31,7 +31,7 @@ MessageCardBody.propTypes = {
   variables: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
-      label: PropTypes.string,
+      display: PropTypes.string,
     })
   ),
 }

--- a/src/components/MessageCard/components/MessageCard.Body.jsx
+++ b/src/components/MessageCard/components/MessageCard.Body.jsx
@@ -2,8 +2,9 @@ import { BodyUI } from '../MessageCard.css'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { noop } from '../../../utilities/other'
+import { replaceMessageVariables } from '../utils/MessageCard.utils'
 
-export const MessageCardBody = ({ withMargin, body, onClick }) => {
+export const MessageCardBody = ({ body, onClick, variables }) => {
   const getBodyToRender = () => {
     // if there is no html in the string, transform new line to paragraph
     if (body && !/<\/?[a-z][\s\S]*>/i.test(body)) {
@@ -12,14 +13,10 @@ export const MessageCardBody = ({ withMargin, body, onClick }) => {
     return body
   }
 
-  const bodyToRender = getBodyToRender()
+  const bodyToRender = replaceMessageVariables(getBodyToRender(), variables)
 
   return bodyToRender ? (
-    <BodyUI
-      onClick={onClick}
-      withMargin={withMargin}
-      data-cy="beacon-message-body-content"
-    >
+    <BodyUI onClick={onClick} data-cy="beacon-message-body-content">
       <div dangerouslySetInnerHTML={{ __html: bodyToRender }} />
     </BodyUI>
   ) : null
@@ -28,10 +25,15 @@ export const MessageCardBody = ({ withMargin, body, onClick }) => {
 MessageCardBody.propTypes = {
   /** Body content */
   body: PropTypes.string,
-  /** Indicate if should add margin above the body */
-  withMargin: PropTypes.string,
   /** Callback when body clicked */
   onClick: PropTypes.func,
+  /** List of variables that can be highlighted inside Body */
+  variables: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string,
+    })
+  ),
 }
 
 MessageCardBody.defaultProps = {

--- a/src/components/MessageCard/utils/MessageCard.utils.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.js
@@ -1,0 +1,35 @@
+export const messageVariableClassName = 'hsds-message-card-variable'
+
+/**
+ * This function replaces all occurrences of variables in provided string with human friendly text
+ * They would be replaced with fallback text, if present. If no fallback text, label from variable would be used
+ * Only variables provided in parameter would be replaced, others are kept untouched in the raw version
+ *
+ * Variable raw text is replaced with <span class="hsds-message-card-variable"> element.
+ *
+ * @param text {String} text to replace variables within (if any)
+ * @param variables {Array<{id: String, label: String}>} list of variables to replace
+ */
+export const replaceMessageVariables = (text = '', variables = []) => {
+  if (variables.length === 0) {
+    return text
+  }
+
+  // Regex to match the following cases:
+  // 1) {%variableName,fallback=Fallback%}
+  // 2) {%variableName,fallback=%}
+  // 3) {%variableName%}
+  // There are 3 groups, from left: variable name, fallback presence (optional), fallback value (optional)
+  const regex = /{%([^,%]+)(,fallback=([^%]*)?)?%}/g
+
+  const replacer = (match, variableId, fallbackConfig, fallback) => {
+    const variable = variables.find(variable => variable.id === variableId)
+    if (variable) {
+      const variableText = !fallback ? variable.label : fallback
+      return `<span class="${messageVariableClassName}">${variableText}</span>`
+    }
+    return match
+  }
+
+  return text.replace(regex, replacer)
+}

--- a/src/components/MessageCard/utils/MessageCard.utils.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.js
@@ -8,7 +8,7 @@ export const messageVariableClassName = 'hsds-message-card-variable'
  * Variable raw text is replaced with <span class="hsds-message-card-variable"> element.
  *
  * @param text {String} text to replace variables within (if any)
- * @param variables {Array<{id: String, label: String}>} list of variables to replace
+ * @param variables {Array<{id: String, display: String}>} list of variables to replace
  */
 export const replaceMessageVariables = (text = '', variables = []) => {
   if (variables.length === 0) {
@@ -25,7 +25,7 @@ export const replaceMessageVariables = (text = '', variables = []) => {
   const replacer = (match, variableId, fallbackConfig, fallback) => {
     const variable = variables.find(variable => variable.id === variableId)
     if (variable) {
-      const variableText = !fallback ? variable.label : fallback
+      const variableText = !fallback ? variable.display : fallback
       return `<span class="${messageVariableClassName}">${variableText}</span>`
     }
     return match

--- a/src/components/MessageCard/utils/MessageCard.utils.test.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.test.js
@@ -1,0 +1,56 @@
+import { replaceMessageVariables } from './MessageCard.utils'
+
+describe('MessageCard.utils', () => {
+  const variables = [
+    {
+      id: 'customer.firstName',
+      label: 'First Name',
+    },
+    {
+      id: 'customer.lastName',
+      label: 'Last Name',
+    },
+    {
+      id: 'customVariable',
+      label: 'Custom Variable',
+    },
+  ]
+
+  it('should replace variables in provided text with fallback value', () => {
+    const text = `<p>Hi {%customer.firstName,fallback=there%} {%customer.lastName,fallback=you%}</p>`
+
+    const result = replaceMessageVariables(text, variables)
+
+    expect(result).toEqual(
+      `<p>Hi <span class="hsds-message-card-variable">there</span> <span class="hsds-message-card-variable">you</span></p>`
+    )
+  })
+
+  it('should replace variables in provided text with variable label when it has not fallback', () => {
+    const text = `<p>Hi {%customer.firstName,fallback=there%} {%customVariable%}</p>`
+
+    const result = replaceMessageVariables(text, variables)
+
+    expect(result).toEqual(
+      `<p>Hi <span class="hsds-message-card-variable">there</span> <span class="hsds-message-card-variable">Custom Variable</span></p>`
+    )
+  })
+
+  it('should replace variables in provided text with variable label when empty fallback', () => {
+    const text = `<p>Hi {%customer.firstName,fallback=%}</p>`
+
+    const result = replaceMessageVariables(text, variables)
+
+    expect(result).toEqual(
+      `<p>Hi <span class="hsds-message-card-variable">First Name</span></p>`
+    )
+  })
+
+  it('should NOT replace unknown variable', () => {
+    const text = `<p>Hi {%customer.unknown,fallback=Test%}</p>`
+
+    const result = replaceMessageVariables(text, variables)
+
+    expect(result).toEqual(text)
+  })
+})

--- a/src/components/MessageCard/utils/MessageCard.utils.test.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.test.js
@@ -4,15 +4,15 @@ describe('MessageCard.utils', () => {
   const variables = [
     {
       id: 'customer.firstName',
-      label: 'First Name',
+      display: 'First Name',
     },
     {
       id: 'customer.lastName',
-      label: 'Last Name',
+      display: 'Last Name',
     },
     {
       id: 'customVariable',
-      label: 'Custom Variable',
+      display: 'Custom Variable',
     },
   ]
 


### PR DESCRIPTION
[JIRA](https://helpscout.atlassian.net/browse/HSDS-229)

# Problem/Feature
This PR adds support for highlighting variables in a MessageCard. Variables are provided via props, so this is not connected to any specific available variables, but whatever would be needed.

Design: https://www.figma.com/file/H2oEYNwn2RMpSVSR94B2vB/Spec%2F-Variable-Support-in-Messages?node-id=34%3A6520

## Taken path
I initially though about implementing just some utility function that is exported and can be used whenever needed. Main reason for this being re-usability, customization (can use different transformation if necessary) and the fact that it is not needed in Beacon Embed, so to not add additional size. 
However, I thought about it again and decided to, at least for now, just include implementation inside MessageCard component. Reason for that being:
- There is no customization I can think of right now that we might need
- The implementation doesn't add a lot of code, so size impact on Beacon would not be significant
- it wouldn't need to be remembered to use transformer in multiple places and if we need to modify implementation, it can be done in one place instead of multiple (like adding variables in heading, in the future)
The transformation function is separated, so at any point we could just change the approach if this one wouldn't work.

## Solution
For the main part - transforming the variables - I have used RegExp to find all occurences of variables and replace them with span element, that can then be styled accordingly. Only those variables that are provided in a separate list would be replaced. This prevents unknown variables provided by hand (or just text looking as if it's variable) from being highlighted.

The replacement span get's defined class name that is then used in MessageCard component for styling, according to the design. I've exported this to a variable so it's easy to change it if necessary.

One more thing I have done here was to re-write MessageCard tests from `enzyme` to `testing-library` - they check the same thing, just in a modern way :)

## Testing
I've added a story `Message Card -> With variables` that can be used for visual testing.

![Screenshot from 2022-01-06 18-57-18](https://user-images.githubusercontent.com/1765264/148428594-abe79347-6fa9-4ca4-999a-3d1904a57539.png)

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
