### PR TITLE
Capture all keyboad originating in Simple Modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
         "re-resizable": "^6.9.0",
         "react": "16.13.1",
         "react-dom": "16.13.1",
+        "react-hotkeys-hook": "^3.4.4",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "remake-cli": "0.0.7",
@@ -17804,6 +17805,12 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
+    "node_modules/hotkeys-js": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz",
+      "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg==",
+      "dev": true
+    },
     "node_modules/html-element-map": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.0.tgz",
@@ -28793,6 +28800,19 @@
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0",
         "react-dom": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/react-hotkeys-hook": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.4.4.tgz",
+      "integrity": "sha512-vaORq07rWgmuF3owWRhgFV/3VL8/l2q9lz0WyVEddJnWTtKW+AOgU5YgYKuwN6h6h7bCcLG3MFsJIjCrM/5DvQ==",
+      "dev": true,
+      "dependencies": {
+        "hotkeys-js": "3.8.7"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
       }
     },
     "node_modules/react-input-autosize": {
@@ -49550,6 +49570,12 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
+    "hotkeys-js": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz",
+      "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg==",
+      "dev": true
+    },
     "html-element-map": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.0.tgz",
@@ -57917,6 +57943,15 @@
         "prop-types": "^15.7.2",
         "react-fast-compare": "^3.2.0",
         "shallowequal": "^1.1.0"
