### PR TITLE
Fix Message Card variable regex so that it's possible to include % sign in fallback

### DIFF
--- a/src/components/MessageCard/utils/MessageCard.utils.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.js
@@ -19,8 +19,9 @@ export const replaceMessageVariables = (text = '', variables = []) => {
   // 1) {%variableName,fallback=Fallback%}
   // 2) {%variableName,fallback=%}
   // 3) {%variableName%}
+  // 4) {%variableName,fallback=Fallback with % sign%}
   // There are 3 groups, from left: variable name, fallback presence (optional), fallback value (optional)
-  const regex = /{%([^,%]+)(,fallback=([^%]*)?)?%}/g
+  const regex = /{%([^,%]+)(,fallback=(.+?(?=%}))?)?%}/g
 
   const replacer = (match, variableId, fallbackConfig, fallback) => {
     const variable = variables.find(variable => variable.id === variableId)

--- a/src/components/MessageCard/utils/MessageCard.utils.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.js
@@ -21,7 +21,8 @@ export const replaceMessageVariables = (text = '', variables = []) => {
   // 3) {%variableName%}
   // 4) {%variableName,fallback=Fallback with % sign%}
   // There are 3 groups, from left: variable name, fallback presence (optional), fallback value (optional)
-  const regex = /{%([^,%]+)(,fallback=(.+?(?=%}))?)?%}/g
+  // (.*?(?=%}) is a group that finds fallback value, up until it reaches first `%}` group of characters
+  const regex = /{%([^,%]+)(,fallback=(.*?(?=%})))?%}/g
 
   const replacer = (match, variableId, fallbackConfig, fallback) => {
     const variable = variables.find(variable => variable.id === variableId)

--- a/src/components/MessageCard/utils/MessageCard.utils.test.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.test.js
@@ -46,6 +46,16 @@ describe('MessageCard.utils', () => {
     )
   })
 
+  it('should replace variables in provided text when fallback contains % sign', () => {
+    const text = `<p>Hi {%customer.firstName,fallback=there % there%} {%customer.lastName,fallback=you % there%}</p>`
+
+    const result = replaceMessageVariables(text, variables)
+
+    expect(result).toEqual(
+      `<p>Hi <span class="hsds-message-card-variable">there % there</span> <span class="hsds-message-card-variable">you % there</span></p>`
+    )
+  })
+
   it('should NOT replace unknown variable', () => {
     const text = `<p>Hi {%customer.unknown,fallback=Test%}</p>`
 

--- a/src/components/MessageCard/utils/MessageCard.utils.test.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.test.js
@@ -37,12 +37,12 @@ describe('MessageCard.utils', () => {
   })
 
   it('should replace variables in provided text with variable label when empty fallback', () => {
-    const text = `<p>Hi {%customer.firstName,fallback=%}</p>`
+    const text = `<p>Hi {%customer.firstName,fallback=%} {%customer.lastName,fallback=you%}</p>`
 
     const result = replaceMessageVariables(text, variables)
 
     expect(result).toEqual(
-      `<p>Hi <span class="hsds-message-card-variable">First Name</span></p>`
+      `<p>Hi <span class="hsds-message-card-variable">First Name</span> <span class="hsds-message-card-variable">you</span></p>`
     )
   })
 


### PR DESCRIPTION
# Problem/Feature
This small PR fixes regex used for finding variables to highlight in MessageCard body so that it's possible to include % sign in fallback. There are tests added/adjusted to cover previously failing cases

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
