### PR TITLE
HSD- 261 Update CheckmarkCard disabled UI

### DIFF
--- a/src/components/CheckMarkCard/CheckMarkCard.css.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.css.js
@@ -4,9 +4,11 @@ import { d400, d400Effect } from '../../styles/mixins/depth.css'
 import ChoiceGroup from '../ChoiceGroup'
 
 import { getColor } from '../../styles/utilities/color'
-import { rgba } from '../../utilities/color'
+import { focusRing } from '../../styles/mixins/focusRing.css'
 
 export const MarkUI = styled('div')`
+  ${focusRing};
+  --focusRingRadius: 3px;
   position: absolute;
   top: 0;
   left: 0;
@@ -31,27 +33,10 @@ export const MarkUI = styled('div')`
     left: 50%;
     transform: translate(-50%, -50%);
   }
+`
 
-  &:focus {
-    &:before {
-      opacity: 1;
-    }
-  }
-
-  // Focus UI
-  &:before {
-    content: '';
-    border-radius: 5px;
-    bottom: -2px;
-    box-shadow: 0px 0px 0 2px ${getColor('blue.500')};
-    left: -2px;
-    pointer-events: none;
-    position: absolute;
-    right: -2px;
-    top: -2px;
-    opacity: 0;
-    transition: opacity ease 0.2s;
-  }
+export const AvatarWrapperUI = styled.div`
+  margin-bottom: 14px;
 `
 
 export const CheckMarkCardContentUI = styled.div`
@@ -67,7 +52,13 @@ export const CheckMarkCardContentUI = styled.div`
 `
 
 export const CheckMarkCardUI = styled('label')`
-  display:flex;
+  ${focusRing};
+  ${d400};
+  --headingColor: ${getColor('charcoal.600')};
+  --subtitleColor: ${getColor('charcoal.400')};
+  --focusRingOffset: 0;
+  --focusRingRadius: 4px;
+  display: flex;
   box-sizing: border-box;
   position: relative;
 
@@ -75,89 +66,72 @@ export const CheckMarkCardUI = styled('label')`
   will-change: transform, box-shadow;
   transition: transform 0.16s ease-in-out, box-shadow 0.16s ease-in-out;
   cursor: pointer;
-  padding:3px;
+  padding: 3px;
   margin-bottom: 0;
-  
+
   /* if no maxWidth are set, let's make sure the card is 170px */
   height: ${({ height }) => (height ? height : 'auto')};
   min-height: ${({ height }) => (!height ? '160px' : '0')};
   width: ${({ maxWidth }) => (maxWidth ? '100%' : '170px')};
   max-width: ${({ maxWidth }) => (maxWidth ? maxWidth : '170px')};
 
-  ${d400}
-
-  // Focus UI
-  &:before{
-    content: '';
-    border-radius: 5px;
-    bottom: 0px;
-    box-shadow: 0px 0px 0 2px ${getColor('blue.500')};
-    left: 0px;
-    pointer-events: none;
-    position: absolute;
-    right: 0px;
-    top: 0px;
-    opacity: 0;
-    transition: opacity ease 0.2s;
-  }
-
-
   &:not(.is-disabled):hover {
-    ${d400Effect}  
+    ${d400Effect}
     transform: translateY(-2px);
   }
 
-  &.is-focused,
-  &:focus-within,
-  &:focus-visible {
-    &:before{
-      opacity:1;
-    }
-  }
-
   &.is-disabled {
-    ${d400}
-    color: ${rgba(getColor('charcoal.500'), 0.85)};
-    opacity: 0.8;
     cursor: not-allowed;
     transition: none;
   }
 
+  &.is-disabled:not(.with-status) {
+    --headingColor: ${getColor('charcoal.400')};
+    --subtitleColor: ${getColor('charcoal.400')};
+
+    box-shadow: none;
+    background: ${getColor('grey.200')};
+
+    ${AvatarWrapperUI} {
+      opacity: 0.5;
+    }
+
+    &:hover {
+      box-shadow: none;
+    }
+  }
+
   &.with-status {
     cursor: default;
-    
+
     &:hover {
       ${d400}
       transform: translateY(0);
     }
   }
 
