### PR TITLE
useClickOutside hook fix

### DIFF
--- a/src/components/SidePanel/SidePanel.test.js
+++ b/src/components/SidePanel/SidePanel.test.js
@@ -96,6 +96,40 @@ describe('Overlay', () => {
 })
 
 describe('Closing', () => {
+  const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetHeight'
+  )
+  const originalOffsetWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetWidth'
+  )
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 200,
+    })
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: 200,
+    })
+  })
+
+  afterAll(() => {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'offsetHeight',
+      originalOffsetHeight
+    )
+
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'offsetWidth',
+      originalOffsetWidth
+    )
+  })
+
   test('should render close button', () => {
     const { container } = render(<SidePanel show />)
     const button = container.querySelector('.SidePanel__CloseButton')

--- a/src/components/SimpleModal/SimpleModal.storiesHelpers.js
+++ b/src/components/SimpleModal/SimpleModal.storiesHelpers.js
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react'
+import React, { useReducer, useState } from 'react'
 import SimpleModal from './SimpleModal'
 import { Portal } from '../../hooks/usePortal'
 import Button from '../Button'
@@ -24,9 +24,17 @@ export const SimpleModalWithTrigger = () => {
     isOpen1: false,
     isOpen2: false,
   })
+  const [buttonVisible, setButtonVisible] = useState(true)
+
   return (
     <>
-      <Button kind="primary" onClick={() => dispatch('OPEN_1')}>
+      <Button
+        kind="primary"
+        onClick={() => {
+          setButtonVisible(true)
+          dispatch('OPEN_1')
+        }}
+      >
         Open modal
       </Button>
       <Portal selector="#root">
@@ -40,10 +48,21 @@ export const SimpleModalWithTrigger = () => {
           }}
           closeOnClickOutside="modal"
         >
-          <div>My modal</div>
           <Button kind="primary" onClick={() => dispatch('OPEN_2')}>
             Open second modal
           </Button>
+          {buttonVisible ? (
+            <Button
+              style={{ marginTop: '20px' }}
+              size="xs"
+              theme="green"
+              onClick={() => {
+                setButtonVisible(false)
+              }}
+            >
+              remove this button
+            </Button>
+          ) : null}
         </SimpleModal>
       </Portal>
       <Portal selector="#root">

--- a/src/components/SimpleModal/SimpleModal.test.js
+++ b/src/components/SimpleModal/SimpleModal.test.js
@@ -28,6 +28,7 @@ describe('Show / no show', () => {
 
     expect(queryByTestId('simple-modal-overlay')).not.toBeInTheDocument()
   })
+
   test('should set z-index on overlay', () => {
     const { queryByTestId } = render(<SimpleModal show zIndex={500} />)
     const styles = window.getComputedStyle(
@@ -51,6 +52,38 @@ describe('Contents', () => {
 })
 
 describe('Closing', () => {
+  const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetHeight'
+  )
+  const originalOffsetWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetWidth'
+  )
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 200,
+    })
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: 200,
+    })
+  })
+
+  afterAll(() => {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'offsetHeight',
+      originalOffsetHeight
+    )
+
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'offsetWidth',
+      originalOffsetWidth
+    )
+  })
   test('should render close button', () => {
     const { container } = render(<SimpleModal show />)
     const button = container.querySelector('.SimpleModal__CloseButton')
@@ -82,13 +115,21 @@ describe('Closing', () => {
   test('should call onClose on clicking outside modal if set', () => {
     const spy = jest.fn()
     const { container } = render(
-      <div className="app">
-        <SimpleModal closeOnClickOutside="modal" show onClose={spy} />
-      </div>
+      <>
+        <div className="app" style={{ width: '500px' }}>
+          <SimpleModal
+            closeOnClickOutside="modal"
+            show
+            onClose={spy}
+            width={'200px'}
+          />
+        </div>
+        <button className="test">test</button>
+      </>
     )
-    const app = container.querySelector('.app')
+    const test = container.querySelector('.test')
 
-    user.click(app)
+    user.click(test)
 
     expect(spy).toHaveBeenCalled()
   })

--- a/src/components/SimpleModal/SimpleModal.test.js
+++ b/src/components/SimpleModal/SimpleModal.test.js
@@ -60,11 +60,13 @@ describe('Closing', () => {
     HTMLElement.prototype,
     'offsetWidth'
   )
+
   beforeAll(() => {
     Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
       configurable: true,
       value: 200,
     })
+
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
       configurable: true,
       value: 200,
@@ -84,6 +86,7 @@ describe('Closing', () => {
       originalOffsetWidth
     )
   })
+
   test('should render close button', () => {
     const { container } = render(<SimpleModal show />)
     const button = container.querySelector('.SimpleModal__CloseButton')

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -9,7 +9,12 @@ import { useEffect } from 'react'
  */
 const useClickOutside = (ref, callback) => {
   const handleClick = e => {
-    if (ref && ref.current && !ref.current.contains(e.target)) {
+    if (
+      ref &&
+      ref.current &&
+      !ref.current.contains(e.target) &&
+      isVisible(e.target)
+    ) {
       callback(e)
     }
   }
@@ -26,6 +31,13 @@ const useClickOutside = (ref, callback) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+}
+
+function isVisible(elem) {
+  return (
+    !!elem &&
+    !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
+  )
 }
 
 export default useClickOutside


### PR DESCRIPTION
# Problem

There are cases when an element inside a modal is no longer there byt the time `useClickOutside` decides whether to execute the callback, making the check always true and so, executing the callback when it shouldn't.

## Solution

Add an extra check: make sure the element clicked is visible to then execute the callback.

Added a test case in the story: https://1713afae.hsds-react.pages.dev/?path=/story/components-overlay-simplemodal--with-trigger-and-nested

1. Open the modal
2. Click the green button, it will get removed and the modal stays open (whereas previously it was closing it)
3. Clicking outside the modal, closes the modal