### PR TITLE
Fix/hsappui-306

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -35,6 +35,7 @@ function Combobox({
   inputPlaceholder = 'Search',
   items = [],
   isOpen = false,
+  menuAriaLabel,
   menuCSS,
   menuWidth,
   onDropListLeave = noop,
@@ -238,6 +239,8 @@ function Combobox({
       <MenuListUI
         className={`${DROPLIST_MENULIST} MenuList-Combobox`}
         {...getMenuProps()}
+        aria-label={menuAriaLabel}
+        aria-labelledby={null}
       >
         {renderListContents({
           customEmptyList,

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -27,6 +27,7 @@ function Select({
   handleSelectedItemChange = noop,
   isOpen = false,
   items = [],
+  menuAriaLabel,
   menuCSS,
   menuWidth,
   focusToggler = noop,
@@ -172,7 +173,9 @@ function Select({
       menuCSS={menuCSS}
       menuWidth={menuWidth}
     >
-      <A11yTogglerUI {...getToggleButtonProps()}>Toggler</A11yTogglerUI>
+      <A11yTogglerUI {...getToggleButtonProps()} aria-labelledby={null}>
+        Toggler
+      </A11yTogglerUI>
       <MenuListUI
         data-event-driver
         className={`${DROPLIST_MENULIST} MenuList-Select`}
@@ -202,6 +205,8 @@ function Select({
             onMenuBlur(e)
           },
         })}
+        aria-label={menuAriaLabel}
+        aria-labelledby={null}
       >
         {renderListContents({
           customEmptyList,

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -47,6 +47,7 @@ function DropListManager({
   inputPlaceholder = 'Search',
   isMenuOpen = false,
   items = [],
+  menuAriaLabel = '',
   menuCSS,
   menuWidth,
   onDropListLeave = noop,
@@ -288,6 +289,7 @@ function DropListManager({
             inputPlaceholder={inputPlaceholder}
             isOpen={isOpen}
             items={parsedItems}
+            menuAriaLabel={menuAriaLabel}
             menuCSS={menuCSS}
             menuWidth={getMenuWidth(DropListVariant.name, menuWidth)}
             onDropListLeave={onDropListLeave}
@@ -368,6 +370,8 @@ DropListManager.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, itemShape, dividerShape, groupShape])
   ),
+  /** Custom aria label for the Menu */
+  menuAriaLabel: PropTypes.string,
   /** Custom css for the Menu */
   menuCSS: PropTypes.any,
   /** Custom width for the Menu */

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -205,6 +205,7 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
       <DropList
         isMenuOpen={boolean('Is Menu Open', false)}
         focusTogglerOnMenuClose={boolean('focusTogglerOnMenuClose', true)}
+        menuAriaLabel="Demo DropList"
         onDropListLeave={() => {
           console.log('DropList Left')
         }}

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -42,6 +42,45 @@ describe('Render', () => {
     expect(getByText('Button Toggler')).toBeInTheDocument()
   })
 
+  test('should add aria label to menu if passsed (select)', async () => {
+    const { getByTestId, queryByRole, queryByLabelText } = render(
+      <DropList
+        menuAriaLabel="Demo label"
+        items={beatles}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+    const toggler = getByTestId('DropList.ButtonToggler')
+
+    expect(queryByRole('listbox')).not.toBeInTheDocument()
+
+    user.click(toggler)
+
+    await waitFor(() => {
+      expect(queryByLabelText('Demo label')).toBeInTheDocument()
+    })
+  })
+
+  test('should add aria label to menu if passsed (combobox)', async () => {
+    const { getByTestId, queryByRole, queryByLabelText } = render(
+      <DropList
+        variant="combobox"
+        menuAriaLabel="Demo label"
+        items={beatles}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+    const toggler = getByTestId('DropList.ButtonToggler')
+
+    expect(queryByRole('listbox')).not.toBeInTheDocument()
+
+    user.click(toggler)
+
+    await waitFor(() => {
+      expect(queryByLabelText('Demo label')).toBeInTheDocument()
+    })
+  })
+
   test('should render a menu list with string items', async () => {
     const { getByTestId, queryByText, queryByRole } = render(
       <DropList

--- a/src/components/Table/Table.HeaderCell.jsx
+++ b/src/components/Table/Table.HeaderCell.jsx
@@ -15,6 +15,10 @@ import {
 } from './Table.utils'
 
 export default function HeaderCell({ column, isLoading, sortedInfo }) {
+  const sorterBtnId = Array.isArray(column.columnKey)
+    ? `${column.columnKey.join('_')}_${column.sortKey}_sorter`
+    : `${column.columnKey}_${column.sortKey}_sorter`
+
   function getColumnSortStatus() {
     const colKey = Array.isArray(column.columnKey)
       ? column.sortKey
@@ -30,11 +34,39 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
     return 'none'
   }
 
-  function handleClick() {
+  function handleClick(e) {
+    e.persist()
+
     if (!isLoading && column.sorter != null) {
-      Array.isArray(column.columnKey)
+      const sorterFn = Array.isArray(column.columnKey)
         ? column.sorter(column.sortKey)
         : column.sorter(column.columnKey)
+
+      /**
+       * If the sorter function returns a promise, we refocus the button only when
+       * the event was triggered via {enter} key press.
+       *
+       * The check here only looks for a `then` function as we don't want
+       * to run this in all cases (like it would be if we use `Promise.resolve`)
+       */
+      if (sorterFn && typeof sorterFn.then === 'function') {
+        sorterFn.then(() => {
+          /**
+           * Refocus button only if the event was triggered with keyboard (thus avoid having to setup a separate onKeyDown event)
+           *
+           * https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
+           *     For click or dblclick events, UIEvent.detail is the current click count.
+           *     For mousedown or mouseup events, UIEvent.detail is 1 plus the current click count.
+           * => For all other UIEvent objects, UIEvent.detail is always zero.
+           */
+          if (e.detail === 0) {
+            // Due to async DOM stuff going on, get this out of the queue to make sure is the last and actually takes effect
+            setTimeout(() => {
+              document.getElementById(sorterBtnId).focus()
+            }, 0)
+          }
+        })
+      }
     }
   }
 
@@ -61,7 +93,7 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
             align={column.align}
             className={`${TABLE_CLASSNAME}__SortableHeaderCell__title`}
             onClick={handleClick}
-            tabIndex="0"
+            id={sorterBtnId}
           >
             {withCustomContent ? (
               generateCustomHeaderCell(column, sortedInfo)

--- a/src/components/Table/Table.HeaderCell.jsx
+++ b/src/components/Table/Table.HeaderCell.jsx
@@ -61,6 +61,7 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
             align={column.align}
             className={`${TABLE_CLASSNAME}__SortableHeaderCell__title`}
             onClick={handleClick}
+            tabIndex="0"
           >
             {withCustomContent ? (
               generateCustomHeaderCell(column, sortedInfo)

--- a/src/components/Table/Table.HeaderCell.jsx
+++ b/src/components/Table/Table.HeaderCell.jsx
@@ -38,7 +38,7 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
     e.persist()
 
     if (!isLoading && column.sorter != null) {
-      const sorterFn = Array.isArray(column.columnKey)
+      const sorterFnResult = Array.isArray(column.columnKey)
         ? column.sorter(column.sortKey)
         : column.sorter(column.columnKey)
 
@@ -49,8 +49,8 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
        * The check here only looks for a `then` function as we don't want
        * to run this in all cases (like it would be if we use `Promise.resolve`)
        */
-      if (sorterFn && typeof sorterFn.then === 'function') {
-        sorterFn.then(() => {
+      if (sorterFnResult && typeof sorterFnResult.then === 'function') {
+        sorterFnResult.then(() => {
           /**
            * Refocus button only if the event was triggered with keyboard (thus avoid having to setup a separate onKeyDown event)
            *

--- a/src/components/Table/Table.css.js
+++ b/src/components/Table/Table.css.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { getColor } from '../../styles/utilities/color'
 import Button from '../Button'
+import { focusRing } from '../../styles/mixins/focusRing.css'
 
 export const HeaderUI = styled('header')`
   display: flex;
@@ -233,16 +234,23 @@ export const SortableCellUI = styled('div')`
     margin-bottom: -4px;
   }
 `
+export const SortableCellContentUI = styled('button')`
+  ${focusRing};
+  --focusRingRadius: 4px;
 
-export const SortableCellContentUI = styled('div')`
   display: inline-flex;
   align-items: center;
   justify-content: ${props => getCellAlignment(props.align)};
   padding: 6px 8px;
   margin-left: -8px;
-  border-radius: 4px;
+  border-radius: var(--focusRingRadius);
+  background-color: transparent;
+  color: ${props => props.theme.fontColorHeader};
+  font-weight: 500;
+  border: 0;
   cursor: pointer;
   transition: background-color 0.15s ease-in-out;
+  font-family: var(--HSDSGlobalFontFamily);
 
   &:hover,
   .sorted & {

--- a/src/components/Table/Table.test.js
+++ b/src/components/Table/Table.test.js
@@ -367,7 +367,8 @@ describe('Sortable', () => {
     )
 
     // Regular column sorting, should be called with 'columnKey'
-    expect(container.querySelector(`thead th`).getAttribute('aria-sort')).toBe(
+    expect(container.querySelector(`thead th`)).toHaveAttribute(
+      'aria-sort',
       'none'
     )
     expect(container.querySelector('.is-sortable')).toBeInTheDocument()
@@ -384,9 +385,13 @@ describe('Sortable', () => {
       />
     )
 
-    expect(container.querySelector('thead th').getAttribute('aria-sort')).toBe(
+    expect(container.querySelector('thead th')).toHaveAttribute(
+      'aria-sort',
       'ascending'
     )
+    expect(
+      container.querySelector('.c-Table__SortableHeaderCell__title')
+    ).toHaveAttribute('tabIndex', '0')
 
     user.click(container.querySelector('.c-Table__SortableHeaderCell__title'))
 
@@ -423,7 +428,8 @@ describe('Sortable', () => {
       />
     )
 
-    expect(container.querySelector('thead th').getAttribute('aria-sort')).toBe(
+    expect(container.querySelector('thead th')).toHaveAttribute(
+      'aria-sort',
       'descending'
     )
   })

--- a/src/components/Table/stories/Table.stories.mdx
+++ b/src/components/Table/stories/Table.stories.mdx
@@ -71,7 +71,7 @@ Full list of acceptable fields 👇:
   - A function that takes the column object and returns a React Component/Element
   - If you need an icon, you can pass on object `{ iconName: 'chat' }` to get the `<Icon />` with the correct styles applied.
 - `renderCell`: To customize how each cell renders it corresponding data on this column. A function that takes the corresponding data and returns a React Component/Element, its arguments are the data provided by `columnKey` above, if using nested data, access it by replaceing the dot (`.`) with an underscore (`_`), for example: `customer.email` in `columnKey` becomes `customer_email` in `renderCell` (see code example below). It also gives you access to the `row`
-- `sorter`: A function that instructs how to sort the data based on this column
+- `sorter`: A function that instructs how to sort the data based on this column. If you return a promise, the table will be able to refocus the button when triggered via pressing the `enter` key
 - `sortKey`: If this column contains more than one columnKey, sorting will be based on this value which should exist in the list of Column Keys for this column.
 
 Note: only `columnKey` is required

--- a/src/components/Table/stories/TableWithSorting.js
+++ b/src/components/Table/stories/TableWithSorting.js
@@ -88,7 +88,7 @@ export default class TablePlayground extends Component {
     })
 
     // simulate sortData as an API call
-    sortData(data, columnKey, sortedInfo.order).then(sortedData => {
+    return sortData(data, columnKey, sortedInfo.order).then(sortedData => {
       this.setState({
         data: sortedData,
         sortedInfo: {

--- a/src/components/Table/stories/TableWithSorting.js
+++ b/src/components/Table/stories/TableWithSorting.js
@@ -10,9 +10,14 @@ export default class TablePlayground extends Component {
       data: createFakeCustomers({ amount: 10 }),
       columns: [
         {
+          title: 'Not sortable',
+          columnKey: ['name'],
+          width: '25%',
+        },
+        {
           title: 'Customer (sorts by name)',
           columnKey: ['name', 'companyName'],
-          width: '30%',
+          width: '25%',
           sortKey: 'name',
           sorter: this.sortAlphabetically,
           renderCell: ({ name, companyName }) => {
@@ -28,7 +33,7 @@ export default class TablePlayground extends Component {
         {
           title: 'Customer (sorts by company)',
           columnKey: ['name', 'companyName'],
-          width: '30%',
+          width: '25%',
           sortKey: 'companyName',
           sorter: this.sortAlphabetically,
           renderCell: ({ name, companyName }) => {
@@ -45,7 +50,7 @@ export default class TablePlayground extends Component {
           title: 'Company',
           columnKey: 'companyName',
           align: 'center',
-          width: '35%',
+          width: '25%',
           renderHeaderCell: { iconName: 'chat' },
           sorter: this.sortAlphabetically,
         },


### PR DESCRIPTION
## Table

When setting up a sortable table, header cells currently are only click-actionable. In this PR we switch the `div` for a  `button` for them to become actionable with a keyboard.

Sorting the table is most likely going to be an async task, and when triggering it with the keyboard the UI state gets lost: in this case we care about the focus state. To make it a better UX, we can now return a Promise on the `sorter` function and we'll take this cue to refocus the button.

Trying it out is better than trying to explain it: https://dad6d9e3.hsds-react.pages.dev/iframe?id=components-structural-table--with-sorting&args=&viewMode=story

cc @digitaldesigner, what would we want as a focus style? Currently (on firefox):

<img width="595" alt="Screen Shot 2022-01-18 at 4 54 53 PM" src="https://user-images.githubusercontent.com/1414086/149971966-96cd2838-5a79-45d6-9172-793bb8beb6d6.png">


## DropList

Downshift automatically adds a `aria-labelledby` attribute to the menu dropdown, but we don't use labels in DropList, making it always point to an inexistent element. We add a `menuAriaLabel` prop to set a custom `aria-label` directly on the menu and we remove the `aria-labelledby` set by downshift

