### PR TITLE
Allow providing head prop to the Frame component

### DIFF
--- a/src/components/Frame/Frame.jsx
+++ b/src/components/Frame/Frame.jsx
@@ -62,12 +62,14 @@ export const FrameComponent = ({
   children,
   initialContent,
   contentDidMount,
+  head,
   ...rest
 }) => {
   return (
     <Frame
       initialContent={initialContent}
       contentDidMount={contentDidMount}
+      head={head}
       {...getValidProps(rest)}
     >
       <FrameContent theme={theme}>{children}</FrameContent>


### PR DESCRIPTION
# Problem/Feature

Context: In Beacon embed we are migrating from React to Preact, for smaller bundle size and better speed. However, there's one issue with combination of Preact portals and frame component library we are using. This library always wants to create 2 portals, one for content and other for `head` element provided via props (even if it's not provided). But Preact is breaking when null element is provided (that is happening in this case).

I believe this might be something to be fixed in both Preact and frame library (I'll be creating some PRs to fix those), but just setting some empty head tag is quicker solution and we need HSDS Frame component to provide this `head` prop to the actual frame component. Before this change, `head` was filtered out by `getValidProps` function.

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
