### PR TITLE
Fix isNil import

### DIFF
--- a/src/utilities/is.js
+++ b/src/utilities/is.js
@@ -1,4 +1,4 @@
-import { isNil } from 'lodash.isnil'
+import isNil from 'lodash.isnil'
 
 // TODO: remove when the rest are removed
 export function typeOf(value, type) {


### PR DESCRIPTION
# Problem/Feature
Previous import if `isNil` function from `lodash.isnil` was incorrect - for the specific lodash package the function needs to be imported with default import

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
