### PR TITLE
Add label to Verification Code input and make unfocusable region not scrollable

### DIFF
--- a/src/components/VerificationCode/VerificationCode.css.js
+++ b/src/components/VerificationCode/VerificationCode.css.js
@@ -111,6 +111,7 @@ export const ClipboardPlaceholderUI = styled('textarea')`
   pointer-events: none;
   width: 1px;
   height: 1px;
+  overflow: hidden;
 `
 
 export const ValidIconUI = styled(Tooltip)`

--- a/src/components/VerificationCode/VerificationCode.jsx
+++ b/src/components/VerificationCode/VerificationCode.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import getValidProps from '@helpscout/react-utils/dist/getValidProps'
 import classNames from 'classnames'
+import VisuallyHidden from '../VisuallyHidden'
 import { copyToClipboard } from '../../utilities/clipboard'
 import {
   selectAll,
@@ -254,6 +255,7 @@ class VerificationCode extends React.Component {
           tabIndex="-1"
           ref={this.setClipboardPlaceholderNode}
         />
+        <VisuallyHidden id="digitInput">Code Digit</VisuallyHidden>
         {Array(numberOfChars)
           .fill(0)
           .map((_, index) => {
@@ -265,6 +267,7 @@ class VerificationCode extends React.Component {
                 <DigitMaskUI className={`DigitMask ${CLASSNAMES.hidden}`} />
                 <DigitInputUI
                   className="DigitInput"
+                  aria-labelledby="digitInput"
                   maxLength="1"
                   onClick={this.handleInputClick}
                   onKeyUp={e => {


### PR DESCRIPTION


# Problem/Feature
This PR fixes two a11y issues in the Verification Code component
1 [Scrollable region must have keyboard access](https://dequeuniversity.com/rules/axe/4.4/scrollable-region-focusable?application=AxeChrome) (Impact: Moderate) : set overflow attribute to hidden for ClipboardPlaceholderUI
2 [Form elements must have labels](https://dequeuniversity.com/rules/axe/4.4/label?application=AxeChrome) (Impact: Critical) : Add aria-labellby to input

Write to your heart's content, include:

- [ ] A link to the Figma design in your story (list regularly updated [here](https://docs.google.com/spreadsheets/d/19-5gNbYuKjOb-kk7VTQZ0i_VWVd_8lubx-uhrlPUu1E/edit#gid=0))
- [ ] A link to the Story(ies) in the description
- [ ] Is there a Jira ticket associated?
- [ ] If useful, add screenshots or videos
- [ ] If useful (and unclear), add a little explanation of why a certain path was taken
- [ ] Instructions on how to test
- [ ] Found any restrictions/limitations? Let us know!

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
