### PR TITLE
Allow table columns to be changed

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -82,6 +82,10 @@ export function Table({
     updateTableData(data, maxRowsToDisplay)
   }, [data, maxRowsToDisplay, sortedInfo])
 
+  useDeepCompareEffect(() => {
+    resetColumns(columns)
+  }, [columns])
+
   function renderHeader() {
     if (!headerContent && !withColumnChooser) {
       return null


### PR DESCRIPTION
# Problem/Feature

It is currently not possible to dynamically change the columns of a table because the state does not update when the props change. This small change ensures that the columns state stays in sync with the columns prop.

This was needed to support changing Mailbox views. When we change views, we load new conversations that get loaded into the table as rows; however we also need to change the columns to show based on the view. See https://github.com/helpscout/hs-app-ui/pull/319 for more context.
