### PR TITLE
Change line height for Message Survey multiple choice option

### DIFF
--- a/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
@@ -231,6 +231,7 @@ export const MultipleChoiceRadioUI = styled(Radio)`
 
     .c-Text {
       font-size: 14px;
+      line-height: normal;
       color: ${getColor('charcoal.700')};
     }
   }


### PR DESCRIPTION
# Problem/Feature
This PR changes line-height of multiple choice radio option, in case if there are 2 rows of text. Before it was looking a bit weird, too stretched

Before:
![Screenshot from 2022-06-02 16-44-23](https://user-images.githubusercontent.com/1765264/171662985-ccef9eed-e0bc-4eb1-8520-68d5d7f82aa9.png)

After:
![Screenshot from 2022-06-02 16-45-20](https://user-images.githubusercontent.com/1765264/171662955-d6950ec2-ff7f-4836-b21f-904e91aba13e.png)


## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
