### PR TITLE
Tag forwarded ref

### DIFF
--- a/src/components/Tag/Tag.css.js
+++ b/src/components/Tag/Tag.css.js
@@ -26,10 +26,11 @@ export const config = {
 export const RemoveTagUI = styled.button`
   ${focusRing}
   --focusRingRadius: 3px;
+  --focusRingOffset: 0px;
   --focusRingShadow: ${focusShadowWithInset};
 
   color: var(--tagTextColor);
-  border-radius: 3px;
+  border-radius: var(--focusRingRadius);
   width: 16px;
   height: 16px;
   display: flex;
@@ -90,9 +91,10 @@ export const RemoveIconUI = styled(Icon)`
 export const TagElementUI = styled('div')`
   ${focusRing}
   --focusRingOffset: -3px;
+  --focusRingRadius: 3px;
 
   background-color: var(--tagBackgroundColor);
-  border-radius: 3px;
+  border-radius: var(--focusRingRadius);
   border: 1px solid var(--tagColor);
   color: var(--tagTextColor);
   display: flex;
@@ -140,10 +142,10 @@ export const TagElementUI = styled('div')`
   }
 
   &.is-removable {
-    padding-right: 16px;
+    padding-right: 18px;
 
     &.is-md {
-      padding-right: 20px;
+      padding-right: 22px;
     }
   }
 `

--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -3,7 +3,7 @@ import React, {
   useState,
   useCallback,
   useEffect,
-  useRef,
+  forwardRef,
 } from 'react'
 import PropTypes from 'prop-types'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
@@ -28,7 +28,7 @@ const useExtendPropsWithContext = (nextProps, context) => {
   return { ...nextProps, ...contextValue }
 }
 
-export const Tag = nextProps => {
+const ForwardedTag = forwardRef(function Tag(props, ref) {
   const {
     allCaps,
     children,
@@ -49,9 +49,7 @@ export const Tag = nextProps => {
     href,
     elementClassName,
     ...rest
-  } = useExtendPropsWithContext(nextProps, TagListContext)
-
-  const tagRef = useRef()
+  } = useExtendPropsWithContext(props, TagListContext)
 
   const [isRemoving, setRemoving] = useState(isRemovingProp)
   const [shouldRender, setRender] = useState(true)
@@ -61,14 +59,9 @@ export const Tag = nextProps => {
     onHide && onHide()
   }, [onHide])
 
-  const handleTransitionEnd = useCallback(
-    e => {
-      if (e.target === tagRef.current && isRemoving) {
-        hideTag()
-      }
-    },
-    [hideTag, isRemoving]
-  )
+  const handleTransitionEnd = useCallback(() => {
+    if (isRemoving) hideTag()
+  }, [hideTag, isRemoving])
 
   const handleClick = useCallback(
     e => {
@@ -92,7 +85,7 @@ export const Tag = nextProps => {
   const shouldShowCount = Number.isInteger(count) && size === 'lg'
 
   useEffect(() => {
-    if (isRemovingProp && tagRef.current) {
+    if (isRemovingProp) {
       hideTag()
     }
   }, [isRemovingProp, hideTag])
@@ -131,7 +124,7 @@ export const Tag = nextProps => {
     <TagUI
       className={tagClassnames}
       onTransitionEnd={handleTransitionEnd}
-      ref={tagRef}
+      ref={ref}
       data-testid="Tag"
     >
       <TagElementUI
@@ -158,9 +151,9 @@ export const Tag = nextProps => {
       )}
     </TagUI>
   ) : null
-}
+})
 
-Tag.defaultProps = {
+ForwardedTag.defaultProps = {
   color: 'grey',
   'data-cy': 'Tag',
   display: 'inline',
@@ -173,7 +166,7 @@ Tag.defaultProps = {
   size: 'sm',
 }
 
-Tag.propTypes = {
+ForwardedTag.propTypes = {
   /** Renders text in Uppercase */
   allCaps: PropTypes.bool,
   /** Custom class names to be added to the component. */
@@ -216,4 +209,4 @@ Tag.propTypes = {
   'data-cy': PropTypes.string,
 }
 
-export default Tag
+export default ForwardedTag

--- a/src/components/Tag/Tag.test.js
+++ b/src/components/Tag/Tag.test.js
@@ -4,7 +4,7 @@ import { mount } from 'enzyme'
 import { render, fireEvent } from '@testing-library/react'
 import user from '@testing-library/user-event'
 
-import { Tag } from './Tag'
+import Tag from './Tag'
 
 jest.useFakeTimers()
 


### PR DESCRIPTION
# Problem
To apply a tooltip correctly to the `Tag`, we had to refactor the component to use `forwardRef`.

We were able to remove the tagRef use internally. Seems that it was not needed anymore to validate the animation was on the correct element.

At the same time, we fixed an issue with the focus ring tag radius and also improve the `X` button placement (so that the focus ring doesn't overlap the tag content)
