### PR TITLE
Improve focus states for Messages survey components

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -304,7 +304,10 @@ export const BodyUI = styled.div`
 `
 
 export const ActionUI = styled('div')`
-  margin-top: 20px;
+  &:not(:only-child) {
+    margin-top: 20px;
+  }
+
   padding: 0 20px;
   flex: 0 0 auto;
 `

--- a/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
@@ -27,6 +27,7 @@ export const SurveyOptionsUI = styled('div')`
 `
 
 export const EmojiButtonUI = styled('button')`
+  position: relative;
   background: white;
   border: none;
   border-radius: 50%;
@@ -39,14 +40,15 @@ export const EmojiButtonUI = styled('button')`
   ${defaultTransition};
 
   ${focusRing};
-  --focusRingOffset: -3px;
+  --focusRingOffset: 0px;
   --focusRingRadius: 50%;
 
   &:first-child {
     margin-left: 0;
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     transform: scale(1.3);
   }
 
@@ -114,6 +116,10 @@ export const RateActionUI = styled(RateAction)`
 
   &.c-RateAction {
     ${defaultTransition};
+
+    ${focusRing};
+    --focusRingOffset: 0px;
+    --focusRingRadius: 50%;
 
     svg {
       ${defaultTransition};

--- a/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
@@ -16,7 +16,7 @@ export const SurveyUI = styled('div')`
   background: ${getColor('grey.200')};
   border-radius: 5px;
   margin: 0px -16px -16px -16px;
-  padding: 14px 15px;
+  padding: 15px;
   position: relative;
 `
 
@@ -153,7 +153,7 @@ export const FeedbackFormUI = styled('form')`
   // adding padding and negative margin to compensate, because of focus state of children
   // without this, the outline (box shadow) is cut off on the sides/bottom
   padding: 4px;
-  margin: 16px -4px -4px;
+  margin: 12px -4px -4px;
   overflow: hidden;
   animation: HeightAnimation 400ms;
 


### PR DESCRIPTION
# Problem/Feature
This PR makes some improvements to focus state of faces/thumbs option for Messages survey components. They are not behaving in the same way and all have blue focus ring when navigating through keyboard. This improves the accessibility of those components.

![Screenshot from 2022-05-24 19-25-55](https://user-images.githubusercontent.com/1765264/170096951-bf2c1ee4-4a3d-407d-b066-50bf4e267631.png)
![Screenshot from 2022-05-24 19-24-14](https://user-images.githubusercontent.com/1765264/170096961-c1f72263-b947-47dc-a4db-780beac77796.png)


## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