+      }
+    },
+    "react-hotkeys-hook": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.4.4.tgz",
+      "integrity": "sha512-vaORq07rWgmuF3owWRhgFV/3VL8/l2q9lz0WyVEddJnWTtKW+AOgU5YgYKuwN6h6h7bCcLG3MFsJIjCrM/5DvQ==",
+      "dev": true,
+      "requires": {
+        "hotkeys-js": "3.8.7"
       }
     },
     "react-input-autosize": {

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "re-resizable": "^6.9.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-hotkeys-hook": "^3.4.4",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "remake-cli": "0.0.7",

--- a/src/components/DropList/DropList.css.js
+++ b/src/components/DropList/DropList.css.js
@@ -54,11 +54,8 @@ export const InputSearchHolderUI = styled('div')`
     box-shadow: inset 0 0 0 1px ${getColor('grey.600')};
     border: 0;
     border-radius: 3px;
-
-    &:focus {
-      outline: 0;
-      box-shadow: 0 0 0 2px ${getColor('blue.500')};
-    }
+    outline: 0;
+    box-shadow: 0 0 0 2px ${getColor('blue.500')};
   }
 `
 

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -330,6 +330,7 @@ class Modal extends React.PureComponent {
 
   render() {
     const {
+      blocksGlobalHotkeys,
       className,
       'data-cy': dataCy,
       isOpen,
@@ -363,6 +364,7 @@ class Modal extends React.PureComponent {
       <ModalUI
         {...rest}
         className={componentClassName}
+        data-blocks-global-hotkeys={blocksGlobalHotkeys}
         data-cy={dataCy}
         role="document"
         style={styles}
@@ -383,6 +385,7 @@ class Modal extends React.PureComponent {
           {...rest}
           className={innerWrapperClassName}
           isHsApp={isHsApp}
+          tabIndex="0"
         >
           {this.getInnerContentMarkup()}
         </InnerWrapperUI>
@@ -393,6 +396,7 @@ class Modal extends React.PureComponent {
 }
 
 Modal.defaultProps = {
+  blocksGlobalHotkeys: true,
   closeIcon: true,
   closeIconOffset: 10,
   closeIconRepositionDelay: 0,
@@ -432,6 +436,8 @@ Modal.defaultProps = {
 }
 
 Modal.propTypes = {
+  /** Adds a data-blocks-global-hotkeys="true" to the modal element in case you want to signal that no global hotkeys should be allowed when the modal is on screen */
+  blocksGlobalHotkeys: PropTypes.bool,
   /** Custom class names to be added to the child `Card` component. */
   cardClassName: PropTypes.string,
   /** Custom class names to be added to the component. */

--- a/src/components/Modal/Modal.storiesHelpers.js
+++ b/src/components/Modal/Modal.storiesHelpers.js
@@ -1,15 +1,25 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import Modal from './'
+import { useHotkeys } from 'react-hotkeys-hook'
+import { allowGlobalHotkeys } from '../SimpleModal/SimpleModal.utils'
 
 export function MyModal() {
+  useHotkeys(
+    'k',
+    e => {
+      e.preventDefault()
+      e.stopPropagation()
+      alert('global hotkey triggered')
+    },
+    {
+      filter: e => allowGlobalHotkeys(e.target),
+    }
+  )
   const inputRef = React.useRef(null)
 
   return (
     <Modal
-      focusModalOnShow={false}
-      onOpen={() => {
-        inputRef.current.focus()
-      }}
+      focusModalOnShow={true}
       trigger={<button>Clicky</button>}
       version={2}
     >
@@ -20,12 +30,24 @@ export function MyModal() {
   )
 }
 
+function BodyWithKeyboardShortcut({ children }) {
+  useEffect(() => {
+    document.body.addEventListener('keydown', e => {
+      const { key } = e
+      if (key === 'j') {
+        alert('J pressed')
+      }
+    })
+  }, [])
+  return <div>{children}</div>
+}
+
 export function ModalWithTriggerAndInput() {
   const inputRef = React.useRef(null)
   const [text, setText] = useState('')
 
   return (
-    <>
+    <BodyWithKeyboardShortcut>
       <input onChange={e => setText(e.target.value)} value={text} />
       <Modal
         focusModalOnShow={false}
@@ -36,6 +58,6 @@ export function ModalWithTriggerAndInput() {
           <input type="text" ref={inputRef} />
         </Modal.Body>
       </Modal>
-    </>
+    </BodyWithKeyboardShortcut>
   )
 }

--- a/src/components/SidePanel/SidePanel.jsx
+++ b/src/components/SidePanel/SidePanel.jsx
@@ -16,6 +16,7 @@ function noop() {}
 
 function SidePanel({
   ariaLabelledBy = '',
+  blocksGlobalHotkeys = false,
   children,
   className,
   closeOnClickOutside = false,
@@ -92,6 +93,7 @@ function SidePanel({
         aria-labelledby={ariaLabelledBy}
         className="SidePanel"
         dataCy={dataCy}
+        data-blocks-global-hotkeys={blocksGlobalHotkeys}
         data-testid="sidepanel"
         id="sidepanel"
         panelWidth={panelWidth}
@@ -116,6 +118,8 @@ function SidePanel({
 SidePanel.propTypes = {
   /** If you include a Heading in the SidePanel, give it the same ID as the value you put here. Otherwise add a `aria-label` with a description */
   ariaLabelledBy: PropTypes.string,
+  /** Adds a data-blocks-global-hotkeys="true" to the modal element in case you want to signal that no global hotkeys should be allowed when the modal is on screen */
+  blocksGlobalHotkeys: PropTypes.bool,
   /** Content to be rendered inside the panel body */
   children: PropTypes.any,
   /** Custom classname on this component */

--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -54,8 +54,10 @@ function SimpleModal({
   }
 
   function handleOverlayKeyDown(e) {
+    // Prevent keyboard events originating from the modal from leaking out onto the page.
+    e.stopPropagation()
+
     if (shouldRender && e.key === 'Escape') {
-      e.stopPropagation()
       onClose(e)
     } else if (e.key === 'Tab' && trapFocus && modalRef.current) {
       manageTrappedFocus(modalRef.current, e)

--- a/src/components/SimpleModal/SimpleModal.jsx
+++ b/src/components/SimpleModal/SimpleModal.jsx
@@ -14,6 +14,7 @@ function noop() {}
 
 function SimpleModal({
   ariaLabelledBy = '',
+  blocksGlobalHotkeys = true,
   children,
   className,
   customCloseButton,
@@ -107,6 +108,7 @@ function SimpleModal({
         className="SimpleModal"
         dataCy={dataCy}
         data-testid="simple-modal"
+        data-blocks-global-hotkeys={blocksGlobalHotkeys}
         id="simple-modal"
         role="dialog"
         ref={modalRef}
@@ -125,6 +127,8 @@ function SimpleModal({
 SimpleModal.propTypes = {
   /** If you include a Heading in the modal, give it the same ID as the value you put here. Otherwise add a `aria-label` with a description */
   ariaLabelledBy: PropTypes.string,
+  /** Adds a data-blocks-global-hotkeys="true" to the modal element in case you want to signal that no global hotkeys should be allowed when the modal is on screen */
+  blocksGlobalHotkeys: PropTypes.bool,
   /** Content to be rendered inside the modal */
   children: PropTypes.any,
   /** Custom classname on this component */

--- a/src/components/SimpleModal/SimpleModal.storiesHelpers.js
+++ b/src/components/SimpleModal/SimpleModal.storiesHelpers.js
@@ -1,7 +1,9 @@
-import React, { useReducer, useState } from 'react'
+import React, { useReducer, useState, useEffect } from 'react'
 import SimpleModal from './SimpleModal'
 import { Portal } from '../../hooks/usePortal'
 import Button from '../Button'
+import { useHotkeys } from 'react-hotkeys-hook'
+import { allowGlobalHotkeys } from './SimpleModal.utils'
 
 function reducer(state, type) {
   switch (type) {
@@ -25,6 +27,34 @@ export const SimpleModalWithTrigger = () => {
     isOpen2: false,
   })
   const [buttonVisible, setButtonVisible] = useState(true)
+
+  useHotkeys(
+    'k',
+    e => {
+      e.preventDefault()
+      e.stopPropagation()
+      alert('global k hotkey triggered')
+    },
+    {
+      filter: e => allowGlobalHotkeys(e.target),
+    }
+  )
+
+  useEffect(() => {
+    function handleEvent(e) {
+      if (e.key === 'j') {
+        if (allowGlobalHotkeys(e.target)) {
+          alert('global j hotkey triggered')
+        }
+      }
+    }
+
+    document.body.addEventListener('keydown', handleEvent)
+
+    return () => {
+      document.body.removeEventListener('keydown', handleEvent)
+    }
+  }, [])
 
   return (
     <>

--- a/src/components/SimpleModal/SimpleModal.test.js
+++ b/src/components/SimpleModal/SimpleModal.test.js
@@ -167,4 +167,105 @@ describe('Closing', () => {
 
     expect(spy).not.toHaveBeenCalled()
   })
+
+  test('(multiple modals outsideClick) should not call onClose clicking the second modal ', () => {
+    const spyOne = jest.fn()
+    const spyTwo = jest.fn()
+    const { container } = render(
+      <>
+        <div className="app" style={{ width: '500px' }}>
+          <SimpleModal
+            closeOnClickOutside="modal"
+            show
+            onClose={spyOne}
+            width={'200px'}
+          />
+          <SimpleModal
+            id="second-modal"
+            closeOnClickOutside="modal"
+            show
+            onClose={spyTwo}
+            width={'200px'}
+          >
+            <strong>My second modal</strong>
+          </SimpleModal>
+        </div>
+      </>
+    )
+
+    const secondModal = container.querySelector('#second-modal')
+
+    user.click(secondModal)
+
+    expect(spyOne).not.toHaveBeenCalled()
+    expect(spyTwo).not.toHaveBeenCalled()
+  })
+
+  test('(multiple modals outsideClick) should only call onClose on the second modal when clicking overlay', () => {
+    const spyOne = jest.fn()
+    const spyTwo = jest.fn()
+    const { container } = render(
+      <>
+        <div className="app" style={{ width: '500px' }}>
+          <SimpleModal
+            closeOnClickOutside="modal"
+            show
+            onClose={spyOne}
+            width={'200px'}
+          />
+          <SimpleModal
+            id="second-modal"
+            closeOnClickOutside="modal"
+            show
+            onClose={spyTwo}
+            width={'200px'}
+          >
+            <strong>My second modal</strong>
+          </SimpleModal>
+        </div>
+      </>
+    )
+
+    const secondModal = container.querySelector('#second-modal')
+    const secondModalOverlay = secondModal.closest('.SimpleModal__Overlay')
+
+    user.click(secondModalOverlay)
+
+    expect(spyOne).not.toHaveBeenCalled()
+    expect(spyTwo).toHaveBeenCalled()
+  })
+
+  test('(multiple modals outsideClick) should not call onClose clicking on content on second modal ', () => {
+    const spyOne = jest.fn()
+    const spyTwo = jest.fn()
+    const { container } = render(
+      <>
+        <div className="app" style={{ width: '500px' }}>
+          <SimpleModal
+            closeOnClickOutside="modal"
+            show
+            onClose={spyOne}
+            width={'200px'}
+          />
+          <SimpleModal
+            id="second-modal"
+            closeOnClickOutside="modal"
+            show
+            onClose={spyTwo}
+            width={'200px'}
+          >
+            <strong>My second modal</strong>
+          </SimpleModal>
+        </div>
+      </>
+    )
+
+    const secondModal = container.querySelector('#second-modal')
+    const secondModalContent = secondModal.querySelector('strong')
+
+    user.click(secondModalContent)
+
+    expect(spyOne).not.toHaveBeenCalled()
+    expect(spyTwo).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/SimpleModal/SimpleModal.utils.js
+++ b/src/components/SimpleModal/SimpleModal.utils.js
@@ -1,0 +1,11 @@
+export function allowGlobalHotkeys(target) {
+  if (target.dataset.blocksGlobalHotkeys) {
+    return false
+  }
+
+  if (target.closest('[data-blocks-global-hotkeys="true"]')) {
+    return false
+  }
+
+  return true
+}

--- a/src/components/Tooltip/Tooltip.css.js
+++ b/src/components/Tooltip/Tooltip.css.js
@@ -73,22 +73,6 @@ export const TooltipUI = styled.div`
     }
   }
 
-  &[data-placement='top-end'],
-  &[data-placement='bottom-end'] {
-    ${ArrowUI} {
-      right: 8px;
-      left: unset !important;
-    }
-  }
-
-  &[data-placement='top-start'],
-  &[data-placement='bottom-start'] {
-    ${ArrowUI} {
-      left: 8px !important;
-      transform: unset !important;
-    }
-  }
-
   &[data-placement^='bottom'] {
     ${ArrowUI} {
       top: calc((${({ arrowSize }) => arrowSize}px / 2) * -1);


### PR DESCRIPTION
## Problem

[Jira ticket](https://helpscout.atlassian.net/browse/HSDS-263)

Keyboard events originating when the Simple Modal was displayed were leaking out onto the page, causing page keyboard shortcuts to be triggered. 

## Solutions

1. Stop propagation of key and click events from the modal
2. Add a `blocksGlobalHotkeys` prop to SimpleModal (and SidePanel) that will add a data attribute that external hooks or events can look for to perform or not a certain action when a modal is present

### Other
1. When having multiple modals on screen outside clicks were being firing 'onClose' for every modal, we added scenarios were we don't want this to happen, for example if having 2 modals open, and we click outside the modal on top, we only want to fire the onClose for that one, not the underneath one.

#### Unrelated
1. Tooltip: removed some styles that were added to fix arrow positioning but now we've seen they cause issues when the tooltip is appended to anything but the default.
2. DropList: little tweak to make the input on comboboxes always show the blue outline to avoid flashing when selecting items