### PR TITLE
Fix long variable preview

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -282,7 +282,7 @@ export const BodyUI = styled.div`
     align-items: center;
     padding: 3px 8px;
     margin-right: 4px;
-    height: 20px;
+    min-height: 20px;
     line-height: 17px;
 
     color: ${getColor('purple.800')};
@@ -293,7 +293,6 @@ export const BodyUI = styled.div`
     font-style: normal;
     font-weight: normal;
     text-decoration: none;
-    white-space: nowrap;
   }
 `
 


### PR DESCRIPTION
# Problem
When the variable preview is too long, it stays on the same line, making it impossible to read the fallback content

## Fix
We remove the `white-space:nowrap; `and set a `min-height`. that way it can span on multiple line if needed. Not the prettiest render since it's an inline node within a paragraph, but we are shooting for usability here

<img width="329" alt="CleanShot 2022-02-03 at 09 54 20@2x" src="https://user-images.githubusercontent.com/203992/152367408-40658655-b080-4c87-8add-41a25446349b.png">


Write to your heart's content, include:

- [ ] A link to the Figma design in your story (list regularly updated [here](https://docs.google.com/spreadsheets/d/19-5gNbYuKjOb-kk7VTQZ0i_VWVd_8lubx-uhrlPUu1E/edit#gid=0))
- [ ] A link to the Story(ies) in the description
- [ ] Is there a Jira ticket associated?
- [ ] If useful, add screenshots or videos
- [ ] If useful (and unclear), add a little explanation of why a certain path was taken
- [ ] Instructions on how to test
- [ ] Found any restrictions/limitations? Let us know!

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
