### PR TITLE
SimpleModal (confirmation layout): Swap which buttons handlers are applied to

### DIFF
--- a/src/components/SimpleModal/SimpleModal.layouts.jsx
+++ b/src/components/SimpleModal/SimpleModal.layouts.jsx
@@ -73,10 +73,10 @@ export function Confirmation({
       <ConfirmationHeadingUI>{heading}</ConfirmationHeadingUI>
       {body && <ConfirmationBodyUI>{body}</ConfirmationBodyUI>}
       <ConfirmationFooterUI>
-        <Button outlined theme="grey" onClick={onConfirm}>
+        <Button outlined theme="grey" onClick={onCancel}>
           {cancelButtonText}
         </Button>
-        <Button theme={danger ? 'red' : 'blue'} onClick={onCancel}>
+        <Button theme={danger ? 'red' : 'blue'} onClick={onConfirm}>
           {confirmButtonText}
         </Button>
       </ConfirmationFooterUI>

--- a/src/components/SimpleModal/SimpleModal.layouts.jsx
+++ b/src/components/SimpleModal/SimpleModal.layouts.jsx
@@ -64,6 +64,8 @@ export function Confirmation({
   body,
   onConfirm = noop,
   onCancel = noop,
+  confirmButtonProps = {},
+  cancelButtonProps = {},
   confirmButtonText = 'Accept',
   cancelButtonText = 'Cancel',
   danger,
@@ -73,10 +75,14 @@ export function Confirmation({
       <ConfirmationHeadingUI>{heading}</ConfirmationHeadingUI>
       {body && <ConfirmationBodyUI>{body}</ConfirmationBodyUI>}
       <ConfirmationFooterUI>
-        <Button outlined theme="grey" onClick={onCancel}>
+        <Button outlined theme="grey" onClick={onCancel} {...cancelButtonProps}>
           {cancelButtonText}
         </Button>
-        <Button theme={danger ? 'red' : 'blue'} onClick={onConfirm}>
+        <Button
+          theme={danger ? 'red' : 'blue'}
+          onClick={onConfirm}
+          {...confirmButtonProps}
+        >
           {confirmButtonText}
         </Button>
       </ConfirmationFooterUI>
@@ -94,6 +100,10 @@ Confirmation.propTypes = {
   onConfirm: PropTypes.func,
   /** Callback to run on cancel action click */
   onCancel: PropTypes.func,
+  /** Any valid prop for a Button to apply to the Cancel button*/
+  cancelButtonProps: PropTypes.any,
+  /** Any valid prop for a Button to apply to the Confirm button*/
+  confirmButtonProps: PropTypes.any,
   /** Text of the main action button */
   confirmButtonText: PropTypes.string,
   /** Text of the cancel button */


### PR DESCRIPTION
# Problem/Feature

The button handlers were connected in reverse:

- The `onCancel` handler was connected to the "Confirm" button.
- The `onConfirm` handler was connected to the "Cancel" button.

# Solution

This pull request is a small change to flip the usage of the button handlers:

- The `onCancel` handler is connected to the "Cancel" button.
- The `onConfirm` handler is connected to the "Confirm" button.

That's it!


### One more thing

Adds 2 props `cancelButtonProps` and `confirmButtonProps` to pass any valid Button prop to each button.