### PR TITLE
DropList focus enhancements

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -35,6 +35,7 @@ function Combobox({
   inputPlaceholder = 'Search',
   items = [],
   isOpen = false,
+  menuAriaLabel,
   menuCSS,
   menuWidth,
   onDropListLeave = noop,
@@ -238,6 +239,8 @@ function Combobox({
       <MenuListUI
         className={`${DROPLIST_MENULIST} MenuList-Combobox`}
         {...getMenuProps()}
+        aria-label={menuAriaLabel}
+        aria-labelledby={null}
       >
         {renderListContents({
           customEmptyList,

--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -8,7 +8,6 @@ import {
   isItemSelected,
   renderListContents,
   isItemHighlightable,
-  checkNextElementFocusedAndThenRun,
 } from './DropList.utils'
 import {
   getA11ySelectionMessageCommon,
@@ -25,7 +24,6 @@ import { DROPLIST_MENULIST, VARIANTS } from './DropList.constants'
 
 function Combobox({
   clearOnSelect = false,
-  closeOnBlur = true,
   closeOnSelection = true,
   customEmptyList = null,
   customEmptyListItems,
@@ -109,7 +107,6 @@ function Combobox({
 
     onIsOpenChange(changes) {
       onIsOpenChangeCommon({
-        closeOnBlur,
         closeOnSelection,
         toggleOpenedState,
         type: `${VARIANTS.COMBOBOX}.${changes.type}`,
@@ -202,10 +199,6 @@ function Combobox({
             ref: inputEl,
             onBlur: event => {
               onMenuBlur(event)
-              checkNextElementFocusedAndThenRun(
-                ['DropListToggler'],
-                onDropListLeave
-              )
             },
             onChange: event => {
               onInputChange(event.target.value)
@@ -216,6 +209,7 @@ function Combobox({
             onKeyDown: event => {
               if (event.key === 'Tab') {
                 toggleOpenedState(false)
+                onDropListLeave()
               } else if (event.key === 'Escape') {
                 focusToggler()
               } else if (event.key === 'Enter') {

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -5,7 +5,6 @@ import {
   itemToString,
   isItemSelected,
   renderListContents,
-  checkNextElementFocusedAndThenRun,
 } from './DropList.utils'
 import {
   getA11ySelectionMessageCommon,
@@ -18,7 +17,6 @@ import { DROPLIST_MENULIST, VARIANTS } from './DropList.constants'
 
 function Select({
   clearOnSelect = false,
-  closeOnBlur = true,
   closeOnSelection = true,
   customEmptyList = null,
   customEmptyListItems,
@@ -163,6 +161,9 @@ function Select({
           onListItemSelectEvent({ listItemNode: item, event })
         }
       })
+    } else if (event.key === 'Tab') {
+      isOpen && toggleOpenedState(false)
+      onDropListLeave()
     }
   }
 
@@ -185,23 +186,6 @@ function Select({
             onMenuFocus(e)
           },
           onBlur: e => {
-            if (closeOnBlur) {
-              /**
-               * Closing on blur
-               *
-               * When clicking on the toggler, this event gets fired _before_
-               * so it sets the isOpen flag to false, and then the click event happens
-               * and sets isOpen to true, making the DropList never close on cliking
-               * the toggler.
-               *
-               * Here we wait a little bit to see if the next element gathering focus
-               * is indeed the toggler, and only close the DropList if it isn't
-               */
-              checkNextElementFocusedAndThenRun(['DropListToggler'], () => {
-                isOpen && toggleOpenedState(false)
-                onDropListLeave()
-              })
-            }
             onMenuBlur(e)
           },
         })}

--- a/src/components/DropList/DropList.Select.jsx
+++ b/src/components/DropList/DropList.Select.jsx
@@ -27,6 +27,7 @@ function Select({
   handleSelectedItemChange = noop,
   isOpen = false,
   items = [],
+  menuAriaLabel,
   menuCSS,
   menuWidth,
   focusToggler = noop,
@@ -172,7 +173,9 @@ function Select({
       menuCSS={menuCSS}
       menuWidth={menuWidth}
     >
-      <A11yTogglerUI {...getToggleButtonProps()}>Toggler</A11yTogglerUI>
+      <A11yTogglerUI {...getToggleButtonProps()} aria-labelledby={null}>
+        Toggler
+      </A11yTogglerUI>
       <MenuListUI
         data-event-driver
         className={`${DROPLIST_MENULIST} MenuList-Select`}
@@ -202,6 +205,8 @@ function Select({
             onMenuBlur(e)
           },
         })}
+        aria-label={menuAriaLabel}
+        aria-labelledby={null}
       >
         {renderListContents({
           customEmptyList,

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -112,22 +112,10 @@ function DropListManager({
 
   function decorateUserToggler(userToggler) {
     if (React.isValidElement(userToggler)) {
-      const {
-        className,
-        onClick,
-        onFocus,
-        onKeyDown,
-        onBlur,
-      } = userToggler.props
+      const { className, onClick, onFocus, onBlur } = userToggler.props
       const togglerProps = {
         className: classNames(DROPLIST_TOGGLER, className),
         isActive: isOpen,
-        onKeyDown: e => {
-          onKeyDown && onKeyDown(e)
-          if (e.key === 'Tab') {
-            debouncedOnDropListLeave()
-          }
-        },
         onBlur: e => {
           onBlur && onBlur(e)
           if (!isOpen) {

--- a/src/components/DropList/DropList.jsx
+++ b/src/components/DropList/DropList.jsx
@@ -47,6 +47,7 @@ function DropListManager({
   inputPlaceholder = 'Search',
   isMenuOpen = false,
   items = [],
+  menuAriaLabel = '',
   menuCSS,
   menuWidth,
   onDropListLeave = noop,
@@ -288,6 +289,7 @@ function DropListManager({
             inputPlaceholder={inputPlaceholder}
             isOpen={isOpen}
             items={parsedItems}
+            menuAriaLabel={menuAriaLabel}
             menuCSS={menuCSS}
             menuWidth={getMenuWidth(DropListVariant.name, menuWidth)}
             onDropListLeave={onDropListLeave}
@@ -368,6 +370,8 @@ DropListManager.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, itemShape, dividerShape, groupShape])
   ),
+  /** Custom aria label for the Menu */
+  menuAriaLabel: PropTypes.string,
   /** Custom css for the Menu */
   menuCSS: PropTypes.any,
   /** Custom width for the Menu */

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -280,36 +280,15 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
       }}
     >
       <DropList
-        isMenuOpen={boolean('Is Menu Open', false)}
-        focusTogglerOnMenuClose={boolean('focusTogglerOnMenuClose', true)}
         menuAriaLabel="Demo DropList"
         onDropListLeave={() => {
           console.log('Select left')
         }}
-        onOpenedStateChange={isOpen => {
-          console.log('onOpenedStateChange', isOpen)
-        }}
-        onListItemSelectEvent={({ event, listItemNode }) => {
-          console.log('event', event)
-          console.log('listItemNode', listItemNode)
-        }}
-        selection={select(
-          'Selection',
-          {
-            clear: null,
-            first: regularItems[0],
-            second: regularItems[1],
-            third: regularItems[2],
-          },
-          regularItems[1]
-        )}
         items={regularItems}
         toggler={<SimpleButton text="Select" />}
       />
       <DropList
         variant="combobox"
-        inputPlaceholder={text('inputPlaceholder', 'Search')}
-        focusTogglerOnMenuClose={boolean('focusTogglerOnMenuClose', true)}
         onDropListLeave={() => {
           console.log('Combobox left')
         }}
@@ -322,10 +301,6 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
           },
           regularItems
         )}
-        onSelect={(selection, clickedItem) => {
-          console.log('🚀 ~ selection', selection)
-          console.log('🚀 ~ clickedItem', clickedItem)
-        }}
         toggler={
           <SimpleButton text="Combobox" style={{ marginLeft: '20px' }} />
         }

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -205,6 +205,7 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
       <DropList
         isMenuOpen={boolean('Is Menu Open', false)}
         focusTogglerOnMenuClose={boolean('focusTogglerOnMenuClose', true)}
+        menuAriaLabel="Demo DropList"
         onDropListLeave={() => {
           console.log('DropList Left')
         }}

--- a/src/components/DropList/DropList.stories.mdx
+++ b/src/components/DropList/DropList.stories.mdx
@@ -206,9 +206,6 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
         isMenuOpen={boolean('Is Menu Open', false)}
         focusTogglerOnMenuClose={boolean('focusTogglerOnMenuClose', true)}
         menuAriaLabel="Demo DropList"
-        onDropListLeave={() => {
-          console.log('DropList Left')
-        }}
         onOpenedStateChange={isOpen => {
           console.log('onOpenedStateChange', isOpen)
         }}
@@ -265,6 +262,73 @@ You can use the `autoSetComboboxAt` prop to automatically choose between the 2 v
           console.log('🚀 ~ clickedItem', clickedItem)
         }}
         toggler={<SimpleButton text="This is a combobox" />}
+      />
+    </div>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Focusing and leaving">
+    <div
+      tabIndex="0"
+      style={{
+        width: '400px',
+        margin: '50px 100px 200px 150px',
+        border: '1px dashed silver',
+        borderRadius: '5px',
+        padding: '20px',
+      }}
+    >
+      <DropList
+        isMenuOpen={boolean('Is Menu Open', false)}
+        focusTogglerOnMenuClose={boolean('focusTogglerOnMenuClose', true)}
+        menuAriaLabel="Demo DropList"
+        onDropListLeave={() => {
+          console.log('Select left')
+        }}
+        onOpenedStateChange={isOpen => {
+          console.log('onOpenedStateChange', isOpen)
+        }}
+        onListItemSelectEvent={({ event, listItemNode }) => {
+          console.log('event', event)
+          console.log('listItemNode', listItemNode)
+        }}
+        selection={select(
+          'Selection',
+          {
+            clear: null,
+            first: regularItems[0],
+            second: regularItems[1],
+            third: regularItems[2],
+          },
+          regularItems[1]
+        )}
+        items={regularItems}
+        toggler={<SimpleButton text="Select" />}
+      />
+      <DropList
+        variant="combobox"
+        inputPlaceholder={text('inputPlaceholder', 'Search')}
+        focusTogglerOnMenuClose={boolean('focusTogglerOnMenuClose', true)}
+        onDropListLeave={() => {
+          console.log('Combobox left')
+        }}
+        items={select(
+          'Items',
+          {
+            regular: regularItems,
+            withDivider: itemsWithDivider,
+            grouped: simpleGroupedItems,
+          },
+          regularItems
+        )}
+        onSelect={(selection, clickedItem) => {
+          console.log('🚀 ~ selection', selection)
+          console.log('🚀 ~ clickedItem', clickedItem)
+        }}
+        toggler={
+          <SimpleButton text="Combobox" style={{ marginLeft: '20px' }} />
+        }
       />
     </div>
   </Story>

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -1664,15 +1664,14 @@ describe('More open close behaviours', () => {
 
     // open the droplist
     user.click(toggler)
-    // click outside
     user.type(queryByRole('listbox'), '{esc}')
 
     expect(getByTestId('DropList.ButtonToggler')).toHaveFocus()
   })
 
-  test('onDropListLeave: click outside', () => {
+  test('onDropListLeave: click outside', async () => {
     const onDropListLeaveSpy = jest.fn()
-    const { queryByText } = render(
+    const { container, queryByText } = render(
       <DropList
         onDropListLeave={onDropListLeaveSpy}
         focusTogglerOnMenuClose={false}
@@ -1685,13 +1684,19 @@ describe('More open close behaviours', () => {
 
     // open the droplist
     user.click(toggler)
-    // click outside
-    user.click(document.body)
+    await waitFor(() => {
+      expect(onDropListLeaveSpy).not.toHaveBeenCalled()
+    })
 
-    expect(onDropListLeaveSpy).toHaveBeenCalled()
+    // click outside
+    user.click(container.parentElement)
+
+    await waitFor(() => {
+      expect(onDropListLeaveSpy).toHaveBeenCalledTimes(1)
+    })
   })
 
-  test('onDropListLeave: tab out of toggler (menu open)', () => {
+  test('onDropListLeave: tab out of toggler (menu open)', async () => {
     const onDropListLeaveSpy = jest.fn()
     const onBlurSpy = jest.fn()
     const { queryByText } = render(
@@ -1712,9 +1717,11 @@ describe('More open close behaviours', () => {
 
     user.click(toggler)
 
-    // Focus passes to the menu when we open it
-    expect(onDropListLeaveSpy).not.toHaveBeenCalled()
-    expect(onBlurSpy).toHaveBeenCalled()
+    await waitFor(() => {
+      // Focus passes to the menu when we open it
+      expect(onDropListLeaveSpy).not.toHaveBeenCalled()
+      expect(onBlurSpy).toHaveBeenCalled()
+    })
   })
 
   test('onDropListLeave: blur out of menu', async () => {
@@ -1742,7 +1749,7 @@ describe('More open close behaviours', () => {
     user.click(queryByText('Demo'))
 
     await waitFor(() => {
-      expect(onDropListLeaveSpy).toHaveBeenCalled()
+      expect(onDropListLeaveSpy).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -1770,7 +1777,7 @@ describe('More open close behaviours', () => {
     user.tab()
 
     await waitFor(() => {
-      expect(onDropListLeaveSpy).toHaveBeenCalled()
+      expect(onDropListLeaveSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/DropList/DropList.test.js
+++ b/src/components/DropList/DropList.test.js
@@ -42,6 +42,45 @@ describe('Render', () => {
     expect(getByText('Button Toggler')).toBeInTheDocument()
   })
 
+  test('should add aria label to menu if passsed (select)', async () => {
+    const { getByTestId, queryByRole, queryByLabelText } = render(
+      <DropList
+        menuAriaLabel="Demo label"
+        items={beatles}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+    const toggler = getByTestId('DropList.ButtonToggler')
+
+    expect(queryByRole('listbox')).not.toBeInTheDocument()
+
+    user.click(toggler)
+
+    await waitFor(() => {
+      expect(queryByLabelText('Demo label')).toBeInTheDocument()
+    })
+  })
+
+  test('should add aria label to menu if passsed (combobox)', async () => {
+    const { getByTestId, queryByRole, queryByLabelText } = render(
+      <DropList
+        variant="combobox"
+        menuAriaLabel="Demo label"
+        items={beatles}
+        toggler={<SimpleButton text="Button Toggler" />}
+      />
+    )
+    const toggler = getByTestId('DropList.ButtonToggler')
+
+    expect(queryByRole('listbox')).not.toBeInTheDocument()
+
+    user.click(toggler)
+
+    await waitFor(() => {
+      expect(queryByLabelText('Demo label')).toBeInTheDocument()
+    })
+  })
+
   test('should render a menu list with string items', async () => {
     const { getByTestId, queryByText, queryByRole } = render(
       <DropList

--- a/src/components/DropList/DropList.utils.js
+++ b/src/components/DropList/DropList.utils.js
@@ -294,31 +294,6 @@ export function getEnabledItemIndex({
     arrowKey,
   })
 }
-/**
- * Helper that allows you to run a callback after a timeout,
- * provided that after the timeout the document.activeElement
- * doesn't have any of the class names provided.
- * Example: Useful when you would like to execute something after
- * a blur event happens but not if the next element that gets focused has a certain
- * classname.
- * @param {String[]} classNames The class names of the document.activeElement that exclude the callback being run
- * @param {*} cb The function to run
- */
-export function checkNextElementFocusedAndThenRun(
-  classNames = [],
-  cb,
-  timeout = 50
-) {
-  setTimeout(() => {
-    const shouldRun = classNames.every(
-      cs => !document.activeElement.classList.contains(cs)
-    )
-
-    if (shouldRun) {
-      cb()
-    }
-  }, timeout)
-}
 
 export function getMenuWidth(variant, menuWidth) {
   if (menuWidth != null) return menuWidth

--- a/src/components/Table/Table.HeaderCell.jsx
+++ b/src/components/Table/Table.HeaderCell.jsx
@@ -15,6 +15,10 @@ import {
 } from './Table.utils'
 
 export default function HeaderCell({ column, isLoading, sortedInfo }) {
+  const sorterBtnId = Array.isArray(column.columnKey)
+    ? `${column.columnKey.join('_')}_${column.sortKey}_sorter`
+    : `${column.columnKey}_${column.sortKey}_sorter`
+
   function getColumnSortStatus() {
     const colKey = Array.isArray(column.columnKey)
       ? column.sortKey
@@ -30,11 +34,39 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
     return 'none'
   }
 
-  function handleClick() {
+  function handleClick(e) {
+    e.persist()
+
     if (!isLoading && column.sorter != null) {
-      Array.isArray(column.columnKey)
+      const sorterFn = Array.isArray(column.columnKey)
         ? column.sorter(column.sortKey)
         : column.sorter(column.columnKey)
+
+      /**
+       * If the sorter function returns a promise, we refocus the button only when
+       * the event was triggered via {enter} key press.
+       *
+       * The check here only looks for a `then` function as we don't want
+       * to run this in all cases (like it would be if we use `Promise.resolve`)
+       */
+      if (sorterFn && typeof sorterFn.then === 'function') {
+        sorterFn.then(() => {
+          /**
+           * Refocus button only if the event was triggered with keyboard (thus avoid having to setup a separate onKeyDown event)
+           *
+           * https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
+           *     For click or dblclick events, UIEvent.detail is the current click count.
+           *     For mousedown or mouseup events, UIEvent.detail is 1 plus the current click count.
+           * => For all other UIEvent objects, UIEvent.detail is always zero.
+           */
+          if (e.detail === 0) {
+            // Due to async DOM stuff going on, get this out of the queue to make sure is the last and actually takes effect
+            setTimeout(() => {
+              document.getElementById(sorterBtnId).focus()
+            }, 0)
+          }
+        })
+      }
     }
   }
 
@@ -61,7 +93,7 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
             align={column.align}
             className={`${TABLE_CLASSNAME}__SortableHeaderCell__title`}
             onClick={handleClick}
-            tabIndex="0"
+            id={sorterBtnId}
           >
             {withCustomContent ? (
               generateCustomHeaderCell(column, sortedInfo)

--- a/src/components/Table/Table.HeaderCell.jsx
+++ b/src/components/Table/Table.HeaderCell.jsx
@@ -61,6 +61,7 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
             align={column.align}
             className={`${TABLE_CLASSNAME}__SortableHeaderCell__title`}
             onClick={handleClick}
+            tabIndex="0"
           >
             {withCustomContent ? (
               generateCustomHeaderCell(column, sortedInfo)

--- a/src/components/Table/Table.HeaderCell.jsx
+++ b/src/components/Table/Table.HeaderCell.jsx
@@ -38,7 +38,7 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
     e.persist()
 
     if (!isLoading && column.sorter != null) {
-      const sorterFn = Array.isArray(column.columnKey)
+      const sorterFnResult = Array.isArray(column.columnKey)
         ? column.sorter(column.sortKey)
         : column.sorter(column.columnKey)
 
@@ -49,8 +49,8 @@ export default function HeaderCell({ column, isLoading, sortedInfo }) {
        * The check here only looks for a `then` function as we don't want
        * to run this in all cases (like it would be if we use `Promise.resolve`)
        */
-      if (sorterFn && typeof sorterFn.then === 'function') {
-        sorterFn.then(() => {
+      if (sorterFnResult && typeof sorterFnResult.then === 'function') {
+        sorterFnResult.then(() => {
           /**
            * Refocus button only if the event was triggered with keyboard (thus avoid having to setup a separate onKeyDown event)
            *

--- a/src/components/Table/Table.css.js
+++ b/src/components/Table/Table.css.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { getColor } from '../../styles/utilities/color'
 import Button from '../Button'
+import { focusRing } from '../../styles/mixins/focusRing.css'
 
 export const HeaderUI = styled('header')`
   display: flex;
@@ -233,16 +234,23 @@ export const SortableCellUI = styled('div')`
     margin-bottom: -4px;
   }
 `
+export const SortableCellContentUI = styled('button')`
+  ${focusRing};
+  --focusRingRadius: 4px;
 
-export const SortableCellContentUI = styled('div')`
   display: inline-flex;
   align-items: center;
   justify-content: ${props => getCellAlignment(props.align)};
   padding: 6px 8px;
   margin-left: -8px;
-  border-radius: 4px;
+  border-radius: var(--focusRingRadius);
+  background-color: transparent;
+  color: ${props => props.theme.fontColorHeader};
+  font-weight: 500;
+  border: 0;
   cursor: pointer;
   transition: background-color 0.15s ease-in-out;
+  font-family: var(--HSDSGlobalFontFamily);
 
   &:hover,
   .sorted & {

--- a/src/components/Table/Table.test.js
+++ b/src/components/Table/Table.test.js
@@ -389,9 +389,6 @@ describe('Sortable', () => {
       'aria-sort',
       'ascending'
     )
-    expect(
-      container.querySelector('.c-Table__SortableHeaderCell__title')
-    ).toHaveAttribute('tabIndex', '0')
 
     user.click(container.querySelector('.c-Table__SortableHeaderCell__title'))
 

--- a/src/components/Table/Table.test.js
+++ b/src/components/Table/Table.test.js
@@ -367,7 +367,8 @@ describe('Sortable', () => {
     )
 
     // Regular column sorting, should be called with 'columnKey'
-    expect(container.querySelector(`thead th`).getAttribute('aria-sort')).toBe(
+    expect(container.querySelector(`thead th`)).toHaveAttribute(
+      'aria-sort',
       'none'
     )
     expect(container.querySelector('.is-sortable')).toBeInTheDocument()
@@ -384,9 +385,13 @@ describe('Sortable', () => {
       />
     )
 
-    expect(container.querySelector('thead th').getAttribute('aria-sort')).toBe(
+    expect(container.querySelector('thead th')).toHaveAttribute(
+      'aria-sort',
       'ascending'
     )
+    expect(
+      container.querySelector('.c-Table__SortableHeaderCell__title')
+    ).toHaveAttribute('tabIndex', '0')
 
     user.click(container.querySelector('.c-Table__SortableHeaderCell__title'))
 
@@ -423,7 +428,8 @@ describe('Sortable', () => {
       />
     )
 
-    expect(container.querySelector('thead th').getAttribute('aria-sort')).toBe(
+    expect(container.querySelector('thead th')).toHaveAttribute(
+      'aria-sort',
       'descending'
     )
   })

--- a/src/components/Table/stories/Table.stories.mdx
+++ b/src/components/Table/stories/Table.stories.mdx
@@ -71,7 +71,7 @@ Full list of acceptable fields 👇:
   - A function that takes the column object and returns a React Component/Element
   - If you need an icon, you can pass on object `{ iconName: 'chat' }` to get the `<Icon />` with the correct styles applied.
 - `renderCell`: To customize how each cell renders it corresponding data on this column. A function that takes the corresponding data and returns a React Component/Element, its arguments are the data provided by `columnKey` above, if using nested data, access it by replaceing the dot (`.`) with an underscore (`_`), for example: `customer.email` in `columnKey` becomes `customer_email` in `renderCell` (see code example below). It also gives you access to the `row`
-- `sorter`: A function that instructs how to sort the data based on this column
+- `sorter`: A function that instructs how to sort the data based on this column. If you return a promise, the table will be able to refocus the button when triggered via pressing the `enter` key
 - `sortKey`: If this column contains more than one columnKey, sorting will be based on this value which should exist in the list of Column Keys for this column.
 
 Note: only `columnKey` is required

--- a/src/components/Table/stories/TableWithSorting.js
+++ b/src/components/Table/stories/TableWithSorting.js
@@ -88,7 +88,7 @@ export default class TablePlayground extends Component {
     })
 
     // simulate sortData as an API call
-    sortData(data, columnKey, sortedInfo.order).then(sortedData => {
+    return sortData(data, columnKey, sortedInfo.order).then(sortedData => {
       this.setState({
         data: sortedData,
         sortedInfo: {

--- a/src/components/Table/stories/TableWithSorting.js
+++ b/src/components/Table/stories/TableWithSorting.js
@@ -10,9 +10,14 @@ export default class TablePlayground extends Component {
       data: createFakeCustomers({ amount: 10 }),
       columns: [
         {
+          title: 'Not sortable',
+          columnKey: ['name'],
+          width: '25%',
+        },
+        {
           title: 'Customer (sorts by name)',
           columnKey: ['name', 'companyName'],
-          width: '30%',
+          width: '25%',
           sortKey: 'name',
           sorter: this.sortAlphabetically,
           renderCell: ({ name, companyName }) => {
@@ -28,7 +33,7 @@ export default class TablePlayground extends Component {
         {
           title: 'Customer (sorts by company)',
           columnKey: ['name', 'companyName'],
-          width: '30%',
+          width: '25%',
           sortKey: 'companyName',
           sorter: this.sortAlphabetically,
           renderCell: ({ name, companyName }) => {
@@ -45,7 +50,7 @@ export default class TablePlayground extends Component {
           title: 'Company',
           columnKey: 'companyName',
           align: 'center',
-          width: '35%',
+          width: '25%',
           renderHeaderCell: { iconName: 'chat' },
           sorter: this.sortAlphabetically,
         },


### PR DESCRIPTION
# Problem
![CleanShot 2022-01-24 at 14 03 03](https://user-images.githubusercontent.com/1414086/150787763-37b2506d-6c25-49f5-8817-d5ca0b3fd350.gif)

In the example above I made the container focusable to demonstrate a couple of things happening:
- When tabbing out of the DropList, for a brief moment it focuses the container, and then focuses back on the toggler.
- Not only is jarring, but the behaviour of focusing back on the toggler is not standard, it should focus on the next focusable element.

# Solution
Change the way we manage focus, a lot of the complexity was because of `onDropListLeave` which we want to fire when the DropList is left, whether is by clicking outside, blurring the toggler, etc.

- Use a combination of memoization and debouncing instead of a special utility with a timeout to avoid the `onDropListLeave` callback to fire multiple times 
- Focus the next focusable element when tabbing out of DropList instead of trying to keep focus on itself.
- Esc still closes the menu and refocus it's own toggler, as you would expect 

![CleanShot 2022-01-24 at 14 09 41](https://user-images.githubusercontent.com/1414086/150788700-096b0001-907a-4a7a-a367-acefa47fba3a.gif)


## Extra

- I removed the dependency on Global context, to set a scope; we always use hsds-react, no need to complicate things
- Downshift automatically adds a `aria-labelledby` attribute to the menu dropdown, but we don't use labels in DropList, making it always point to an inexistent element. We add a `menuAriaLabel` prop to set a custom `aria-label` directly on the menu and we remove the `aria-labelledby` set by downshift
- It includes Table changes from https://github.com/helpscout/hsds-react/pull/1016, which I will close and release this instead:

	When setting up a sortable table, header cells currently are only click-actionable. In this PR we switch the `div` for a  `button` for them to become actionable with a keyboard.

	Sorting the table is most likely going to be an async task, and when triggering it with the keyboard the UI state gets lost: in this case we care about the focus state. To make it a better UX, we can now return a Promise on the `sorter` function and we'll take this cue to refocus the button.
