### PR TITLE
HSDS-277: Support for Freeform Text Survey 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.56.0",
+  "version": "3.57.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpscout/hsds-react",
-      "version": "3.56.0",
+      "version": "3.57.0-0",
       "license": "MIT",
       "dependencies": {
         "@datepicker-react/hooks": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/hsds-react",
-  "version": "3.56.0",
+  "version": "3.57.0-0",
   "private": false,
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/MessageCard/MessageCard.stories.mdx
+++ b/src/components/MessageCard/MessageCard.stories.mdx
@@ -326,7 +326,7 @@ This component renders a Message Card Notification with (optional) Title, Subtit
         action={() => (
           <MessageCard.Survey
             isTextOnlySurvey
-            feedbackFormPlaceholder="Tell us more..."
+            feedbackFormText="Tell us more..."
             onSubmit={data => console.log(data)}
           />
         )}

--- a/src/components/MessageCard/MessageCard.stories.mdx
+++ b/src/components/MessageCard/MessageCard.stories.mdx
@@ -315,6 +315,26 @@ This component renders a Message Card Notification with (optional) Title, Subtit
   </Story>
 </Canvas>
 
+# With Text survey
+
+<Canvas>
+  <Story name="With Text survey">
+    <MessageCardStoryWrapperUI>
+      <MessageCard
+        title="Which pizza do you like the most?"
+        body="Your feedback is valuable to us. Let us know how we did so we can continue to improve our services."
+        action={() => (
+          <MessageCard.Survey
+            isTextOnlySurvey
+            feedbackFormPlaceholder="Tell us more..."
+            onSubmit={data => console.log(data)}
+          />
+        )}
+      />
+    </MessageCardStoryWrapperUI>
+  </Story>
+</Canvas>
+
 # With video
 
 <Canvas>

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -526,7 +526,7 @@ describe('Surveys', () => {
     render(
       <MessageCard.Survey
         isTextOnlySurvey
-        feedbackFormPlaceholder={formLabel}
+        feedbackFormText={formLabel}
         onSubmit={onSubmit}
       />
     )

--- a/src/components/MessageCard/MessageCard.test.js
+++ b/src/components/MessageCard/MessageCard.test.js
@@ -519,6 +519,29 @@ describe('Surveys', () => {
     expect(screen.queryByLabelText(formLabel)).toBeInTheDocument()
   })
 
+  test('Renders a feedback form by default if isTextOnlySurvey is set', () => {
+    const onSubmit = jest.fn()
+    const formLabel = 'Tell us more...'
+
+    render(
+      <MessageCard.Survey
+        isTextOnlySurvey
+        feedbackFormPlaceholder={formLabel}
+        onSubmit={onSubmit}
+      />
+    )
+
+    expect(screen.queryByLabelText(formLabel)).toBeInTheDocument()
+
+    userEvent.type(screen.getByLabelText(formLabel), 'Great question')
+    userEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      feedback: 'Great question',
+      selected: null,
+    })
+  })
+
   test('Renders a feedback form delayed after selection if withShowFeedbackFormDelay is set', () => {
     const formLabel = 'Tell us more...'
 

--- a/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.css.js
@@ -18,6 +18,13 @@ export const SurveyUI = styled('div')`
   margin: 0px -16px -16px -16px;
   padding: 15px;
   position: relative;
+
+  ${({ $isTextOnly }) =>
+    $isTextOnly &&
+    css`
+      padding-top: 0px;
+      background: transparent;
+    `};
 `
 
 export const SurveyOptionsUI = styled('div')`
@@ -180,6 +187,15 @@ export const FeedbackFormUI = styled('form')`
   margin: 12px -4px -4px;
   overflow: hidden;
   animation: HeightAnimation 400ms;
+
+  ${({ $isTextOnly }) =>
+    $isTextOnly &&
+    css`
+      // This essentially resets the padding and margin to 0, but leaving space for the focus state
+      // as mentioned in the comment above.
+      padding-top: 1px;
+      margin-top: -1px;
+    `};
 
   @keyframes HeightAnimation {
     0% {

--- a/src/components/MessageCard/components/survey/MessageCard.Survey.jsx
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.jsx
@@ -13,6 +13,7 @@ import Input from '../../../Input'
 import Spinner from '../../../Spinner'
 import Icon from '../../../Icon'
 import Truncate from '../../../Truncate'
+import VisuallyHidden from '../../../VisuallyHidden'
 
 function noop() {}
 
@@ -23,18 +24,21 @@ export const MessageCardSurvey = ({
   withFeedbackForm = false,
   forceFeedbackForm = false,
   feedbackFormText = '',
+  feedbackFormPlaceholder = '',
   confirmationText = 'Thanks for the feedback',
   submitButtonText = 'Send',
   onSubmit = noop,
   showSpinner = false,
   showConfirmationMessage = false,
   theme,
+  isTextOnlySurvey = false,
   withShowFeedbackFormDelay = false,
 }) => {
   const [feedback, setFeedback] = React.useState('')
   const [selected, setSelected] = React.useState(null)
   const [showFeedbackForm, setShowFeedbackForm] = React.useState(false)
-  const shouldShowFeedbackForm = showFeedbackForm || forceFeedbackForm
+  const shouldShowFeedbackForm =
+    showFeedbackForm || forceFeedbackForm || isTextOnlySurvey
   const isMounted = useRef(true)
 
   useEffect(() => {
@@ -88,16 +92,27 @@ export const MessageCardSurvey = ({
   }
 
   return (
-    <SurveyUI data-cy="beacon-message-cta-survey">
-      <SurveyContext.Provider value={contextValue}>
-        {children}
-      </SurveyContext.Provider>
+    <SurveyUI
+      data-cy="beacon-message-cta-survey"
+      $isTextOnly={isTextOnlySurvey}
+    >
+      {children && (
+        <SurveyContext.Provider value={contextValue}>
+          {children}
+        </SurveyContext.Provider>
+      )}
 
       {shouldShowFeedbackForm && (
-        <FeedbackFormUI onSubmit={handleSubmit}>
-          <FeedbackLabelUI htmlFor="survey-comment">
-            {feedbackFormText}
-          </FeedbackLabelUI>
+        <FeedbackFormUI onSubmit={handleSubmit} $isTextOnly={isTextOnlySurvey}>
+          {!isTextOnlySurvey ? (
+            <FeedbackLabelUI htmlFor="survey-comment">
+              {feedbackFormText}
+            </FeedbackLabelUI>
+          ) : (
+            <VisuallyHidden>
+              <label htmlFor="survey-comment">{feedbackFormPlaceholder}</label>
+            </VisuallyHidden>
+          )}
           <Input
             id="survey-comment"
             name="survey-comment"
@@ -106,6 +121,7 @@ export const MessageCardSurvey = ({
             multiline={3}
             value={feedback}
             onChange={value => setFeedback(value)}
+            placeholder={feedbackFormPlaceholder}
           />
           <SubmitFeedbackFormButtonUI
             data-cy="beacon-message-cta-survey-submit"
@@ -128,12 +144,14 @@ export const MessageCardSurvey = ({
 }
 
 MessageCardSurvey.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   withFeedbackForm: PropTypes.bool,
   forceFeedbackForm: PropTypes.bool,
   feedbackFormText: PropTypes.string,
+  feedbackFormPlaceholder: PropTypes.string,
   confirmationText: PropTypes.string,
   onSubmit: PropTypes.func,
   showSpinner: PropTypes.bool,
   showConfirmationMessage: PropTypes.bool,
+  isTextOnlySurvey: PropTypes.bool,
 }

--- a/src/components/MessageCard/components/survey/MessageCard.Survey.jsx
+++ b/src/components/MessageCard/components/survey/MessageCard.Survey.jsx
@@ -24,7 +24,6 @@ export const MessageCardSurvey = ({
   withFeedbackForm = false,
   forceFeedbackForm = false,
   feedbackFormText = '',
-  feedbackFormPlaceholder = '',
   confirmationText = 'Thanks for the feedback',
   submitButtonText = 'Send',
   onSubmit = noop,
@@ -91,6 +90,12 @@ export const MessageCardSurvey = ({
     withFeedbackForm,
   }
 
+  const formLabel = (
+    <FeedbackLabelUI htmlFor="survey-comment">
+      {feedbackFormText}
+    </FeedbackLabelUI>
+  )
+
   return (
     <SurveyUI
       data-cy="beacon-message-cta-survey"
@@ -104,14 +109,10 @@ export const MessageCardSurvey = ({
 
       {shouldShowFeedbackForm && (
         <FeedbackFormUI onSubmit={handleSubmit} $isTextOnly={isTextOnlySurvey}>
-          {!isTextOnlySurvey ? (
-            <FeedbackLabelUI htmlFor="survey-comment">
-              {feedbackFormText}
-            </FeedbackLabelUI>
+          {isTextOnlySurvey ? (
+            <VisuallyHidden>{formLabel}</VisuallyHidden>
           ) : (
-            <VisuallyHidden>
-              <label htmlFor="survey-comment">{feedbackFormPlaceholder}</label>
-            </VisuallyHidden>
+            formLabel
           )}
           <Input
             id="survey-comment"
@@ -121,7 +122,7 @@ export const MessageCardSurvey = ({
             multiline={3}
             value={feedback}
             onChange={value => setFeedback(value)}
-            placeholder={feedbackFormPlaceholder}
+            placeholder={isTextOnlySurvey ? feedbackFormText : ''}
           />
           <SubmitFeedbackFormButtonUI
             data-cy="beacon-message-cta-survey-submit"
@@ -148,7 +149,6 @@ MessageCardSurvey.propTypes = {
   withFeedbackForm: PropTypes.bool,
   forceFeedbackForm: PropTypes.bool,
   feedbackFormText: PropTypes.string,
-  feedbackFormPlaceholder: PropTypes.string,
   confirmationText: PropTypes.string,
   onSubmit: PropTypes.func,
   showSpinner: PropTypes.bool,

--- a/src/utilities/pkg.js
+++ b/src/utilities/pkg.js
@@ -1,3 +1,3 @@
 export default {
-  version: '3.56.0',
+  version: '3.57.0-0',
 }


### PR DESCRIPTION
**Note:** This PR is a copy of https://github.com/helpscout/hsds/pull/6 adapted for hsds-react.

## MessageCard

This PR adds support for Freeform Text surveys. Unlike other survey types, this is not a variant. The functionality for submitting text responses was already part of the `MessageCard.Survey` component, so I've simply added a new `isTextOnlySurvey` prop to enable it by default as well as adjusting some styles.

<img width="646" alt="CleanShot 2022-08-16 at 14 05 49@2x" src="https://user-images.githubusercontent.com/44473/184985080-7a023fe2-a7e4-4f81-bf94-e5945c3d6be0.png">

## How to Test

- [Direct Link](https://hsds-277-message-card-text-s.hsds-react.pages.dev/?path=/story/components-conversation-message-messagecard--with-text-survey)
- Open the Storybook Deploy Preview
- Navigate to the MessageCard component and select the "With Text survey" variant.
