### PR TITLE
Fix survey issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.54.0",
+  "version": "3.54.1-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpscout/hsds-react",
-      "version": "3.54.0",
+      "version": "3.54.1-0",
       "license": "MIT",
       "dependencies": {
         "@datepicker-react/hooks": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.54.0",
+  "version": "3.54.1-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/MessageCard/MessageCard.stories.mdx
+++ b/src/components/MessageCard/MessageCard.stories.mdx
@@ -7,6 +7,8 @@ import {
   MultipleChoiceSurvey,
   ThumbsSurvey,
 } from './MessageCard.Survey.variants'
+import { ThemeProvider } from 'styled-components'
+import { makeBrandColors } from '../../styles/utilities/color'
 
 <Meta
   title="Components/Conversation/Message/MessageCard"
@@ -201,6 +203,7 @@ This component renders a Message Card Notification with (optional) Title, Subtit
             withFeedbackForm
             feedbackFormText="Tell us more..."
             onSubmit={data => console.log(data)}
+            withShowFeedbackFormDelay
           >
             <ThumbsSurvey />
           </MessageCard.Survey>
@@ -219,13 +222,17 @@ This component renders a Message Card Notification with (optional) Title, Subtit
         title="How did you feel about your checkout experience?"
         body="Your feedback is valuable to us. Let us know how we did so we can continue to improve our services."
         action={() => (
-          <MessageCard.Survey
-            withFeedbackForm
-            feedbackFormText="Tell us more..."
-            onSubmit={data => console.log(data)}
-          >
-            <FacesSurvey />
-          </MessageCard.Survey>
+          <ThemeProvider theme={{ brandColor: makeBrandColors('#8c3c4a') }}>
+            <MessageCard.Survey
+              withFeedbackForm
+              feedbackFormText="Tell us more..."
+              submitButtonText="Send with some long button text"
+              onSubmit={data => console.log(data)}
+              withShowFeedbackFormDelay
+            >
+              <FacesSurvey />
+            </MessageCard.Survey>
+          </ThemeProvider>
         )}
       />
     </MessageCardStoryWrapperUI>

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -4,6 +4,8 @@ import MessageCard from './MessageCard'
 import { ThumbsSurvey } from './MessageCard.Survey.variants'
 import { MessageCardButton as Button } from './MessageCard.Button'
 import userEvent from '@testing-library/user-event'
+import { makeBrandColors } from '../../styles/utilities/color'
+import { ThemeProvider } from 'styled-components'
 
 describe('className', () => {
   test('Has default className', () => {
@@ -499,6 +501,8 @@ describe('Message Button', () => {
 })
 
 describe('Surveys', () => {
+  jest.useFakeTimers()
+
   test('Renders a feedback form after selection if withFeedbackForm is set', () => {
     const formLabel = 'Tell us more...'
 
@@ -511,6 +515,30 @@ describe('Surveys', () => {
     expect(screen.queryByLabelText(formLabel)).not.toBeInTheDocument()
 
     userEvent.click(screen.getByRole('button', { name: 'thumbs-up' }))
+
+    expect(screen.queryByLabelText(formLabel)).toBeInTheDocument()
+  })
+
+  test('Renders a feedback form delayed after selection if withShowFeedbackFormDelay is set', () => {
+    const formLabel = 'Tell us more...'
+
+    render(
+      <MessageCard.Survey
+        withFeedbackForm
+        withShowFeedbackFormDelay
+        feedbackFormText={formLabel}
+      >
+        <ThumbsSurvey />
+      </MessageCard.Survey>
+    )
+
+    expect(screen.queryByLabelText(formLabel)).not.toBeInTheDocument()
+    userEvent.click(screen.getByRole('button', { name: 'thumbs-up' }))
+    expect(screen.queryByLabelText(formLabel)).not.toBeInTheDocument()
+
+    act(() => {
+      jest.runAllTimers()
+    })
 
     expect(screen.queryByLabelText(formLabel)).toBeInTheDocument()
   })

--- a/src/components/MessageCard/components/survey/MessageCard.Survey.MultipleChoice.jsx
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.MultipleChoice.jsx
@@ -5,7 +5,6 @@ import {
   MultipleChoiceRadioUI,
 } from './MessageCard.Survey.css'
 import { useSurveyContext } from '../../utils/MessageCard.Survey.context'
-import Radio from '../../../Radio'
 
 export const MessageCardSurveyMultipleChoice = ({ choices }) => {
   const { onSelection } = useSurveyContext()

--- a/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
@@ -5,6 +5,8 @@ import Button from '../../../Button'
 import RateAction from '../../../RateAction'
 import ChoiceGroup from '../../../ChoiceGroup'
 import Radio from '../../../Radio'
+import { setFontSize } from '../../../../styles/utilities/font'
+import { FONT_FAMILY } from '../../../../styles/configs/constants'
 
 const defaultTransition = css`
   transition: all 0.2s ease-in-out;
@@ -143,6 +145,17 @@ export const RateActionUI = styled(RateAction)`
 
 export const FeedbackFormUI = styled('form')`
   margin-top: 16px;
+  overflow: hidden;
+  animation: HeightAnimation 400ms;
+
+  @keyframes HeightAnimation {
+    0% {
+      max-height: 0;
+    }
+    100% {
+      max-height: 400px;
+    }
+  }
 `
 
 export const FeedbackLabelUI = styled('label')`
@@ -155,6 +168,11 @@ export const SubmitFeedbackFormButtonUI = styled(Button)`
   &.is-size-xxl {
     --buttonMinWidth: 100%;
     margin-top: 15px;
+    width: 100%;
+
+    ${setFontSize(14)};
+    font-family: ${FONT_FAMILY};
+    line-height: normal !important;
   }
 `
 

--- a/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
@@ -144,7 +144,10 @@ export const RateActionUI = styled(RateAction)`
 `
 
 export const FeedbackFormUI = styled('form')`
-  margin-top: 16px;
+  // adding padding and negative margin to compensate, because of focus state of children
+  // without this, the outline (box shadow) is cut off on the sides/bottom
+  padding: 4px;
+  margin: 16px -4px -4px;
   overflow: hidden;
   animation: HeightAnimation 400ms;
 

--- a/src/components/MessageCard/components/survey/MessageCard.Survey.jsx
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import {
   ConfirmationMessageUI,
@@ -12,8 +12,11 @@ import { SurveyContext } from '../../utils/MessageCard.Survey.context'
 import Input from '../../../Input'
 import Spinner from '../../../Spinner'
 import Icon from '../../../Icon'
+import Truncate from '../../../Truncate'
 
 function noop() {}
+
+const SHOW_FEEDBACK_FORM_DELAY = 600
 
 export const MessageCardSurvey = ({
   children,
@@ -25,17 +28,32 @@ export const MessageCardSurvey = ({
   onSubmit = noop,
   showSpinner = false,
   showConfirmationMessage = false,
+  theme,
+  withShowFeedbackFormDelay = false,
 }) => {
   const [feedback, setFeedback] = React.useState('')
   const [selected, setSelected] = React.useState(null)
   const [showFeedbackForm, setShowFeedbackForm] = React.useState(false)
   const shouldShowFeedbackForm = showFeedbackForm || forceFeedbackForm
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
 
   function handleSelection(id) {
     setSelected(id)
 
     if (withFeedbackForm) {
-      setShowFeedbackForm(true)
+      if (withShowFeedbackFormDelay) {
+        setTimeout(() => {
+          isMounted.current && setShowFeedbackForm(true)
+        }, SHOW_FEEDBACK_FORM_DELAY)
+      } else {
+        setShowFeedbackForm(true)
+      }
       return
     }
 
@@ -89,8 +107,13 @@ export const MessageCardSurvey = ({
             value={feedback}
             onChange={value => setFeedback(value)}
           />
-          <SubmitFeedbackFormButtonUI submit size="xxl" theme="blue">
-            {submitButtonText}
+          <SubmitFeedbackFormButtonUI
+            data-cy="beacon-message-cta-survey-submit"
+            submit
+            size="xxl"
+            theme={theme || 'blue'}
+          >
+            <Truncate>{submitButtonText}</Truncate>
           </SubmitFeedbackFormButtonUI>
         </FeedbackFormUI>
       )}

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.54.0',
+  version: '3.54.1-0',
 }


### PR DESCRIPTION
# Problem/Feature

This PR fixes some issues found for Messages survey components:
- Color of submit button was always blue, it should be using the current theme instead
- Text for submit button was not truncated
- The animations/transitions when selecting thumb/face was a bit clunky - I had to delay (optionally) showing confirmation form after selecting an option, so that the animation for option finishes before. I also added some height animation to the form itself for nicer entry

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
