### PR TITLE
Add custom remove label option to Tag component

### DIFF
--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -32,6 +32,7 @@ const ForwardedTag = forwardRef(function Tag(props, ref) {
     className,
     color,
     count,
+    customRemoveLabel,
     display,
     filled,
     id,
@@ -139,8 +140,8 @@ const ForwardedTag = forwardRef(function Tag(props, ref) {
       </TagElementUI>
       {isRemovable && (
         <RemoveTagUI
-          aria-label="Remove tag"
-          data-testid="RemoveTag"
+          aria-label={customRemoveLabel || 'Remove tag'}
+          data-testid={customRemoveLabel || 'RemoveTag'}
           onClick={handleRemove}
         >
           <RemoveIconUI name="cross-small" size={18} title="Remove" />
@@ -184,6 +185,8 @@ ForwardedTag.propTypes = {
   ]),
   /** Renders a badge within a medium sized tag */
   count: PropTypes.number,
+  /** Sets a custom value for the label */
+  customRemoveLabel: PropTypes.string,
   /** Determines the CSS `display` of the component. Default `inline`. */
   display: PropTypes.oneOf(['block', 'inline']),
   /** Custom class names to be added to the element component. */

--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -32,7 +32,6 @@ const ForwardedTag = forwardRef(function Tag(props, ref) {
     className,
     color,
     count,
-    customRemoveLabel,
     display,
     filled,
     id,
@@ -40,6 +39,7 @@ const ForwardedTag = forwardRef(function Tag(props, ref) {
     onRemove,
     onHide,
     isRemoving: isRemovingProp,
+    removeProps,
     showTooltipOnTruncate,
     size,
     value,
@@ -140,9 +140,10 @@ const ForwardedTag = forwardRef(function Tag(props, ref) {
       </TagElementUI>
       {isRemovable && (
         <RemoveTagUI
-          aria-label={customRemoveLabel || 'Remove tag'}
-          data-testid={customRemoveLabel || 'RemoveTag'}
+          aria-label="Remove tag"
+          data-testid="RemoveTag"
           onClick={handleRemove}
+          {...removeProps}
         >
           <RemoveIconUI name="cross-small" size={18} title="Remove" />
         </RemoveTagUI>
@@ -185,8 +186,6 @@ ForwardedTag.propTypes = {
   ]),
   /** Renders a badge within a medium sized tag */
   count: PropTypes.number,
-  /** Sets a custom value for the label */
-  customRemoveLabel: PropTypes.string,
   /** Determines the CSS `display` of the component. Default `inline`. */
   display: PropTypes.oneOf(['block', 'inline']),
   /** Custom class names to be added to the element component. */
@@ -199,6 +198,8 @@ ForwardedTag.propTypes = {
   isRemovable: PropTypes.bool,
   /** Renders the `Spinner` and replaces the `x` `Icon` */
   isRemoving: PropTypes.bool,
+  /** Custom props to pass to the remove button */
+  removeProps: PropTypes.object,
   /** Apply a different size to the component */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   /** Callback function when component is removed and unmounted. */

--- a/src/components/Tag/Tag.stories.mdx
+++ b/src/components/Tag/Tag.stories.mdx
@@ -115,11 +115,11 @@ A Tag component is a UI element that provide contextual labels for categories/ta
 
 ## Stories
 
-If you're using the Tag component as something other than a tag, you may want to customize
+If you're using the Tag component as something other than a tag, you may want to customize the remove button. Use the `removeProps` prop to pass down
 
 <Canvas>
   <Story name="custom remove label">
-    <Tag isRemovable={true} customRemoveLabel="Remove Steve Aoki">
+    <Tag isRemovable={true} removeProps={{ 'aria-label': 'Remove Steve Aoki' }}>
       Steve Aoki
     </Tag>
   </Story>

--- a/src/components/Tag/Tag.stories.mdx
+++ b/src/components/Tag/Tag.stories.mdx
@@ -115,7 +115,7 @@ A Tag component is a UI element that provide contextual labels for categories/ta
 
 ## Stories
 
-If you're using the Tag component as something other than a tag, you may want to customize the remove button. Use the `removeProps` prop to pass down
+If you're using the Tag component as something other than a tag, you may want to customize the remove button. Use the `removeProps` prop to pass down an aria label, test ID, or whatever else you might need!
 
 <Canvas>
   <Story name="custom remove label">

--- a/src/components/Tag/Tag.stories.mdx
+++ b/src/components/Tag/Tag.stories.mdx
@@ -112,3 +112,15 @@ A Tag component is a UI element that provide contextual labels for categories/ta
 ### Props
 
 <ArgsTable of={Tag} />
+
+## Stories
+
+If you're using the Tag component as something other than a tag, you may want to customize
+
+<Canvas>
+  <Story name="custom remove label">
+    <Tag isRemovable={true} customRemoveLabel="Remove Steve Aoki">
+      Steve Aoki
+    </Tag>
+  </Story>
+</Canvas>


### PR DESCRIPTION
# Problem/Feature

In the beautiful CC/BCC implementation that @plbabin did for the mailbox rewrite, we're using the Tag component as a badge to represent the email address. [During accessibility review](https://github.com/helpscout/hs-app-ui/pull/351), we found it would be best to be able to customize the label, since it reads "Remove Tag" but in this context there isn't a tag. This adds a prop to be able to set the aria-label and test ID of the removal element to a different value:

![CleanShot 2022-03-23 at 14 28 43](https://user-images.githubusercontent.com/3252290/159800352-7e9a0f51-3886-4307-899d-95a5815acb97.gif)

## Guidelines

Make sure the pull request:

- [x] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [x] Did you verify some accessibility (a11y) basics?
- [x] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [x] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
