### PR TITLE
Show ellipsis for long Message variable values

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -277,23 +277,29 @@ export const BodyUI = styled.div`
     text-decoration: line-through;
   }
 
-  span.${messageVariableClassName} {
+  .${messageVariableClassName} {
     display: inline-flex;
-    align-items: center;
+    max-width: 50%;
     padding: 3px 8px;
     margin-right: 4px;
     height: 20px;
     line-height: 17px;
-
+    align-items: center;
     color: ${getColor('purple.800')};
     background-color: ${getColor('purple.200')};
     border-radius: 100px;
 
-    // clearing any text style coming from b or i elements, as we want to have it always display the same
-    font-style: normal;
-    font-weight: normal;
-    text-decoration: none;
-    white-space: nowrap;
+    &__text {
+      max-width: 100%;
+
+      // clearing any text style coming from b or i elements, as we want to have it always display the same
+      font-style: normal;
+      font-weight: normal;
+      text-decoration: none;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 `
 

--- a/src/components/MessageCard/MessageCard.stories.mdx
+++ b/src/components/MessageCard/MessageCard.stories.mdx
@@ -153,7 +153,10 @@ This component renders a Message Card Notification with (optional) Title, Subtit
       title={text('Title', 'Need help?')}
       body={text(
         'Body',
-        '<p>Hi {%customer.firstName,fallback=there%}!</p> <p>This <i>sentence</i> has five <u>words</u>. </p> <p>See you at our <b>amazing show with {%coordinator,fallback=Coordinator%}</b>!</p> <p>It would happen at {%date%}</p> <p>And this is non-existing variable {%nonExisting,fallback=no%}</p>'
+        '<p>Hi {%customer.firstName,fallback=there%}!</p> <p>This <i>sentence</i> has five <u>words</u>. </p>' +
+          ' <p>See you at our <b>amazing show with {%coordinator,fallback=Coordinator%}</b>!</p>' +
+          ' <p>It would happen at {%date%}</p> <p>And this is non-existing variable {%nonExisting,fallback=no%}</p>' +
+          ' <p>Long variable {%coordinator,fallback=Some quite very very long variable fallback%}</p>'
       )}
       variables={[
         { id: 'customer.firstName', display: 'First Name' },

--- a/src/components/MessageCard/utils/MessageCard.utils.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.js
@@ -5,7 +5,8 @@ export const messageVariableClassName = 'hsds-message-card-variable'
  * They would be replaced with fallback text, if present. If no fallback text, label from variable would be used
  * Only variables provided in parameter would be replaced, others are kept untouched in the raw version
  *
- * Variable raw text is replaced with <span class="hsds-message-card-variable"> element.
+ * Variable raw text is replaced with <span class="hsds-message-card-variable"> and <span class="hsds-message-card-variable__text"> elements.
+ * Two elements are necessary to properly insert ellipsis for longer variables, and keep the proper styling
  *
  * @param text {String} text to replace variables within (if any)
  * @param variables {Array<{id: String, display: String}>} list of variables to replace
@@ -28,7 +29,7 @@ export const replaceMessageVariables = (text = '', variables = []) => {
     const variable = variables.find(variable => variable.id === variableId)
     if (variable) {
       const variableText = !fallback ? variable.display : fallback
-      return `<span class="${messageVariableClassName}">${variableText}</span>`
+      return `<span class="${messageVariableClassName}" title="${variableText}"><span class="${messageVariableClassName}__text">${variableText}</span></span>`
     }
     return match
   }

--- a/src/components/MessageCard/utils/MessageCard.utils.test.js
+++ b/src/components/MessageCard/utils/MessageCard.utils.test.js
@@ -22,7 +22,7 @@ describe('MessageCard.utils', () => {
     const result = replaceMessageVariables(text, variables)
 
     expect(result).toEqual(
-      `<p>Hi <span class="hsds-message-card-variable">there</span> <span class="hsds-message-card-variable">you</span></p>`
+      `<p>Hi <span class="hsds-message-card-variable" title="there"><span class="hsds-message-card-variable__text">there</span></span> <span class="hsds-message-card-variable" title="you"><span class="hsds-message-card-variable__text">you</span></span></p>`
     )
   })
 
@@ -32,7 +32,7 @@ describe('MessageCard.utils', () => {
     const result = replaceMessageVariables(text, variables)
 
     expect(result).toEqual(
-      `<p>Hi <span class="hsds-message-card-variable">there</span> <span class="hsds-message-card-variable">Custom Variable</span></p>`
+      `<p>Hi <span class="hsds-message-card-variable" title="there"><span class="hsds-message-card-variable__text">there</span></span> <span class="hsds-message-card-variable" title="Custom Variable"><span class="hsds-message-card-variable__text">Custom Variable</span></span></p>`
     )
   })
 
@@ -42,7 +42,7 @@ describe('MessageCard.utils', () => {
     const result = replaceMessageVariables(text, variables)
 
     expect(result).toEqual(
-      `<p>Hi <span class="hsds-message-card-variable">First Name</span> <span class="hsds-message-card-variable">you</span></p>`
+      `<p>Hi <span class="hsds-message-card-variable" title="First Name"><span class="hsds-message-card-variable__text">First Name</span></span> <span class="hsds-message-card-variable" title="you"><span class="hsds-message-card-variable__text">you</span></span></p>`
     )
   })
 
@@ -52,7 +52,7 @@ describe('MessageCard.utils', () => {
     const result = replaceMessageVariables(text, variables)
 
     expect(result).toEqual(
-      `<p>Hi <span class="hsds-message-card-variable">there % there</span> <span class="hsds-message-card-variable">you % there</span></p>`
+      `<p>Hi <span class="hsds-message-card-variable" title="there % there"><span class="hsds-message-card-variable__text">there % there</span></span> <span class="hsds-message-card-variable" title="you % there"><span class="hsds-message-card-variable__text">you % there</span></span></p>`
     )
   })
 


### PR DESCRIPTION
# Problem/Feature
There was an issue with long variable value inserted into MessageCard - it was going out of the right edge of a card, like here:
<img width="1147" alt="Screenshot 2022-01-28 at 20 17 32" src="https://user-images.githubusercontent.com/1765264/152337669-61f945d4-6a71-4142-b1eb-e2c203122793.png">

The solution is to limit the width of the variable pill to up to 50% of the available width within a card and to show ellipsis is there are more characters than displayed:
![Screenshot from 2022-02-03 12-46-44](https://user-images.githubusercontent.com/1765264/152337842-6d1df228-5775-4319-bea9-47c247baff72.png)

Use `MessageCard -> With variables` story to see example

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
