### PR TITLE
Fix margin on microsurvey emojis and comment label alignment

### DIFF
--- a/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
@@ -34,7 +34,8 @@ export const EmojiButtonUI = styled('button')`
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.1);
   cursor: pointer;
   font-size: 22px;
-  margin-left: 10px;
+  margin-left: 5px;
+  margin-right: 5px;
   height: 42px;
   width: 42px;
   ${defaultTransition};
@@ -42,10 +43,6 @@ export const EmojiButtonUI = styled('button')`
   ${focusRing};
   --focusRingOffset: 0px;
   --focusRingRadius: 50%;
-
-  &:first-child {
-    margin-left: 0;
-  }
 
   &:hover,
   &:focus {
@@ -112,7 +109,8 @@ export const EmojiButtonUI = styled('button')`
 `
 
 export const RateActionUI = styled(RateAction)`
-  margin-left: 10px !important;
+  margin-left: 5px !important;
+  margin-right: 5px !important;
 
   &.c-RateAction {
     ${defaultTransition};
@@ -170,7 +168,8 @@ export const FeedbackFormUI = styled('form')`
 export const FeedbackLabelUI = styled('label')`
   color: ${getColor('charcoal.500')};
   display: block;
-  margin-bottom: 6px;
+  margin-bottom: 10px;
+  text-align: center;
 `
 
 export const SubmitFeedbackFormButtonUI = styled(Button)`


### PR DESCRIPTION
# Problem/Feature
This PR fixes the margin on Messages microsurvey emojis (faces and thumbs). Previously there was unnecessary left padding.
Other thing is label text alignment to the center on microsurvey comment textarea.

See related PR comment: https://github.com/helpscout/hs-app-ui/pull/527#issuecomment-1167832054

To test it, open `MessageCard` in storybook and then `With Thumbs survey` and `With Faces survey` to see it looks ok now :)

## Guidelines

Make sure the pull request:

- [ ] Follows the established folder/file structure
- [ ] Adds unit tests
- [ ] If it is a refactor or change to an existing component, have you verified it won't break existing Cypress tests or have you updated them?
- [ ] Did you verify some accessibility (a11y) basics?
- [ ] Adds/updates stories. [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-4-writing-stories--page)
- [ ] Adds/updates documentation (ie `proptypes`) [Guidelines](https://hsds.helpscout.com/?path=/docs/%F0%9F%8F%A0-welcome-3-writing-components--page)
- [ ] Has it been tested in [Help Scout's supported browsers](https://docs.helpscout.com/article/1292-supported-browsers-and-system-requirements)?
- [ ] Requests review from designer of the feature
- [ ] Add label (bug? feature?)
