### PR TITLE
HSDS-267: Update MessageCard Padding

### DIFF
--- a/src/components/MessageCard/MessageCard.css.js
+++ b/src/components/MessageCard/MessageCard.css.js
@@ -19,7 +19,7 @@ export const MessageCardUI = styled(Card)`
   background-color: white;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  padding: 17px 0 20px;
+  padding: 20px 0;
   width: 300px;
   word-break: break-word;
   display: flex;


### PR DESCRIPTION
# Problem/Feature

This PR updates the padding-top of the MessageCard component from 17px to 20px so that it is consistent with other spacing. 

## Screenshots

### With text and image
<img width="334" alt="CleanShot 2022-06-06 at 09 30 07@2x" src="https://user-images.githubusercontent.com/44473/172203990-14454f60-2e16-4e07-b4dc-79909cd2e1b7.png">

### With video only
<img width="336" alt="CleanShot 2022-06-06 at 09 30 42@2x" src="https://user-images.githubusercontent.com/44473/172204058-1569de58-771b-429a-9332-14878607c1ec.png">


## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