-  &.is-checked ${CheckMarkCardContentUI}{
-      background:${getColor('blue.100')};
+  &.is-checked ${CheckMarkCardContentUI} {
+    background: ${getColor('blue.100')};
   }
 
-  &.is-lavender{
-    &:before{
+  &.is-lavender {
+    &:before {
       opacity: 0;
     }
-        
-    ${MarkUI} {
+
+    ${MarkUI}  {
       background-color: ${getColor('lavender.600')};
     }
 
-    ${CheckMarkCardContentUI}{
-      background:${getColor('purple.100')};
+    ${CheckMarkCardContentUI} {
+      background: ${getColor('purple.100')};
     }
   }
-`
-
-export const AvatarWrapperUI = styled.div`
-  margin-bottom: 14px;
 `
 
 export const SubtitleUI = styled('div')`
   font-size: 13px;
-  color: ${getColor('charcoal.400')};
+  color: var(--subtitleColor);
 `
 
 export const HeadingUI = styled('div')`
@@ -167,7 +141,7 @@ export const HeadingUI = styled('div')`
   overflow: hidden;
   padding: 0 10px;
   font-weight: 500;
-  color: ${getColor('charcoal.600')};
+  color: var(--headingColor);
   text-overflow: ellipsis;
   width: 100%;
   white-space: nowrap;

--- a/src/components/CheckMarkCard/CheckMarkCard.jsx
+++ b/src/components/CheckMarkCard/CheckMarkCard.jsx
@@ -47,7 +47,8 @@ const Mark = props => {
 
   // ? "Render" MarkUI below even if neither withStatus or checked with opacity 0
   // ? so we can animate the transition
-  return Boolean(tooltipText) ? (
+  const shouldHaveTooltip = Boolean(tooltipText) && withStatus
+  return shouldHaveTooltip ? (
     <Tooltip
       title={tooltipText}
       triggerOn="mouseenter focus"
@@ -64,6 +65,7 @@ const Mark = props => {
 const CheckMarkCard = props => {
   const {
     avatar,
+    cardTooltipText,
     checked,
     children,
     className,
@@ -145,7 +147,8 @@ const CheckMarkCard = props => {
   const shouldDisplayHeading = showHeading && (heading || label)
   // let the Avatar component handle nullified value
   const shouldShowAvatar = props.hasOwnProperty('avatar')
-  return (
+
+  const component = (
     <CheckMarkCardUI
       {...rest}
       className={checkmarkClassnames}
@@ -180,8 +183,22 @@ const CheckMarkCard = props => {
       </VisuallyHidden>
     </CheckMarkCardUI>
   )
-}
 
+  if (cardTooltipText && !shouldShowStatus) {
+    return (
+      <Tooltip
+        title={cardTooltipText}
+        triggerOn="mouseenter focus"
+        appendTo={document.body}
+        withTriggerWrapper={false}
+      >
+        {component}
+      </Tooltip>
+    )
+  }
+
+  return component
+}
 CheckMarkCard.defaultProps = {
   checked: false,
   'data-cy': 'CheckMarkCard',
@@ -195,6 +212,8 @@ CheckMarkCard.defaultProps = {
 CheckMarkCard.propTypes = {
   /** Image url that will be used within the Avatar component. If the prop is declared the Avatar will be shown no matter the value */
   avatar: PropTypes.string,
+  /** The card tooltip text that will appear on hover/focus */
+  cardTooltipText: PropTypes.string,
   /** Custom class names to be added to the component. */
   className: PropTypes.string,
   /** Determines if the card is checked. */

--- a/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
+++ b/src/components/CheckMarkCard/CheckMarkCard.stories.mdx
@@ -105,6 +105,7 @@ This component provides richer context to the of the default HTML `<input>` of t
         label="Mugatu"
         value="mugatu"
         disabled
+        cardTooltipText="Tooltip on the whole card"
         avatar={AvatarSpec.generate().image}
         subtitle="Tokyo"
       ></CheckMarkCard>

--- a/src/components/CheckMarkCard/CheckMarkCard.test.js
+++ b/src/components/CheckMarkCard/CheckMarkCard.test.js
@@ -139,6 +139,13 @@ describe('Disabled', () => {
 
     expect(wrapper.getDOMNode().classList.contains('is-disabled')).toBeFalsy()
   })
+
+  test('show tooltip to the card if provided', () => {
+    const wrapper = mount(<CheckMarkCard cardTooltipText="hello" disabled />)
+
+    expect(wrapper.find(Tooltip).length).toBeTruthy()
+    expect(wrapper.find(Tooltip).first().props().title).toBe('hello')
+  })
 })
 
 describe('Events', () => {


### PR DESCRIPTION
# Problem/Feature
![CleanShot 2022-05-10 at 10 13 54](https://user-images.githubusercontent.com/203992/167652664-dc4c30ac-694f-47ce-b0f4-4b46932d6519.gif)
 
To support the work in an upcoming project, we had to implement some changes to the disabled state of the CheckmarkCard:

## Update the UI
We removed all shadows and set a grey background (`grey.200`). Avatar is faded out and the heading/subtitle color are slightly lighter
<img width="183" alt="CleanShot 2022-05-10 at 10 35 26@2x" src="https://user-images.githubusercontent.com/203992/167654384-da5fb4f5-6185-43a6-b8da-4f742b1d6c8d.png">

## Add tooltip support to the whole card
By passing a cardTooltipText prop to the CheckmarkCard, a tooltip will appear on focus/mouseover. The tooltip will still work when the card is disabled
<img width="196" alt="CleanShot 2022-05-10 at 10 37 05@2x" src="https://user-images.githubusercontent.com/203992/167654738-b47b5a63-29aa-4a0d-996e-9eaeb09cdfe9.png">

## Focus ring
we migrate the component to use the `focusRing` mixin for both the card and mark component. It simplifies the code but nothing should have change visually