### PR TITLE
Change DropList combobox filter comparison to allow for matches with same starting characters

### DIFF
--- a/src/components/DropList/DropList.Combobox.jsx
+++ b/src/components/DropList/DropList.Combobox.jsx
@@ -84,8 +84,8 @@ function Combobox({
     },
 
     onInputValueChange({ inputValue }) {
-      let filtered = items.filter(item =>
-        itemToString(item).toLowerCase().startsWith(inputValue.toLowerCase())
+      let filtered = items.filter(
+        item => itemToString(item).toLowerCase() === inputValue.toLowerCase()
       )
       const isListEmpty = filtered.length === 0
 


### PR DESCRIPTION
# Problem/Feature

We're going through UI/A11y fixes for work that shipped without QA 😬  and one of the items from [this card](https://helpscout.atlassian.net/browse/HSAPPUI-538) is:

 **Cannot create a tag if it contains characters from a current tag.**

![image](https://user-images.githubusercontent.com/3252290/157567032-81ddc5db-d21b-41d7-ae04-471d4a7ecd7b.png)

In other words, if I have the tag "sample" and I enter a search for "sam" into the combobox, I don't get the option to create a new tag "sam", but I should. 

I believe it's down to the line that I've changed in this PR, which is that the combobox filter is comparing what the string starts with rather than comparing the entire string and since we already have a tag that starts with "sam" it doesn't give me the option to create another.

## Guidelines

Make sure the pull request:

- [x] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [x] Requests review from designer of the feature
- [x] Add label (bug? feature?)
