### PR TITLE
Adds ResizeObserver polyfill to use on Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@helpscout/motion": "0.0.8",
     "@helpscout/react-utils": "^2.4.0",
     "@helpscout/wedux": "0.0.11",
+    "@juggle/resize-observer": "^3.3.1",
     "@tippyjs/react": "^4.0.2",
     "array-move": "2.1.0",
     "chalk": "^1.1.3",

--- a/src/components/Frame/Frame.jsx
+++ b/src/components/Frame/Frame.jsx
@@ -62,12 +62,14 @@ export const FrameComponent = ({
   children,
   initialContent,
   contentDidMount,
+  head,
   ...rest
 }) => {
   return (
     <Frame
       initialContent={initialContent}
       contentDidMount={contentDidMount}
+      head={head}
       {...getValidProps(rest)}
     >
       <FrameContent theme={theme}>{children}</FrameContent>

--- a/src/components/Popover/Popover.jsx
+++ b/src/components/Popover/Popover.jsx
@@ -60,7 +60,7 @@ export const Popover = ({
   withArrow = true,
   ...rest
 }) => {
-  const render = ({ scope, ...tooltipProps }) => {
+  const render = tooltipProps => {
     const toolTipComponent = (
       <TooltipAnimationUI>
         <PopoverUI {...tooltipProps} data-cy="PopoverContent">
@@ -77,7 +77,7 @@ export const Popover = ({
       </TooltipAnimationUI>
     )
 
-    return <div className={scope}>{toolTipComponent}</div>
+    return <div className="hsds-react hsds-beacon">{toolTipComponent}</div>
   }
 
   return (

--- a/src/hooks/useMeasureNode.js
+++ b/src/hooks/useMeasureNode.js
@@ -38,7 +38,7 @@ export function setupObserver({
   observerEntryType = 'borderBoxSize',
 }) {
   // TODO: remove when Safari fully supports ResizeObserverEntry (which should be on 15.4)
-  const RO = !isSafari ? ResizeObserver : PolyfilledResizeObserver
+  const RO = !isSafari() ? ResizeObserver : PolyfilledResizeObserver
 
   return new RO(entries => {
     for (let entry of entries) {

--- a/src/hooks/useMeasureNode.js
+++ b/src/hooks/useMeasureNode.js
@@ -1,6 +1,8 @@
 // very difficult to test with JSDom
 /* istanbul ignore file */
 import { useState, useCallback, useRef } from 'react'
+import { ResizeObserver as PolyfilledResizeObserver } from '@juggle/resize-observer'
+import { isSafari } from '../utilities/browser'
 
 export default function useMeasureNode({ observeSize = false }) {
   const [measures, setMeasures] = useState(null)
@@ -35,7 +37,9 @@ export function setupObserver({
   dimensions,
   observerEntryType = 'borderBoxSize',
 }) {
-  return new ResizeObserver(entries => {
+  const RO = !isSafari ? ResizeObserver : PolyfilledResizeObserver
+
+  return new RO(entries => {
     for (let entry of entries) {
       if (entry[observerEntryType]) {
         const size = Array.isArray(entry[observerEntryType])

--- a/src/hooks/useMeasureNode.js
+++ b/src/hooks/useMeasureNode.js
@@ -37,6 +37,7 @@ export function setupObserver({
   dimensions,
   observerEntryType = 'borderBoxSize',
 }) {
+  // TODO: remove when Safari fully supports ResizeObserverEntry (which should be on 15.4)
   const RO = !isSafari ? ResizeObserver : PolyfilledResizeObserver
 
   return new RO(entries => {


### PR DESCRIPTION
## Problem

@nickolas described it [here](https://github.com/helpscout/hs-app-ui/pull/283#issuecomment-1043441561).

In a nutshell Safari does not support ResizeObserver fully yet, so AvatarRow and any other things that use it don't work as expected.

## Solution

In this PR we add the polyfill [`@juggle/resize-observer`](https://github.com/juggle/resize-observer) to be used _only_ on Safari. We can remove it when Safari supports RO properly (allegedly v15.4 which is coming soon).

[🎥 Little demo in safari](https://i.hlp.sc/j7p6Qz)

--

We also include this https://github.com/helpscout/hsds-react/pull/1034 by @jakubjanczyk