### PR TITLE
Allow Collabsible/Accordion.Body content to be pre-rendered

### DIFF
--- a/src/components/Accordion/Accordion.Body.jsx
+++ b/src/components/Accordion/Accordion.Body.jsx
@@ -52,7 +52,7 @@ const getComponentClassName = ({
 }
 
 export const AccordionBody = props => {
-  const { className } = props
+  const { className, preRender } = props
   const { isPage, isSeamless, duration, onOpen, onClose, size } =
     useContext(AccordionContext) || {}
   const { isOpen, uuid } = useContext(SectionContext) || {}
@@ -76,6 +76,7 @@ export const AccordionBody = props => {
       onClose={() => {
         onClose(uuid)
       }}
+      preRenderContent={preRender}
     >
       <BodyUI {...getValidProps(props)} className={componentClassName} />
     </Collapsible>
@@ -84,6 +85,7 @@ export const AccordionBody = props => {
 
 AccordionBody.defaultProps = {
   'data-cy': 'AccordionBody',
+  preRender: false,
 }
 
 AccordionBody.propTypes = {
@@ -93,6 +95,8 @@ AccordionBody.propTypes = {
   className: PropTypes.string,
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,
+  /** Flag indicating if content should be pre-rendered to the DOM (otherwise the content would not be in the DOM until opened) */
+  preRender: PropTypes.bool,
 }
 
 export default AccordionBody

--- a/src/components/Accordion/__tests__/Accordion.Body.test.js
+++ b/src/components/Accordion/__tests__/Accordion.Body.test.js
@@ -89,6 +89,18 @@ describe('open', () => {
     const o = wrapper.find(`div.${classNames.baseComponentClassName}`)
     expect(o).toHaveLength(0)
   })
+
+  test('Has body when closed, but preRender set to true', () => {
+    const wrapper = mount(
+      <Accordion duration={0}>
+        <Section>
+          <Body preRender />
+        </Section>
+      </Accordion>
+    )
+    const o = wrapper.find(`div.${classNames.baseComponentClassName}`)
+    expect(o).toHaveLength(1)
+  })
 })
 
 describe('Events', () => {

--- a/src/components/Collapsible/Collapsible.jsx
+++ b/src/components/Collapsible/Collapsible.jsx
@@ -159,6 +159,7 @@ class Collapsible extends React.Component {
       onOpen,
       onClose,
       style,
+      preRenderContent,
       ...rest
     } = this.props
     const { animationState, height } = this.state
@@ -176,7 +177,7 @@ class Collapsible extends React.Component {
 
     const displayHeight = this.collapsibleHeight(isOpen, animationState, height)
 
-    const content = animating || isOpen ? children : null
+    const content = animating || isOpen || preRenderContent ? children : null
 
     const collapseStyle = {
       height: displayHeight,
@@ -207,6 +208,7 @@ Collapsible.defaultProps = {
   isOpen: false,
   onOpen: noop,
   onClose: noop,
+  preRenderContent: false,
 }
 
 Collapsible.propTypes = {
@@ -228,6 +230,8 @@ Collapsible.propTypes = {
   style: PropTypes.any,
   /** Data attr for Cypress tests. */
   'data-cy': PropTypes.string,
+  /** Flag indicating if content should be pre-rendered to the DOM (otherwise the content would not be in the DOM until opened) */
+  preRenderContent: PropTypes.bool,
 }
 
 export default Collapsible

--- a/src/components/Collapsible/Collapsible.test.js
+++ b/src/components/Collapsible/Collapsible.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { render, waitFor, screen } from '@testing-library/react'
 import { mount } from 'enzyme'
 import Collapsible from './Collapsible'
 
@@ -192,6 +192,28 @@ describe('Collapsible', () => {
       wrapper.setState({ animationState: 'closing' })
 
       expect(o.getTransitionDuration()).toBe(100)
+    })
+  })
+
+  describe('Content', () => {
+    it('should render content if preRenderContent is set to true', () => {
+      render(
+        <Collapsible preRenderContent>
+          <div>Content</div>
+        </Collapsible>
+      )
+
+      expect(screen.getByText('Content')).toBeInTheDocument()
+    })
+
+    it('should not render content by default if preRenderContent is set to false', () => {
+      render(
+        <Collapsible preRenderContent={false}>
+          <div>Content</div>
+        </Collapsible>
+      )
+
+      expect(screen.queryByText('Content')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/components/SidePanel/SidePanel.layouts.jsx
+++ b/src/components/SidePanel/SidePanel.layouts.jsx
@@ -69,7 +69,7 @@ HeaderAndFooter.propTypes = {
   /** If the default footer is present, this disables the button */
   mainActionDisabled: PropTypes.bool,
   /** Retrieve the Main Action button node */
-  mainActionNode: PropTypes.func,
+  mainActionNode: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /** If the default Header included, this is the Heading */
   panelHeading: PropTypes.string,
   /** ID for the H1, make sure it matches the ariaLabelledBy from the SidePanel */


### PR DESCRIPTION
# Problem/Feature
For one case in Messages app we'd like to use Accordion component for it's functionality. However, we need the content of the Accordion Body to be rendered, because some background operations need to be performed, even if Accordion is closed. Currently the content is conditionally not rendered in `Collapsible` component (until opened)

This PR adds a new flags to `Accordion.Body` and `Collapsible` components so that the content would be rendered to the DOM. It is still hidden from user, but React lifecycle would fire for them.

I've not added any story for that, but there are tests confirming it works as expected.

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
