### PR TITLE
Do not set aria-describedby on Choice input when no helpText

### DIFF
--- a/src/components/Choice/Choice.jsx
+++ b/src/components/Choice/Choice.jsx
@@ -177,7 +177,7 @@ class Choice extends React.PureComponent {
       disabled,
       helpText,
       id: choiceID,
-      ariaDescribedBy: `${choiceID}_description`,
+      ariaDescribedBy: helpText ? `${choiceID}_description` : null,
       inputRef,
       innerRef,
       kind,

--- a/src/components/Choice/Choice.test.js
+++ b/src/components/Choice/Choice.test.js
@@ -147,6 +147,13 @@ describe('HelpText', () => {
     )
     wrapper.unmount()
   })
+
+  test('Does not set described by on input if no help text', () => {
+    const wrapper = mount(<Choice label="Label" id="test-id" />)
+
+    expect(wrapper.find('input').prop('aria-describedby')).not.toBeDefined()
+    wrapper.unmount()
+  })
 })
 
 describe('Label', () => {


### PR DESCRIPTION
# Problem/Feature
This PR fixes previous fix (:facepalm:) - `aria-describedby` should not be set on Choice input if there's no helpText.

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
