### PR TITLE
Tags CANI

### DIFF
--- a/src/components/Tag/Tag.css.js
+++ b/src/components/Tag/Tag.css.js
@@ -87,7 +87,7 @@ export const RemoveIconUI = styled(Icon)`
   width: 100%;
 `
 
-export const TagUI = styled('div')`
+export const TagElementUI = styled('div')`
   ${focusRing}
   --focusRingOffset: -3px;
 
@@ -148,7 +148,7 @@ export const TagUI = styled('div')`
   }
 `
 
-export const TagGroupUI = styled.div`
+export const TagUI = styled.div`
   position: relative;
   display: inline-flex;
   opacity: 0;

--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -8,7 +8,7 @@ import React, {
 import PropTypes from 'prop-types'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import classNames from 'classnames'
-import { noop } from '../../utilities/other'
+
 import { TagListContext } from '../TagList/TagList'
 import {
   TagUI,
@@ -16,8 +16,10 @@ import {
   RemoveTagUI,
   TruncateUI,
   CountUI,
-  TagGroupUI,
+  TagElementUI,
 } from './Tag.css'
+
+const noop = () => undefined
 
 export const tagClassName = 'c-Tag'
 
@@ -38,12 +40,14 @@ export const Tag = nextProps => {
     id,
     isRemovable,
     onRemove,
+    onHide,
     isRemoving: isRemovingProp,
     showTooltipOnTruncate,
     size,
     value,
     onClick,
     href,
+    elementClassName,
     ...rest
   } = useExtendPropsWithContext(nextProps, TagListContext)
 
@@ -54,7 +58,8 @@ export const Tag = nextProps => {
 
   const hideTag = useCallback(() => {
     setRender(false)
-  }, [])
+    onHide && onHide()
+  }, [onHide])
 
   const handleTransitionEnd = useCallback(
     e => {
@@ -92,21 +97,22 @@ export const Tag = nextProps => {
     }
   }, [isRemovingProp, hideTag])
 
-  const componentClassNames = classNames(
+  const tagClassnames = classNames(
+    tagClassName,
+    display && `is-display-${display}`,
+    !isRemoving && 'element-in',
+    color && `is-${color}`,
+    filled && 'is-filled',
+    className
+  )
+
+  const tagElementClassNames = classNames(
     tagClassName,
     isClickable && 'is-clickable',
     isRemovable && 'is-removable',
     allCaps && 'is-all-caps',
     size && `is-${size}`,
-    shouldShowCount && 'has-count',
-    className
-  )
-  const groupClassNames = classNames(
-    display && `is-display-${display}`,
-    size && `is-${size}`,
-    !isRemoving && 'element-in',
-    color && `is-${color}`,
-    filled && 'is-filled'
+    elementClassName
   )
 
   let as = 'div'
@@ -115,20 +121,24 @@ export const Tag = nextProps => {
   }
 
   const tagProps = {
-    className: componentClassNames,
+    className: tagElementClassNames,
     as,
     onClick: handleClick,
   }
   if (href) tagProps.href = href
 
   return shouldRender ? (
-    <TagGroupUI
-      className={groupClassNames}
+    <TagUI
+      className={tagClassnames}
       onTransitionEnd={handleTransitionEnd}
       ref={tagRef}
-      data-testid="TagGroup"
+      data-testid="Tag"
     >
-      <TagUI {...getValidProps(rest)} {...tagProps} data-testid="Tag">
+      <TagElementUI
+        {...getValidProps(rest)}
+        {...tagProps}
+        data-testid="TagElement"
+      >
         <TruncateUI
           className="c-Tag__textWrapper"
           showTooltipOnTruncate={showTooltipOnTruncate}
@@ -136,7 +146,7 @@ export const Tag = nextProps => {
           {value || children || null}
         </TruncateUI>
         {shouldShowCount && <CountUI data-testid="Tag.Count">{count}</CountUI>}
-      </TagUI>
+      </TagElementUI>
       {isRemovable && (
         <RemoveTagUI
           aria-label="Remove tag"
@@ -146,7 +156,7 @@ export const Tag = nextProps => {
           <RemoveIconUI name="cross-small" size={18} title="Remove" />
         </RemoveTagUI>
       )}
-    </TagGroupUI>
+    </TagUI>
   ) : null
 }
 
@@ -157,6 +167,7 @@ Tag.defaultProps = {
   isRemovable: false,
   isRemoving: false,
   onRemove: noop,
+  onHide: noop,
   showTooltipOnTruncate: true,
   value: '',
   size: 'sm',
@@ -183,6 +194,8 @@ Tag.propTypes = {
   count: PropTypes.number,
   /** Determines the CSS `display` of the component. Default `inline`. */
   display: PropTypes.oneOf(['block', 'inline']),
+  /** Custom class names to be added to the element component. */
+  elementClassName: PropTypes.string,
   /** Applies a filled in color style to the component. */
   filled: PropTypes.bool,
   /** ID of the component. */

--- a/src/components/Tag/Tag.test.js
+++ b/src/components/Tag/Tag.test.js
@@ -5,7 +5,6 @@ import { render, fireEvent } from '@testing-library/react'
 import user from '@testing-library/user-event'
 
 import { Tag } from './Tag'
-import { Animate, Icon, Text } from '../index'
 
 jest.useFakeTimers()
 
@@ -20,6 +19,11 @@ describe('ClassNames', () => {
     const { getByTestId } = render(<Tag className="mugatu" />)
 
     expect(getByTestId('Tag')).toHaveClass('mugatu')
+  })
+  test('Accepts custom element classNames', () => {
+    const { getByTestId } = render(<Tag elementClassName="mugatu" />)
+
+    expect(getByTestId('TagElement')).toHaveClass('mugatu')
   })
 })
 
@@ -68,7 +72,7 @@ describe('Remove', () => {
       <Tag isRemovable onRemove={spy} id={1} value="Ron" />
     )
     user.click(getByTestId('RemoveTag'))
-    fireEvent.transitionEnd(queryByTestId('TagGroup'))
+    fireEvent.transitionEnd(queryByTestId('Tag'))
     expect(spy).toHaveBeenCalled()
     expect(spy.mock.calls[0][0].id).toBe(1)
     expect(spy.mock.calls[0][0].value).toBe('Ron')
@@ -78,8 +82,8 @@ describe('Remove', () => {
 describe('Styles', () => {
   test('Has allCaps styles', () => {
     const { getByTestId } = render(<Tag allCaps />)
-    expect(getByTestId('Tag')).toHaveClass('is-all-caps')
-    expect(getByTestId('Tag')).toHaveStyle('text-transform: uppercase;')
+    expect(getByTestId('TagElement')).toHaveClass('is-all-caps')
+    expect(getByTestId('TagElement')).toHaveStyle('text-transform: uppercase;')
   })
 
   test('Has color styles', () => {
@@ -89,20 +93,20 @@ describe('Styles', () => {
 
   test('Has size styles', () => {
     const { getByTestId } = render(<Tag size="md" />)
-    expect(getByTestId('Tag')).toHaveClass('is-md')
+    expect(getByTestId('TagElement')).toHaveClass('is-md')
   })
 
   test('Has display flex styles', () => {
     const { getByTestId } = render(<Tag display="block" />)
 
-    expect(getByTestId('TagGroup')).toHaveClass('is-display-block')
-    expect(getByTestId('TagGroup')).toHaveStyle('display: flex;')
+    expect(getByTestId('Tag')).toHaveClass('is-display-block')
+    expect(getByTestId('Tag')).toHaveStyle('display: flex;')
   })
   test('Has display inline-flex styles', () => {
     const { getByTestId } = render(<Tag display="inline" />)
 
-    expect(getByTestId('TagGroup')).toHaveClass('is-display-inline')
-    expect(getByTestId('TagGroup')).toHaveStyle('display: inline-flex;')
+    expect(getByTestId('Tag')).toHaveClass('is-display-inline')
+    expect(getByTestId('Tag')).toHaveStyle('display: inline-flex;')
   })
 
   test('Has filled styles', () => {
@@ -130,7 +134,7 @@ describe('clickable', () => {
   test('onClick set the tag as clickable', () => {
     const spy = jest.fn()
     const { getByTestId } = render(<Tag onClick={spy} id={1} value="Ron" />)
-    user.click(getByTestId('Tag'))
+    user.click(getByTestId('TagElement'))
     expect(spy).toHaveBeenCalled()
     expect(spy.mock.calls[0][1].id).toBe(1)
     expect(spy.mock.calls[0][1].value).toBe('Ron')


### PR DESCRIPTION
With this update, we wanted to make it easier to customize the Tag component. 

* Colors  & sizes were moved to the root component.
* The default classname is now assigned to the root component
* We add the `elementClassname` prop in case developer want to pass a className directly to the tag.
* We add more css variables to help with customization (`--tagTextColor` & `tagBackgroundColor`)
